### PR TITLE
Adding the first batch of work to support multithread done by John Mainzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ before creating PRs to the HDF5 develop branch. This is for Lifeboat's internal 
 
 One must use the --enable-multithread for configure to enable the multithread support. On Mac OS, this option requires the presence of Pthread library and the Atomic header (stdatomic.h).
 On Linux, it requires the presence of Pthread and Atomic libraries and the Atomic header.  Missing any of these requirements will cause configure to fail. Using the multithread feature requires
-disabling the high-level API, C++, Fortran, Java interfaces, and thread safe. This feature currently only works with debugging mode (--enable-build-mode=debug), not the production mode.
+disabling the high-level API, C++, Fortran, Java interfaces, and thread safe. This feature currently only works with debugging mode (--enable-build-mode=debug), not the production mode (we are still working on it).
 
 The following command is an example to enable the multithread support:
     > configure --enable-multithread --enable-build-mode=debug --disable-hl
 
-The only test program to check the correctness of multithread support is hdf5/test/mt_id_test.c.
+The only test program to check the correctness of multithread support is hdf5/test/mt_id_test.c.  During the build of the library and the test program, there are multiple warnings related to the atomic issues that we're investigating and fixing.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Experimental
 
-This repo contains the modified source code of HDF5 r1.14.2. The code will be used to prototype changes for multi-threaded support before creating PRs to the HDF5 develop branch. This is for Lifeboat's internal use only but anyone is welcome to watch our progress.
+This repo contains the modified source code of HDF5 r1.14.2, which is in the 1_14_2_multithread branch. The code will be used to prototype changes for multi-threaded support 
+before creating PRs to the HDF5 develop branch. This is for Lifeboat's internal use only but anyone is welcome to watch our progress.
+
+One must use the --enable-multithread for configure to enable the multithread support. On Mac OS, this option requires the presence of Pthread library and the Atomic header (stdatomic.h).
+On Linux, it requires the presence of Pthread and Atomic libraries and the Atomic header.  Missing any of these requirements will cause configure to fail. Using the multithread feature requires
+disabling the high-level API, C++, Fortran, Java interfaces, and thread safe. This feature currently only works with debugging mode (--enable-build-mode=debug), not the production mode.
+
+The following command is an example to enable the multithread support:
+    > configure --enable-multithread --enable-build-mode=debug --disable-hl
+
+The only test program to check the correctness of multithread support is hdf5/test/mt_id_test.c.

--- a/hdf5/configure
+++ b/hdf5/configure
@@ -31091,16 +31091,16 @@ printf "%s\n" "$as_me: Always 'no' if cross-compiling. Edit the config file if y
 fi
 
 ## ----------------------------------------------------------------------
-## Enable multithread feature of library.  It requires Pthread support
-## on POSIX systems.
+## Enable multithread feature of library.  It requires Pthread and Atomic
+## support on POSIX systems.
 ##
 
 
 ## Default is no multithread
 MULTITHREAD=no
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for multithread support" >&5
-printf %s "checking for multithread support... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for multithread configure option" >&5
+printf %s "checking for multithread configure option... " >&6; }
 # Check whether --enable-multithread was given.
 if test ${enable_multithread+y}
 then :
@@ -31434,6 +31434,142 @@ fi
           fi
         fi
         ;;
+    esac
+
+    case "$host_cpu-$host_vendor-$host_os" in
+      *linux*)
+	# Replace C99 with C11 standard to support atomic datatype
+	H5_CFLAGS=$(echo $H5_CFLAGS | sed -e "s/-std=c99/-std=c11/g")
+
+	# Propagate the change to CFLAGS, too
+	CFLAGS="$H5_CFLAGS $AM_CFLAGS $CFLAGS"
+
+	HAVE_STDATOMIC_H="yes"
+
+	# Check the presence of stdatomic.h for atomic data type
+	       for ac_header in stdatomic.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "stdatomic.h" "ac_cv_header_stdatomic_h" "$ac_includes_default"
+if test "x$ac_cv_header_stdatomic_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_STDATOMIC_H 1" >>confdefs.h
+
+else $as_nop
+  HAVE_STDATOMIC_H="no"
+fi
+
+done
+
+	# Check the presence of atomic library
+	if test "x$HAVE_STDATOMIC_H" = "xyes"; then
+	  HAVE_LIBATOMIC="yes"
+	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __atomic_compare_exchange_16 in -latomic" >&5
+printf %s "checking for __atomic_compare_exchange_16 in -latomic... " >&6; }
+if test ${ac_cv_lib_atomic___atomic_compare_exchange_16+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-latomic  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char __atomic_compare_exchange_16 ();
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main (void)
+{
+return __atomic_compare_exchange_16 ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib_atomic___atomic_compare_exchange_16=yes
+else $as_nop
+  ac_cv_lib_atomic___atomic_compare_exchange_16=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_atomic___atomic_compare_exchange_16" >&5
+printf "%s\n" "$ac_cv_lib_atomic___atomic_compare_exchange_16" >&6; }
+if test "x$ac_cv_lib_atomic___atomic_compare_exchange_16" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBATOMIC 1" >>confdefs.h
+
+  LIBS="-latomic $LIBS"
+
+else $as_nop
+  HAVE_LIBATOMIC="no"
+fi
+
+	fi
+
+	# Define HAVE_MULTITHREAD only if stdatomic.h, atomic library, and pthread library are present
+	if  test "x$HAVE_STDATOMIC_H" = "xyes"  &&   test "x$HAVE_LIBATOMIC" = "xyes"  &&  test "x$HAVE_PTHREAD" = "xyes" ; then
+
+printf "%s\n" "#define HAVE_MULTITHREAD 1" >>confdefs.h
+
+	else
+	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+	  as_fn_error $? "Must use Pthread and atomic library and header with multithread" "$LINENO" 5
+	fi
+	;;
+
+      *apple*)
+	# Replace C99 with C11 standard to support atomic datatype
+	H5_CFLAGS=$(echo $H5_CFLAGS | sed -e "s/-std=c99/-std=c11/g")
+
+	# Propagate the change to CFLAGS, too
+	CFLAGS="$H5_CFLAGS $AM_CFLAGS $CFLAGS"
+
+	# Check the presence of stdatomic.h for atomic data type.  Unlike GCC on Linux, clang on Mac OS doesn't need
+	# to link to the atomic library (-latomic)
+	HAVE_STDATOMIC_H="yes"
+
+	       for ac_header in stdatomic.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "stdatomic.h" "ac_cv_header_stdatomic_h" "$ac_includes_default"
+if test "x$ac_cv_header_stdatomic_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_STDATOMIC_H 1" >>confdefs.h
+
+else $as_nop
+  HAVE_STDATOMIC_H="no"
+fi
+
+done
+
+	# Define HAVE_MULTITHREAD on if stdatomic.h and pthread are present
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for multithread support (pthread and atomic libraries)" >&5
+printf %s "checking for multithread support (pthread and atomic libraries)... " >&6; }
+
+	if  test "x$HAVE_STDATOMIC_H" = "xyes"  &&  test "x$HAVE_PTHREAD" = "xyes" ; then
+	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+printf "%s\n" "#define HAVE_MULTITHREAD 1" >>confdefs.h
+
+	else
+	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+	  as_fn_error $? "Must use Pthread and atomic header with multithread" "$LINENO" 5
+	fi
+	;;
     esac
 fi
 

--- a/hdf5/configure.ac
+++ b/hdf5/configure.ac
@@ -1970,15 +1970,15 @@ if test "X$THREADSAFE" = "Xyes"; then
 fi
 
 ## ----------------------------------------------------------------------
-## Enable multithread feature of library.  It requires Pthread support
-## on POSIX systems.
+## Enable multithread feature of library.  It requires Pthread and Atomic
+## support on POSIX systems.
 ##
 AC_SUBST([MULTITHREAD])
 
 ## Default is no multithread
 MULTITHREAD=no
 
-AC_MSG_CHECKING([for multithread support])
+AC_MSG_CHECKING([for multithread configure option])
 AC_ARG_ENABLE([multithread],
               [AS_HELP_STRING([--enable-multithread],
                               [Enable multithread feature.
@@ -2114,6 +2114,60 @@ if test "X$MULTITHREAD" = "Xyes"; then
           fi
         fi
         ;;
+    esac
+
+    case "$host_cpu-$host_vendor-$host_os" in
+      *linux*)
+	# Replace C99 with C11 standard to support atomic datatype
+	H5_CFLAGS=$(echo $H5_CFLAGS | sed -e "s/-std=c99/-std=c11/g")
+
+	# Propagate the change to CFLAGS, too
+	CFLAGS="$H5_CFLAGS $AM_CFLAGS $CFLAGS"
+
+	HAVE_STDATOMIC_H="yes"
+
+	# Check the presence of stdatomic.h for atomic data type
+	AC_CHECK_HEADERS([stdatomic.h],,[HAVE_STDATOMIC_H="no"])
+
+	# Check the presence of atomic library
+	if test "x$HAVE_STDATOMIC_H" = "xyes"; then
+	  HAVE_LIBATOMIC="yes"
+	  AC_CHECK_LIB([atomic], [__atomic_compare_exchange_16],,[HAVE_LIBATOMIC="no"])
+	fi
+
+	# Define HAVE_MULTITHREAD only if stdatomic.h, atomic library, and pthread library are present
+	if [ test "x$HAVE_STDATOMIC_H" = "xyes" ] &&  [ test "x$HAVE_LIBATOMIC" = "xyes" ] && [ test "x$HAVE_PTHREAD" = "xyes" ]; then
+	  AC_DEFINE([HAVE_MULTITHREAD], [1], [Define if we have multithread support (pthread and atomic libraries)])
+	else
+	  AC_MSG_RESULT([no])
+	  AC_MSG_ERROR([Must use Pthread and atomic library and header with multithread])
+	fi
+	;;
+
+      *apple*)
+	# Replace C99 with C11 standard to support atomic datatype
+	H5_CFLAGS=$(echo $H5_CFLAGS | sed -e "s/-std=c99/-std=c11/g")
+
+	# Propagate the change to CFLAGS, too
+	CFLAGS="$H5_CFLAGS $AM_CFLAGS $CFLAGS"
+
+	# Check the presence of stdatomic.h for atomic data type.  Unlike GCC on Linux, clang on Mac OS doesn't need
+	# to link to the atomic library (-latomic)
+	HAVE_STDATOMIC_H="yes"
+
+	AC_CHECK_HEADERS([stdatomic.h],,[HAVE_STDATOMIC_H="no"])
+
+	# Define HAVE_MULTITHREAD on if stdatomic.h and pthread are present
+	AC_MSG_CHECKING([for multithread support (pthread and atomic libraries)])
+
+	if [ test "x$HAVE_STDATOMIC_H" = "xyes" ] && [ test "x$HAVE_PTHREAD" = "xyes" ]; then
+	  AC_MSG_RESULT([yes])
+	  AC_DEFINE([HAVE_MULTITHREAD], [1], [Define if we have multithread support (pthread and atomic header)])
+	else
+	  AC_MSG_RESULT([no])
+	  AC_MSG_ERROR([Must use Pthread and atomic header with multithread])
+	fi
+	;;
     esac
 fi
 

--- a/hdf5/src/H5.c
+++ b/hdf5/src/H5.c
@@ -25,6 +25,7 @@
 #include "H5Eprivate.h"  /* Error handling                           */
 #include "H5FLprivate.h" /* Free lists                               */
 #include "H5FSprivate.h" /* File free space                          */
+#include "H5Iprivate.h"  /* Index                                    */
 #include "H5Lprivate.h"  /* Links                                    */
 #include "H5MMprivate.h" /* Memory management                        */
 #include "H5Pprivate.h"  /* Property lists                           */
@@ -249,7 +250,12 @@ H5_init_library(void)
             herr_t (*func)(void);
             const char *descr;
         } initializer[] = {
+#if H5_HAVE_MULTITHREAD
+            {H5I_init, "index"}
+        ,   {H5E_init, "error"}
+#else /* H5_HAVE_MULTITHREAD */
             {H5E_init, "error"}
+#endif /* H5_HAVE_MULTITHREAD */
         ,   {H5VL_init_phase1, "VOL"}
         ,   {H5SL_init, "skip lists"}
         ,   {H5FD_init, "VFD"}

--- a/hdf5/src/H5Edefin.h
+++ b/hdf5/src/H5Edefin.h
@@ -18,47 +18,60 @@
 #define H5Edefin_H
 
 /* Major error IDs */
-hid_t H5E_BTREE_g          = FAIL;      /* B-Tree node */
-hid_t H5E_SOHM_g           = FAIL;      /* Shared Object Header Messages */
-hid_t H5E_IO_g             = FAIL;      /* Low-level I/O */
-hid_t H5E_FARRAY_g         = FAIL;      /* Fixed Array */
 hid_t H5E_ID_g             = FAIL;      /* Object ID */
-hid_t H5E_DATATYPE_g       = FAIL;      /* Datatype */
-hid_t H5E_VOL_g            = FAIL;      /* Virtual Object Layer */
-hid_t H5E_FILE_g           = FAIL;      /* File accessibility */
-hid_t H5E_REFERENCE_g      = FAIL;      /* References */
-hid_t H5E_CACHE_g          = FAIL;      /* Object cache */
-hid_t H5E_PAGEBUF_g        = FAIL;      /* Page Buffering */
-hid_t H5E_PLINE_g          = FAIL;      /* Data filters */
-hid_t H5E_DATASET_g        = FAIL;      /* Dataset */
-hid_t H5E_RESOURCE_g       = FAIL;      /* Resource unavailable */
-hid_t H5E_ERROR_g          = FAIL;      /* Error API */
+hid_t H5E_FUNC_g           = FAIL;      /* Function entry/exit */
+hid_t H5E_PLIST_g          = FAIL;      /* Property lists */
 hid_t H5E_PLUGIN_g         = FAIL;      /* Plugin for dynamically loaded library */
+hid_t H5E_EARRAY_g         = FAIL;      /* Extensible Array */
+hid_t H5E_CONTEXT_g        = FAIL;      /* API Context */
+hid_t H5E_FILE_g           = FAIL;      /* File accessibility */
+hid_t H5E_FARRAY_g         = FAIL;      /* Fixed Array */
+hid_t H5E_DATATYPE_g       = FAIL;      /* Datatype */
+hid_t H5E_TST_g            = FAIL;      /* Ternary Search Trees */
+hid_t H5E_LIB_g            = FAIL;      /* General library infrastructure */
 hid_t H5E_FSPACE_g         = FAIL;      /* Free Space Manager */
 hid_t H5E_NONE_MAJOR_g     = FAIL;      /* No error */
-hid_t H5E_RS_g             = FAIL;      /* Reference Counted Strings */
-hid_t H5E_FUNC_g           = FAIL;      /* Function entry/exit */
-hid_t H5E_EFL_g            = FAIL;      /* External file list */
-hid_t H5E_TST_g            = FAIL;      /* Ternary Search Trees */
-hid_t H5E_EVENTSET_g       = FAIL;      /* Event Set */
-hid_t H5E_VFL_g            = FAIL;      /* Virtual File Layer */
 hid_t H5E_STORAGE_g        = FAIL;      /* Data storage */
-hid_t H5E_DATASPACE_g      = FAIL;      /* Dataspace */
-hid_t H5E_OHDR_g           = FAIL;      /* Object header */
-hid_t H5E_LINK_g           = FAIL;      /* Links */
-hid_t H5E_MAP_g            = FAIL;      /* Map */
-hid_t H5E_HEAP_g           = FAIL;      /* Heap */
-hid_t H5E_ATTR_g           = FAIL;      /* Attribute */
-hid_t H5E_EARRAY_g         = FAIL;      /* Extensible Array */
-hid_t H5E_SLIST_g          = FAIL;      /* Skip Lists */
-hid_t H5E_LIB_g            = FAIL;      /* General library infrastructure */
-hid_t H5E_PLIST_g          = FAIL;      /* Property lists */
-hid_t H5E_ARGS_g           = FAIL;      /* Invalid arguments to routine */
+hid_t H5E_BTREE_g          = FAIL;      /* B-Tree node */
+hid_t H5E_REFERENCE_g      = FAIL;      /* References */
+hid_t H5E_EVENTSET_g       = FAIL;      /* Event Set */
 hid_t H5E_INTERNAL_g       = FAIL;      /* Internal error (too specific to document in detail) */
+hid_t H5E_ERROR_g          = FAIL;      /* Error API */
+hid_t H5E_SOHM_g           = FAIL;      /* Shared Object Header Messages */
+hid_t H5E_SLIST_g          = FAIL;      /* Skip Lists */
+hid_t H5E_DATASET_g        = FAIL;      /* Dataset */
+hid_t H5E_ATTR_g           = FAIL;      /* Attribute */
+hid_t H5E_HEAP_g           = FAIL;      /* Heap */
+hid_t H5E_VOL_g            = FAIL;      /* Virtual Object Layer */
+hid_t H5E_RS_g             = FAIL;      /* Reference Counted Strings */
+hid_t H5E_PAGEBUF_g        = FAIL;      /* Page Buffering */
 hid_t H5E_SYM_g            = FAIL;      /* Symbol table */
-hid_t H5E_CONTEXT_g        = FAIL;      /* API Context */
+hid_t H5E_EFL_g            = FAIL;      /* External file list */
+hid_t H5E_OHDR_g           = FAIL;      /* Object header */
+hid_t H5E_PLINE_g          = FAIL;      /* Data filters */
+hid_t H5E_ARGS_g           = FAIL;      /* Invalid arguments to routine */
+hid_t H5E_DATASPACE_g      = FAIL;      /* Dataspace */
+hid_t H5E_VFL_g            = FAIL;      /* Virtual File Layer */
+hid_t H5E_RESOURCE_g       = FAIL;      /* Resource unavailable */
+hid_t H5E_CACHE_g          = FAIL;      /* Object cache */
+hid_t H5E_MAP_g            = FAIL;      /* Map */
+hid_t H5E_IO_g             = FAIL;      /* Low-level I/O */
+hid_t H5E_LINK_g           = FAIL;      /* Links */
 
 /* Minor error IDs */
+
+/* Datatype conversion errors */
+hid_t H5E_CANTCONVERT_g    = FAIL;      /* Can't convert datatypes */
+hid_t H5E_BADSIZE_g        = FAIL;      /* Bad size for object */
+
+/* Map related errors */
+hid_t H5E_CANTPUT_g        = FAIL;      /* Can't put value */
+
+/* Property list errors */
+hid_t H5E_CANTGET_g        = FAIL;      /* Can't get value */
+hid_t H5E_CANTSET_g        = FAIL;      /* Can't set value */
+hid_t H5E_DUPCLASS_g       = FAIL;      /* Duplicate class name in parent class */
+hid_t H5E_SETDISALLOWED_g  = FAIL;      /* Disallowed operation */
 
 /* Argument errors */
 hid_t H5E_UNINITIALIZED_g  = FAIL;      /* Information is uinitialized */
@@ -69,6 +82,84 @@ hid_t H5E_BADVALUE_g       = FAIL;      /* Bad value */
 
 /* Plugin errors */
 hid_t H5E_OPENERROR_g      = FAIL;      /* Can't open directory or file */
+
+/* Generic low-level file I/O errors */
+hid_t H5E_SEEKERROR_g      = FAIL;      /* Seek failed */
+hid_t H5E_READERROR_g      = FAIL;      /* Read failed */
+hid_t H5E_WRITEERROR_g     = FAIL;      /* Write failed */
+hid_t H5E_CLOSEERROR_g     = FAIL;      /* Close failed */
+hid_t H5E_OVERFLOW_g       = FAIL;      /* Address overflowed */
+hid_t H5E_FCNTL_g          = FAIL;      /* File control (fcntl) failed */
+
+/* System level errors */
+hid_t H5E_SYSERRSTR_g      = FAIL;      /* System error message */
+
+/* I/O pipeline errors */
+hid_t H5E_NOFILTER_g       = FAIL;      /* Requested filter is not available */
+hid_t H5E_CALLBACK_g       = FAIL;      /* Callback failed */
+hid_t H5E_CANAPPLY_g       = FAIL;      /* Error from filter 'can apply' callback */
+hid_t H5E_SETLOCAL_g       = FAIL;      /* Error from filter 'set local' callback */
+hid_t H5E_NOENCODER_g      = FAIL;      /* Filter present but encoding disabled */
+hid_t H5E_CANTFILTER_g     = FAIL;      /* Filter operation failed */
+
+/* No error */
+hid_t H5E_NONE_MINOR_g     = FAIL;      /* No error */
+
+/* Asynchronous operation errors */
+hid_t H5E_CANTWAIT_g       = FAIL;      /* Can't wait on operation */
+hid_t H5E_CANTCANCEL_g     = FAIL;      /* Can't cancel operation */
+
+/* Resource errors */
+hid_t H5E_NOSPACE_g        = FAIL;      /* No space available for allocation */
+hid_t H5E_CANTALLOC_g      = FAIL;      /* Can't allocate space */
+hid_t H5E_CANTCOPY_g       = FAIL;      /* Unable to copy object */
+hid_t H5E_CANTFREE_g       = FAIL;      /* Unable to free object */
+hid_t H5E_ALREADYEXISTS_g  = FAIL;      /* Object already exists */
+hid_t H5E_CANTLOCK_g       = FAIL;      /* Unable to lock object */
+hid_t H5E_CANTUNLOCK_g     = FAIL;      /* Unable to unlock object */
+hid_t H5E_CANTGC_g         = FAIL;      /* Unable to garbage collect */
+hid_t H5E_CANTGETSIZE_g    = FAIL;      /* Unable to compute size */
+hid_t H5E_OBJOPEN_g        = FAIL;      /* Object is already open */
+
+/* Object ID related errors */
+hid_t H5E_BADID_g          = FAIL;      /* Unable to find ID information (already closed?) */
+hid_t H5E_BADGROUP_g       = FAIL;      /* Unable to find ID group information */
+hid_t H5E_CANTREGISTER_g   = FAIL;      /* Unable to register new ID */
+hid_t H5E_CANTINC_g        = FAIL;      /* Unable to increment reference count */
+hid_t H5E_CANTDEC_g        = FAIL;      /* Unable to decrement reference count */
+hid_t H5E_NOIDS_g          = FAIL;      /* Out of IDs for group */
+
+/* B-tree related errors */
+hid_t H5E_NOTFOUND_g       = FAIL;      /* Object not found */
+hid_t H5E_EXISTS_g         = FAIL;      /* Object already exists */
+hid_t H5E_CANTENCODE_g     = FAIL;      /* Unable to encode value */
+hid_t H5E_CANTDECODE_g     = FAIL;      /* Unable to decode value */
+hid_t H5E_CANTSPLIT_g      = FAIL;      /* Unable to split node */
+hid_t H5E_CANTREDISTRIBUTE_g = FAIL;      /* Unable to redistribute records */
+hid_t H5E_CANTSWAP_g       = FAIL;      /* Unable to swap records */
+hid_t H5E_CANTINSERT_g     = FAIL;      /* Unable to insert object */
+hid_t H5E_CANTLIST_g       = FAIL;      /* Unable to list node */
+hid_t H5E_CANTMODIFY_g     = FAIL;      /* Unable to modify record */
+hid_t H5E_CANTREMOVE_g     = FAIL;      /* Unable to remove object */
+hid_t H5E_CANTFIND_g       = FAIL;      /* Unable to check for record */
+
+/* Free space errors */
+hid_t H5E_CANTMERGE_g      = FAIL;      /* Can't merge objects */
+hid_t H5E_CANTREVIVE_g     = FAIL;      /* Can't revive object */
+hid_t H5E_CANTSHRINK_g     = FAIL;      /* Can't shrink container */
+
+/* Link related errors */
+hid_t H5E_TRAVERSE_g       = FAIL;      /* Link traversal failure */
+hid_t H5E_NLINKS_g         = FAIL;      /* Too many soft links in path */
+hid_t H5E_NOTREGISTERED_g  = FAIL;      /* Link class not registered */
+hid_t H5E_CANTMOVE_g       = FAIL;      /* Can't move object */
+hid_t H5E_CANTSORT_g       = FAIL;      /* Can't sort objects */
+
+/* Group related errors */
+hid_t H5E_CANTOPENOBJ_g    = FAIL;      /* Can't open object */
+hid_t H5E_CANTCLOSEOBJ_g   = FAIL;      /* Can't close object */
+hid_t H5E_COMPLEN_g        = FAIL;      /* Name component is too long */
+hid_t H5E_PATH_g           = FAIL;      /* Problem with path to object */
 
 /* Function entry/exit interface errors */
 hid_t H5E_CANTINIT_g       = FAIL;      /* Unable to initialize object */
@@ -104,44 +195,6 @@ hid_t H5E_LOGGING_g        = FAIL;      /* Failure in the cache logging framewor
 hid_t H5E_CANTCORK_g       = FAIL;      /* Unable to cork an object */
 hid_t H5E_CANTUNCORK_g     = FAIL;      /* Unable to uncork an object */
 
-/* System level errors */
-hid_t H5E_SYSERRSTR_g      = FAIL;      /* System error message */
-
-/* Parallel MPI errors */
-hid_t H5E_MPI_g            = FAIL;      /* Some MPI function failed */
-hid_t H5E_MPIERRSTR_g      = FAIL;      /* MPI Error String */
-hid_t H5E_CANTRECV_g       = FAIL;      /* Can't receive data */
-hid_t H5E_CANTGATHER_g     = FAIL;      /* Can't gather data */
-hid_t H5E_NO_INDEPENDENT_g = FAIL;      /* Can't perform independent IO */
-
-/* Free space errors */
-hid_t H5E_CANTMERGE_g      = FAIL;      /* Can't merge objects */
-hid_t H5E_CANTREVIVE_g     = FAIL;      /* Can't revive object */
-hid_t H5E_CANTSHRINK_g     = FAIL;      /* Can't shrink container */
-
-/* File accessibility errors */
-hid_t H5E_FILEEXISTS_g     = FAIL;      /* File already exists */
-hid_t H5E_FILEOPEN_g       = FAIL;      /* File already open */
-hid_t H5E_CANTCREATE_g     = FAIL;      /* Unable to create file */
-hid_t H5E_CANTOPENFILE_g   = FAIL;      /* Unable to open file */
-hid_t H5E_CANTCLOSEFILE_g  = FAIL;      /* Unable to close file */
-hid_t H5E_NOTHDF5_g        = FAIL;      /* Not an HDF5 file */
-hid_t H5E_BADFILE_g        = FAIL;      /* Bad file ID accessed */
-hid_t H5E_TRUNCATED_g      = FAIL;      /* File has been truncated */
-hid_t H5E_MOUNT_g          = FAIL;      /* File mount error */
-hid_t H5E_UNMOUNT_g        = FAIL;      /* File unmount error */
-hid_t H5E_CANTDELETEFILE_g = FAIL;      /* Unable to delete file */
-hid_t H5E_CANTLOCKFILE_g   = FAIL;      /* Unable to lock file */
-hid_t H5E_CANTUNLOCKFILE_g = FAIL;      /* Unable to unlock file */
-
-/* Generic low-level file I/O errors */
-hid_t H5E_SEEKERROR_g      = FAIL;      /* Seek failed */
-hid_t H5E_READERROR_g      = FAIL;      /* Read failed */
-hid_t H5E_WRITEERROR_g     = FAIL;      /* Write failed */
-hid_t H5E_CLOSEERROR_g     = FAIL;      /* Close failed */
-hid_t H5E_OVERFLOW_g       = FAIL;      /* Address overflowed */
-hid_t H5E_FCNTL_g          = FAIL;      /* File control (fcntl) failed */
-
 /* Heap errors */
 hid_t H5E_CANTRESTORE_g    = FAIL;      /* Can't restore condition */
 hid_t H5E_CANTCOMPUTE_g    = FAIL;      /* Can't compute value */
@@ -150,73 +203,12 @@ hid_t H5E_CANTATTACH_g     = FAIL;      /* Can't attach object */
 hid_t H5E_CANTUPDATE_g     = FAIL;      /* Can't update object */
 hid_t H5E_CANTOPERATE_g    = FAIL;      /* Can't operate on object */
 
-/* I/O pipeline errors */
-hid_t H5E_NOFILTER_g       = FAIL;      /* Requested filter is not available */
-hid_t H5E_CALLBACK_g       = FAIL;      /* Callback failed */
-hid_t H5E_CANAPPLY_g       = FAIL;      /* Error from filter 'can apply' callback */
-hid_t H5E_SETLOCAL_g       = FAIL;      /* Error from filter 'set local' callback */
-hid_t H5E_NOENCODER_g      = FAIL;      /* Filter present but encoding disabled */
-hid_t H5E_CANTFILTER_g     = FAIL;      /* Filter operation failed */
-
-/* Group related errors */
-hid_t H5E_CANTOPENOBJ_g    = FAIL;      /* Can't open object */
-hid_t H5E_CANTCLOSEOBJ_g   = FAIL;      /* Can't close object */
-hid_t H5E_COMPLEN_g        = FAIL;      /* Name component is too long */
-hid_t H5E_PATH_g           = FAIL;      /* Problem with path to object */
-
-/* Object ID related errors */
-hid_t H5E_BADID_g          = FAIL;      /* Unable to find ID information (already closed?) */
-hid_t H5E_BADGROUP_g       = FAIL;      /* Unable to find ID group information */
-hid_t H5E_CANTREGISTER_g   = FAIL;      /* Unable to register new ID */
-hid_t H5E_CANTINC_g        = FAIL;      /* Unable to increment reference count */
-hid_t H5E_CANTDEC_g        = FAIL;      /* Unable to decrement reference count */
-hid_t H5E_NOIDS_g          = FAIL;      /* Out of IDs for group */
-
-/* No error */
-hid_t H5E_NONE_MINOR_g     = FAIL;      /* No error */
-
-/* Resource errors */
-hid_t H5E_NOSPACE_g        = FAIL;      /* No space available for allocation */
-hid_t H5E_CANTALLOC_g      = FAIL;      /* Can't allocate space */
-hid_t H5E_CANTCOPY_g       = FAIL;      /* Unable to copy object */
-hid_t H5E_CANTFREE_g       = FAIL;      /* Unable to free object */
-hid_t H5E_ALREADYEXISTS_g  = FAIL;      /* Object already exists */
-hid_t H5E_CANTLOCK_g       = FAIL;      /* Unable to lock object */
-hid_t H5E_CANTUNLOCK_g     = FAIL;      /* Unable to unlock object */
-hid_t H5E_CANTGC_g         = FAIL;      /* Unable to garbage collect */
-hid_t H5E_CANTGETSIZE_g    = FAIL;      /* Unable to compute size */
-hid_t H5E_OBJOPEN_g        = FAIL;      /* Object is already open */
-
-/* Property list errors */
-hid_t H5E_CANTGET_g        = FAIL;      /* Can't get value */
-hid_t H5E_CANTSET_g        = FAIL;      /* Can't set value */
-hid_t H5E_DUPCLASS_g       = FAIL;      /* Duplicate class name in parent class */
-hid_t H5E_SETDISALLOWED_g  = FAIL;      /* Disallowed operation */
-
-/* Datatype conversion errors */
-hid_t H5E_CANTCONVERT_g    = FAIL;      /* Can't convert datatypes */
-hid_t H5E_BADSIZE_g        = FAIL;      /* Bad size for object */
-
-/* Link related errors */
-hid_t H5E_TRAVERSE_g       = FAIL;      /* Link traversal failure */
-hid_t H5E_NLINKS_g         = FAIL;      /* Too many soft links in path */
-hid_t H5E_NOTREGISTERED_g  = FAIL;      /* Link class not registered */
-hid_t H5E_CANTMOVE_g       = FAIL;      /* Can't move object */
-hid_t H5E_CANTSORT_g       = FAIL;      /* Can't sort objects */
-
-/* B-tree related errors */
-hid_t H5E_NOTFOUND_g       = FAIL;      /* Object not found */
-hid_t H5E_EXISTS_g         = FAIL;      /* Object already exists */
-hid_t H5E_CANTENCODE_g     = FAIL;      /* Unable to encode value */
-hid_t H5E_CANTDECODE_g     = FAIL;      /* Unable to decode value */
-hid_t H5E_CANTSPLIT_g      = FAIL;      /* Unable to split node */
-hid_t H5E_CANTREDISTRIBUTE_g = FAIL;      /* Unable to redistribute records */
-hid_t H5E_CANTSWAP_g       = FAIL;      /* Unable to swap records */
-hid_t H5E_CANTINSERT_g     = FAIL;      /* Unable to insert object */
-hid_t H5E_CANTLIST_g       = FAIL;      /* Unable to list node */
-hid_t H5E_CANTMODIFY_g     = FAIL;      /* Unable to modify record */
-hid_t H5E_CANTREMOVE_g     = FAIL;      /* Unable to remove object */
-hid_t H5E_CANTFIND_g       = FAIL;      /* Unable to check for record */
+/* Parallel MPI errors */
+hid_t H5E_MPI_g            = FAIL;      /* Some MPI function failed */
+hid_t H5E_MPIERRSTR_g      = FAIL;      /* MPI Error String */
+hid_t H5E_CANTRECV_g       = FAIL;      /* Can't receive data */
+hid_t H5E_CANTGATHER_g     = FAIL;      /* Can't gather data */
+hid_t H5E_NO_INDEPENDENT_g = FAIL;      /* Can't perform independent IO */
 
 /* Dataspace errors */
 hid_t H5E_CANTCLIP_g       = FAIL;      /* Can't clip hyperslab region */
@@ -239,11 +231,19 @@ hid_t H5E_CANTPACK_g       = FAIL;      /* Can't pack messages */
 hid_t H5E_CANTRESET_g      = FAIL;      /* Can't reset object */
 hid_t H5E_CANTRENAME_g     = FAIL;      /* Unable to rename object */
 
-/* Asynchronous operation errors */
-hid_t H5E_CANTWAIT_g       = FAIL;      /* Can't wait on operation */
-hid_t H5E_CANTCANCEL_g     = FAIL;      /* Can't cancel operation */
-
-/* Map related errors */
-hid_t H5E_CANTPUT_g        = FAIL;      /* Can't put value */
+/* File accessibility errors */
+hid_t H5E_FILEEXISTS_g     = FAIL;      /* File already exists */
+hid_t H5E_FILEOPEN_g       = FAIL;      /* File already open */
+hid_t H5E_CANTCREATE_g     = FAIL;      /* Unable to create file */
+hid_t H5E_CANTOPENFILE_g   = FAIL;      /* Unable to open file */
+hid_t H5E_CANTCLOSEFILE_g  = FAIL;      /* Unable to close file */
+hid_t H5E_NOTHDF5_g        = FAIL;      /* Not an HDF5 file */
+hid_t H5E_BADFILE_g        = FAIL;      /* Bad file ID accessed */
+hid_t H5E_TRUNCATED_g      = FAIL;      /* File has been truncated */
+hid_t H5E_MOUNT_g          = FAIL;      /* File mount error */
+hid_t H5E_UNMOUNT_g        = FAIL;      /* File unmount error */
+hid_t H5E_CANTDELETEFILE_g = FAIL;      /* Unable to delete file */
+hid_t H5E_CANTLOCKFILE_g   = FAIL;      /* Unable to lock file */
+hid_t H5E_CANTUNLOCKFILE_g = FAIL;      /* Unable to unlock file */
 
 #endif /* H5Edefin_H */

--- a/hdf5/src/H5Einit.h
+++ b/hdf5/src/H5Einit.h
@@ -21,85 +21,60 @@
 /* Major error codes */
 /*********************/
 
-assert(H5E_BTREE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "B-Tree node"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_BTREE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_SOHM_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Shared Object Header Messages"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_SOHM_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_IO_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Low-level I/O"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_IO_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_FARRAY_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Fixed Array"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_FARRAY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 assert(H5E_ID_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MAJOR, "Object ID"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
 if((H5E_ID_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_DATATYPE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Datatype"))==NULL)
+assert(H5E_FUNC_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Function entry/exit"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_DATATYPE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_FUNC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_VOL_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Virtual Object Layer"))==NULL)
+assert(H5E_PLIST_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Property lists"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_VOL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_PLIST_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_PLUGIN_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Plugin for dynamically loaded library"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_PLUGIN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_EARRAY_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Extensible Array"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_EARRAY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CONTEXT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "API Context"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CONTEXT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 assert(H5E_FILE_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MAJOR, "File accessibility"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
 if((H5E_FILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_REFERENCE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "References"))==NULL)
+assert(H5E_FARRAY_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Fixed Array"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_REFERENCE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_FARRAY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CACHE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Object cache"))==NULL)
+assert(H5E_DATATYPE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Datatype"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CACHE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_DATATYPE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_PAGEBUF_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Page Buffering"))==NULL)
+assert(H5E_TST_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Ternary Search Trees"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_PAGEBUF_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_TST_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_PLINE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Data filters"))==NULL)
+assert(H5E_LIB_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "General library infrastructure"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_PLINE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_DATASET_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Dataset"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_DATASET_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_RESOURCE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Resource unavailable"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_RESOURCE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_ERROR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Error API"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_ERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_PLUGIN_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Plugin for dynamically loaded library"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_PLUGIN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_LIB_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 assert(H5E_FSPACE_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MAJOR, "Free Space Manager"))==NULL)
@@ -111,116 +86,182 @@ if((msg = H5E__create_msg(cls, H5E_MAJOR, "No error"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
 if((H5E_NONE_MAJOR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_RS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Reference Counted Strings"))==NULL)
+assert(H5E_STORAGE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Data storage"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_RS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_STORAGE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_FUNC_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Function entry/exit"))==NULL)
+assert(H5E_BTREE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "B-Tree node"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_FUNC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_BTREE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_EFL_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "External file list"))==NULL)
+assert(H5E_REFERENCE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "References"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_EFL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_TST_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Ternary Search Trees"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_TST_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_REFERENCE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 assert(H5E_EVENTSET_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MAJOR, "Event Set"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
 if((H5E_EVENTSET_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_VFL_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Virtual File Layer"))==NULL)
+assert(H5E_INTERNAL_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Internal error (too specific to document in detail)"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_VFL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_INTERNAL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_STORAGE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Data storage"))==NULL)
+assert(H5E_ERROR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Error API"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_STORAGE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_ERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_DATASPACE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Dataspace"))==NULL)
+assert(H5E_SOHM_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Shared Object Header Messages"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_DATASPACE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_OHDR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Object header"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_OHDR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_LINK_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Links"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_LINK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_MAP_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Map"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_MAP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_HEAP_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Heap"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_HEAP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_ATTR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Attribute"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_ATTR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_EARRAY_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Extensible Array"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_EARRAY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_SOHM_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 assert(H5E_SLIST_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MAJOR, "Skip Lists"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
 if((H5E_SLIST_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_LIB_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "General library infrastructure"))==NULL)
+assert(H5E_DATASET_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Dataset"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_LIB_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_DATASET_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_PLIST_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Property lists"))==NULL)
+assert(H5E_ATTR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Attribute"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_PLIST_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_ATTR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_ARGS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Invalid arguments to routine"))==NULL)
+assert(H5E_HEAP_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Heap"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_ARGS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_HEAP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_INTERNAL_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "Internal error (too specific to document in detail)"))==NULL)
+assert(H5E_VOL_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Virtual Object Layer"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_INTERNAL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_VOL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_RS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Reference Counted Strings"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_RS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_PAGEBUF_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Page Buffering"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_PAGEBUF_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 assert(H5E_SYM_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MAJOR, "Symbol table"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
 if((H5E_SYM_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CONTEXT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MAJOR, "API Context"))==NULL)
+assert(H5E_EFL_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "External file list"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CONTEXT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_EFL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_OHDR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Object header"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_OHDR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_PLINE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Data filters"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_PLINE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_ARGS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Invalid arguments to routine"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_ARGS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_DATASPACE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Dataspace"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_DATASPACE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_VFL_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Virtual File Layer"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_VFL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_RESOURCE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Resource unavailable"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_RESOURCE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CACHE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Object cache"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CACHE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_MAP_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Map"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_MAP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_IO_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Low-level I/O"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_IO_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_LINK_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MAJOR, "Links"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_LINK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
 /*********************/
 /* Minor error codes */
 /*********************/
 
+
+/* Datatype conversion errors */
+assert(H5E_CANTCONVERT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't convert datatypes"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTCONVERT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_BADSIZE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Bad size for object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_BADSIZE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Map related errors */
+assert(H5E_CANTPUT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't put value"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTPUT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Property list errors */
+assert(H5E_CANTGET_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't get value"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTGET_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTSET_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't set value"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTSET_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_DUPCLASS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Duplicate class name in parent class"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_DUPCLASS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_SETDISALLOWED_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Disallowed operation"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_SETDISALLOWED_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
 /* Argument errors */
 assert(H5E_UNINITIALIZED_g==(-1));
@@ -254,6 +295,308 @@ assert(H5E_OPENERROR_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't open directory or file"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
 if((H5E_OPENERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Generic low-level file I/O errors */
+assert(H5E_SEEKERROR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Seek failed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_SEEKERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_READERROR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Read failed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_READERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_WRITEERROR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Write failed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_WRITEERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CLOSEERROR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Close failed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CLOSEERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_OVERFLOW_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Address overflowed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_OVERFLOW_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_FCNTL_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "File control (fcntl) failed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_FCNTL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* System level errors */
+assert(H5E_SYSERRSTR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "System error message"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_SYSERRSTR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* I/O pipeline errors */
+assert(H5E_NOFILTER_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Requested filter is not available"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NOFILTER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CALLBACK_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Callback failed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CALLBACK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANAPPLY_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Error from filter 'can apply' callback"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANAPPLY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_SETLOCAL_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Error from filter 'set local' callback"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_SETLOCAL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_NOENCODER_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Filter present but encoding disabled"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NOENCODER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTFILTER_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Filter operation failed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTFILTER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* No error */
+assert(H5E_NONE_MINOR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "No error"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NONE_MINOR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Asynchronous operation errors */
+assert(H5E_CANTWAIT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't wait on operation"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTWAIT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTCANCEL_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't cancel operation"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTCANCEL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Resource errors */
+assert(H5E_NOSPACE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "No space available for allocation"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NOSPACE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTALLOC_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't allocate space"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTALLOC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTCOPY_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to copy object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTCOPY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTFREE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to free object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTFREE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_ALREADYEXISTS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Object already exists"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_ALREADYEXISTS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTLOCK_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to lock object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTLOCK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTUNLOCK_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to unlock object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTUNLOCK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTGC_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to garbage collect"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTGC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTGETSIZE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to compute size"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTGETSIZE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_OBJOPEN_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Object is already open"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_OBJOPEN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Object ID related errors */
+assert(H5E_BADID_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to find ID information (already closed?)"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_BADID_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_BADGROUP_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to find ID group information"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_BADGROUP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTREGISTER_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to register new ID"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTREGISTER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTINC_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to increment reference count"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTINC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTDEC_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to decrement reference count"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTDEC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_NOIDS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Out of IDs for group"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NOIDS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* B-tree related errors */
+assert(H5E_NOTFOUND_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Object not found"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NOTFOUND_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_EXISTS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Object already exists"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_EXISTS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTENCODE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to encode value"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTENCODE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTDECODE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to decode value"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTDECODE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTSPLIT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to split node"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTSPLIT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTREDISTRIBUTE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to redistribute records"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTREDISTRIBUTE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTSWAP_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to swap records"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTSWAP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTINSERT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to insert object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTINSERT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTLIST_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to list node"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTLIST_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTMODIFY_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to modify record"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTMODIFY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTREMOVE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to remove object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTREMOVE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTFIND_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to check for record"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTFIND_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Free space errors */
+assert(H5E_CANTMERGE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't merge objects"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTMERGE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTREVIVE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't revive object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTREVIVE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTSHRINK_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't shrink container"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTSHRINK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Link related errors */
+assert(H5E_TRAVERSE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Link traversal failure"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_TRAVERSE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_NLINKS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Too many soft links in path"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NLINKS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_NOTREGISTERED_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Link class not registered"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NOTREGISTERED_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTMOVE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't move object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTMOVE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTSORT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't sort objects"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTSORT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+
+/* Group related errors */
+assert(H5E_CANTOPENOBJ_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't open object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTOPENOBJ_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTCLOSEOBJ_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't close object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTCLOSEOBJ_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_COMPLEN_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Name component is too long"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_COMPLEN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_PATH_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Problem with path to object"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_PATH_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
 /* Function entry/exit interface errors */
@@ -410,156 +753,6 @@ if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to uncork an object"))==NULL)
 if((H5E_CANTUNCORK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
-/* System level errors */
-assert(H5E_SYSERRSTR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "System error message"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_SYSERRSTR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Parallel MPI errors */
-assert(H5E_MPI_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Some MPI function failed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_MPI_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_MPIERRSTR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "MPI Error String"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_MPIERRSTR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTRECV_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't receive data"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTRECV_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTGATHER_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't gather data"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTGATHER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_NO_INDEPENDENT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't perform independent IO"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NO_INDEPENDENT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Free space errors */
-assert(H5E_CANTMERGE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't merge objects"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTMERGE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTREVIVE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't revive object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTREVIVE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTSHRINK_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't shrink container"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTSHRINK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* File accessibility errors */
-assert(H5E_FILEEXISTS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "File already exists"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_FILEEXISTS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_FILEOPEN_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "File already open"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_FILEOPEN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTCREATE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to create file"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTCREATE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTOPENFILE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to open file"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTOPENFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTCLOSEFILE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to close file"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTCLOSEFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_NOTHDF5_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Not an HDF5 file"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NOTHDF5_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_BADFILE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Bad file ID accessed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_BADFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_TRUNCATED_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "File has been truncated"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_TRUNCATED_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_MOUNT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "File mount error"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_MOUNT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_UNMOUNT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "File unmount error"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_UNMOUNT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTDELETEFILE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to delete file"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTDELETEFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTLOCKFILE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to lock file"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTLOCKFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTUNLOCKFILE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to unlock file"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTUNLOCKFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Generic low-level file I/O errors */
-assert(H5E_SEEKERROR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Seek failed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_SEEKERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_READERROR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Read failed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_READERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_WRITEERROR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Write failed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_WRITEERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CLOSEERROR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Close failed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CLOSEERROR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_OVERFLOW_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Address overflowed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_OVERFLOW_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_FCNTL_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "File control (fcntl) failed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_FCNTL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
 /* Heap errors */
 assert(H5E_CANTRESTORE_g==(-1));
 if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't restore condition"))==NULL)
@@ -592,272 +785,31 @@ if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't operate on object"))==NULL)
 if((H5E_CANTOPERATE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
-/* I/O pipeline errors */
-assert(H5E_NOFILTER_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Requested filter is not available"))==NULL)
+/* Parallel MPI errors */
+assert(H5E_MPI_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Some MPI function failed"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NOFILTER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_MPI_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CALLBACK_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Callback failed"))==NULL)
+assert(H5E_MPIERRSTR_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "MPI Error String"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CALLBACK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_MPIERRSTR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANAPPLY_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Error from filter 'can apply' callback"))==NULL)
+assert(H5E_CANTRECV_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't receive data"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANAPPLY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_CANTRECV_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_SETLOCAL_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Error from filter 'set local' callback"))==NULL)
+assert(H5E_CANTGATHER_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't gather data"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_SETLOCAL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_CANTGATHER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_NOENCODER_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Filter present but encoding disabled"))==NULL)
+assert(H5E_NO_INDEPENDENT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't perform independent IO"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NOENCODER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTFILTER_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Filter operation failed"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTFILTER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Group related errors */
-assert(H5E_CANTOPENOBJ_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't open object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTOPENOBJ_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTCLOSEOBJ_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't close object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTCLOSEOBJ_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_COMPLEN_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Name component is too long"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_COMPLEN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_PATH_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Problem with path to object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_PATH_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Object ID related errors */
-assert(H5E_BADID_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to find ID information (already closed?)"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_BADID_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_BADGROUP_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to find ID group information"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_BADGROUP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTREGISTER_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to register new ID"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTREGISTER_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTINC_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to increment reference count"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTINC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTDEC_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to decrement reference count"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTDEC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_NOIDS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Out of IDs for group"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NOIDS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* No error */
-assert(H5E_NONE_MINOR_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "No error"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NONE_MINOR_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Resource errors */
-assert(H5E_NOSPACE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "No space available for allocation"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NOSPACE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTALLOC_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't allocate space"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTALLOC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTCOPY_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to copy object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTCOPY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTFREE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to free object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTFREE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_ALREADYEXISTS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Object already exists"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_ALREADYEXISTS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTLOCK_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to lock object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTLOCK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTUNLOCK_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to unlock object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTUNLOCK_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTGC_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to garbage collect"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTGC_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTGETSIZE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to compute size"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTGETSIZE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_OBJOPEN_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Object is already open"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_OBJOPEN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Property list errors */
-assert(H5E_CANTGET_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't get value"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTGET_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTSET_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't set value"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTSET_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_DUPCLASS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Duplicate class name in parent class"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_DUPCLASS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_SETDISALLOWED_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Disallowed operation"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_SETDISALLOWED_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Datatype conversion errors */
-assert(H5E_CANTCONVERT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't convert datatypes"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTCONVERT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_BADSIZE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Bad size for object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_BADSIZE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Link related errors */
-assert(H5E_TRAVERSE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Link traversal failure"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_TRAVERSE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_NLINKS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Too many soft links in path"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NLINKS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_NOTREGISTERED_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Link class not registered"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NOTREGISTERED_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTMOVE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't move object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTMOVE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTSORT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't sort objects"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTSORT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* B-tree related errors */
-assert(H5E_NOTFOUND_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Object not found"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_NOTFOUND_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_EXISTS_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Object already exists"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_EXISTS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTENCODE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to encode value"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTENCODE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTDECODE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to decode value"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTDECODE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTSPLIT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to split node"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTSPLIT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTREDISTRIBUTE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to redistribute records"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTREDISTRIBUTE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTSWAP_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to swap records"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTSWAP_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTINSERT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to insert object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTINSERT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTLIST_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to list node"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTLIST_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTMODIFY_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to modify record"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTMODIFY_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTREMOVE_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to remove object"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTREMOVE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTFIND_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to check for record"))==NULL)
-    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTFIND_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_NO_INDEPENDENT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
 /* Dataspace errors */
@@ -949,23 +901,71 @@ if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to rename object"))==NULL)
 if((H5E_CANTRENAME_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
-/* Asynchronous operation errors */
-assert(H5E_CANTWAIT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't wait on operation"))==NULL)
+/* File accessibility errors */
+assert(H5E_FILEEXISTS_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "File already exists"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTWAIT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_FILEEXISTS_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-assert(H5E_CANTCANCEL_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't cancel operation"))==NULL)
+assert(H5E_FILEOPEN_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "File already open"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTCANCEL_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_FILEOPEN_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
-
-/* Map related errors */
-assert(H5E_CANTPUT_g==(-1));
-if((msg = H5E__create_msg(cls, H5E_MINOR, "Can't put value"))==NULL)
+assert(H5E_CANTCREATE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to create file"))==NULL)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
-if((H5E_CANTPUT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+if((H5E_CANTCREATE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTOPENFILE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to open file"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTOPENFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTCLOSEFILE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to close file"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTCLOSEFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_NOTHDF5_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Not an HDF5 file"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_NOTHDF5_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_BADFILE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Bad file ID accessed"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_BADFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_TRUNCATED_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "File has been truncated"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_TRUNCATED_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_MOUNT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "File mount error"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_MOUNT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_UNMOUNT_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "File unmount error"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_UNMOUNT_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTDELETEFILE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to delete file"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTDELETEFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTLOCKFILE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to lock file"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTLOCKFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+assert(H5E_CANTUNLOCKFILE_g==(-1));
+if((msg = H5E__create_msg(cls, H5E_MINOR, "Unable to unlock file"))==NULL)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "error message initialization failed");
+if((H5E_CANTUNLOCKFILE_g = H5I_register(H5I_ERROR_MSG, msg, FALSE))<0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 
 #endif /* H5Einit_H */

--- a/hdf5/src/H5Epubgen.h
+++ b/hdf5/src/H5Epubgen.h
@@ -25,88 +25,108 @@ extern "C" {
 /* Major error codes */
 /*********************/
 
-#define H5E_BTREE            (H5OPEN H5E_BTREE_g)
-#define H5E_SOHM             (H5OPEN H5E_SOHM_g)
-#define H5E_IO               (H5OPEN H5E_IO_g)
-#define H5E_FARRAY           (H5OPEN H5E_FARRAY_g)
 #define H5E_ID               (H5OPEN H5E_ID_g)
-#define H5E_DATATYPE         (H5OPEN H5E_DATATYPE_g)
-#define H5E_VOL              (H5OPEN H5E_VOL_g)
-#define H5E_FILE             (H5OPEN H5E_FILE_g)
-#define H5E_REFERENCE        (H5OPEN H5E_REFERENCE_g)
-#define H5E_CACHE            (H5OPEN H5E_CACHE_g)
-#define H5E_PAGEBUF          (H5OPEN H5E_PAGEBUF_g)
-#define H5E_PLINE            (H5OPEN H5E_PLINE_g)
-#define H5E_DATASET          (H5OPEN H5E_DATASET_g)
-#define H5E_RESOURCE         (H5OPEN H5E_RESOURCE_g)
-#define H5E_ERROR            (H5OPEN H5E_ERROR_g)
+#define H5E_FUNC             (H5OPEN H5E_FUNC_g)
+#define H5E_PLIST            (H5OPEN H5E_PLIST_g)
 #define H5E_PLUGIN           (H5OPEN H5E_PLUGIN_g)
+#define H5E_EARRAY           (H5OPEN H5E_EARRAY_g)
+#define H5E_CONTEXT          (H5OPEN H5E_CONTEXT_g)
+#define H5E_FILE             (H5OPEN H5E_FILE_g)
+#define H5E_FARRAY           (H5OPEN H5E_FARRAY_g)
+#define H5E_DATATYPE         (H5OPEN H5E_DATATYPE_g)
+#define H5E_TST              (H5OPEN H5E_TST_g)
+#define H5E_LIB              (H5OPEN H5E_LIB_g)
 #define H5E_FSPACE           (H5OPEN H5E_FSPACE_g)
 #define H5E_NONE_MAJOR       (H5OPEN H5E_NONE_MAJOR_g)
-#define H5E_RS               (H5OPEN H5E_RS_g)
-#define H5E_FUNC             (H5OPEN H5E_FUNC_g)
-#define H5E_EFL              (H5OPEN H5E_EFL_g)
-#define H5E_TST              (H5OPEN H5E_TST_g)
-#define H5E_EVENTSET         (H5OPEN H5E_EVENTSET_g)
-#define H5E_VFL              (H5OPEN H5E_VFL_g)
 #define H5E_STORAGE          (H5OPEN H5E_STORAGE_g)
-#define H5E_DATASPACE        (H5OPEN H5E_DATASPACE_g)
-#define H5E_OHDR             (H5OPEN H5E_OHDR_g)
-#define H5E_LINK             (H5OPEN H5E_LINK_g)
-#define H5E_MAP              (H5OPEN H5E_MAP_g)
-#define H5E_HEAP             (H5OPEN H5E_HEAP_g)
-#define H5E_ATTR             (H5OPEN H5E_ATTR_g)
-#define H5E_EARRAY           (H5OPEN H5E_EARRAY_g)
-#define H5E_SLIST            (H5OPEN H5E_SLIST_g)
-#define H5E_LIB              (H5OPEN H5E_LIB_g)
-#define H5E_PLIST            (H5OPEN H5E_PLIST_g)
-#define H5E_ARGS             (H5OPEN H5E_ARGS_g)
+#define H5E_BTREE            (H5OPEN H5E_BTREE_g)
+#define H5E_REFERENCE        (H5OPEN H5E_REFERENCE_g)
+#define H5E_EVENTSET         (H5OPEN H5E_EVENTSET_g)
 #define H5E_INTERNAL         (H5OPEN H5E_INTERNAL_g)
+#define H5E_ERROR            (H5OPEN H5E_ERROR_g)
+#define H5E_SOHM             (H5OPEN H5E_SOHM_g)
+#define H5E_SLIST            (H5OPEN H5E_SLIST_g)
+#define H5E_DATASET          (H5OPEN H5E_DATASET_g)
+#define H5E_ATTR             (H5OPEN H5E_ATTR_g)
+#define H5E_HEAP             (H5OPEN H5E_HEAP_g)
+#define H5E_VOL              (H5OPEN H5E_VOL_g)
+#define H5E_RS               (H5OPEN H5E_RS_g)
+#define H5E_PAGEBUF          (H5OPEN H5E_PAGEBUF_g)
 #define H5E_SYM              (H5OPEN H5E_SYM_g)
-#define H5E_CONTEXT          (H5OPEN H5E_CONTEXT_g)
-H5_DLLVAR hid_t H5E_BTREE_g;         /* B-Tree node */
-H5_DLLVAR hid_t H5E_SOHM_g;          /* Shared Object Header Messages */
-H5_DLLVAR hid_t H5E_IO_g;            /* Low-level I/O */
-H5_DLLVAR hid_t H5E_FARRAY_g;        /* Fixed Array */
+#define H5E_EFL              (H5OPEN H5E_EFL_g)
+#define H5E_OHDR             (H5OPEN H5E_OHDR_g)
+#define H5E_PLINE            (H5OPEN H5E_PLINE_g)
+#define H5E_ARGS             (H5OPEN H5E_ARGS_g)
+#define H5E_DATASPACE        (H5OPEN H5E_DATASPACE_g)
+#define H5E_VFL              (H5OPEN H5E_VFL_g)
+#define H5E_RESOURCE         (H5OPEN H5E_RESOURCE_g)
+#define H5E_CACHE            (H5OPEN H5E_CACHE_g)
+#define H5E_MAP              (H5OPEN H5E_MAP_g)
+#define H5E_IO               (H5OPEN H5E_IO_g)
+#define H5E_LINK             (H5OPEN H5E_LINK_g)
 H5_DLLVAR hid_t H5E_ID_g;            /* Object ID */
-H5_DLLVAR hid_t H5E_DATATYPE_g;      /* Datatype */
-H5_DLLVAR hid_t H5E_VOL_g;           /* Virtual Object Layer */
-H5_DLLVAR hid_t H5E_FILE_g;          /* File accessibility */
-H5_DLLVAR hid_t H5E_REFERENCE_g;     /* References */
-H5_DLLVAR hid_t H5E_CACHE_g;         /* Object cache */
-H5_DLLVAR hid_t H5E_PAGEBUF_g;       /* Page Buffering */
-H5_DLLVAR hid_t H5E_PLINE_g;         /* Data filters */
-H5_DLLVAR hid_t H5E_DATASET_g;       /* Dataset */
-H5_DLLVAR hid_t H5E_RESOURCE_g;      /* Resource unavailable */
-H5_DLLVAR hid_t H5E_ERROR_g;         /* Error API */
+H5_DLLVAR hid_t H5E_FUNC_g;          /* Function entry/exit */
+H5_DLLVAR hid_t H5E_PLIST_g;         /* Property lists */
 H5_DLLVAR hid_t H5E_PLUGIN_g;        /* Plugin for dynamically loaded library */
+H5_DLLVAR hid_t H5E_EARRAY_g;        /* Extensible Array */
+H5_DLLVAR hid_t H5E_CONTEXT_g;       /* API Context */
+H5_DLLVAR hid_t H5E_FILE_g;          /* File accessibility */
+H5_DLLVAR hid_t H5E_FARRAY_g;        /* Fixed Array */
+H5_DLLVAR hid_t H5E_DATATYPE_g;      /* Datatype */
+H5_DLLVAR hid_t H5E_TST_g;           /* Ternary Search Trees */
+H5_DLLVAR hid_t H5E_LIB_g;           /* General library infrastructure */
 H5_DLLVAR hid_t H5E_FSPACE_g;        /* Free Space Manager */
 H5_DLLVAR hid_t H5E_NONE_MAJOR_g;    /* No error */
-H5_DLLVAR hid_t H5E_RS_g;            /* Reference Counted Strings */
-H5_DLLVAR hid_t H5E_FUNC_g;          /* Function entry/exit */
-H5_DLLVAR hid_t H5E_EFL_g;           /* External file list */
-H5_DLLVAR hid_t H5E_TST_g;           /* Ternary Search Trees */
-H5_DLLVAR hid_t H5E_EVENTSET_g;      /* Event Set */
-H5_DLLVAR hid_t H5E_VFL_g;           /* Virtual File Layer */
 H5_DLLVAR hid_t H5E_STORAGE_g;       /* Data storage */
-H5_DLLVAR hid_t H5E_DATASPACE_g;     /* Dataspace */
-H5_DLLVAR hid_t H5E_OHDR_g;          /* Object header */
-H5_DLLVAR hid_t H5E_LINK_g;          /* Links */
-H5_DLLVAR hid_t H5E_MAP_g;           /* Map */
-H5_DLLVAR hid_t H5E_HEAP_g;          /* Heap */
-H5_DLLVAR hid_t H5E_ATTR_g;          /* Attribute */
-H5_DLLVAR hid_t H5E_EARRAY_g;        /* Extensible Array */
-H5_DLLVAR hid_t H5E_SLIST_g;         /* Skip Lists */
-H5_DLLVAR hid_t H5E_LIB_g;           /* General library infrastructure */
-H5_DLLVAR hid_t H5E_PLIST_g;         /* Property lists */
-H5_DLLVAR hid_t H5E_ARGS_g;          /* Invalid arguments to routine */
+H5_DLLVAR hid_t H5E_BTREE_g;         /* B-Tree node */
+H5_DLLVAR hid_t H5E_REFERENCE_g;     /* References */
+H5_DLLVAR hid_t H5E_EVENTSET_g;      /* Event Set */
 H5_DLLVAR hid_t H5E_INTERNAL_g;      /* Internal error (too specific to document in detail) */
+H5_DLLVAR hid_t H5E_ERROR_g;         /* Error API */
+H5_DLLVAR hid_t H5E_SOHM_g;          /* Shared Object Header Messages */
+H5_DLLVAR hid_t H5E_SLIST_g;         /* Skip Lists */
+H5_DLLVAR hid_t H5E_DATASET_g;       /* Dataset */
+H5_DLLVAR hid_t H5E_ATTR_g;          /* Attribute */
+H5_DLLVAR hid_t H5E_HEAP_g;          /* Heap */
+H5_DLLVAR hid_t H5E_VOL_g;           /* Virtual Object Layer */
+H5_DLLVAR hid_t H5E_RS_g;            /* Reference Counted Strings */
+H5_DLLVAR hid_t H5E_PAGEBUF_g;       /* Page Buffering */
 H5_DLLVAR hid_t H5E_SYM_g;           /* Symbol table */
-H5_DLLVAR hid_t H5E_CONTEXT_g;       /* API Context */
+H5_DLLVAR hid_t H5E_EFL_g;           /* External file list */
+H5_DLLVAR hid_t H5E_OHDR_g;          /* Object header */
+H5_DLLVAR hid_t H5E_PLINE_g;         /* Data filters */
+H5_DLLVAR hid_t H5E_ARGS_g;          /* Invalid arguments to routine */
+H5_DLLVAR hid_t H5E_DATASPACE_g;     /* Dataspace */
+H5_DLLVAR hid_t H5E_VFL_g;           /* Virtual File Layer */
+H5_DLLVAR hid_t H5E_RESOURCE_g;      /* Resource unavailable */
+H5_DLLVAR hid_t H5E_CACHE_g;         /* Object cache */
+H5_DLLVAR hid_t H5E_MAP_g;           /* Map */
+H5_DLLVAR hid_t H5E_IO_g;            /* Low-level I/O */
+H5_DLLVAR hid_t H5E_LINK_g;          /* Links */
 
 /*********************/
 /* Minor error codes */
 /*********************/
+
+/* Datatype conversion errors */
+#define H5E_CANTCONVERT      (H5OPEN H5E_CANTCONVERT_g)
+#define H5E_BADSIZE          (H5OPEN H5E_BADSIZE_g)
+H5_DLLVAR hid_t H5E_CANTCONVERT_g;   /* Can't convert datatypes */
+H5_DLLVAR hid_t H5E_BADSIZE_g;       /* Bad size for object */
+
+/* Map related errors */
+#define H5E_CANTPUT          (H5OPEN H5E_CANTPUT_g)
+H5_DLLVAR hid_t H5E_CANTPUT_g;       /* Can't put value */
+
+/* Property list errors */
+#define H5E_CANTGET          (H5OPEN H5E_CANTGET_g)
+#define H5E_CANTSET          (H5OPEN H5E_CANTSET_g)
+#define H5E_DUPCLASS         (H5OPEN H5E_DUPCLASS_g)
+#define H5E_SETDISALLOWED    (H5OPEN H5E_SETDISALLOWED_g)
+H5_DLLVAR hid_t H5E_CANTGET_g;       /* Can't get value */
+H5_DLLVAR hid_t H5E_CANTSET_g;       /* Can't set value */
+H5_DLLVAR hid_t H5E_DUPCLASS_g;      /* Duplicate class name in parent class */
+H5_DLLVAR hid_t H5E_SETDISALLOWED_g; /* Disallowed operation */
 
 /* Argument errors */
 #define H5E_UNINITIALIZED    (H5OPEN H5E_UNINITIALIZED_g)
@@ -123,6 +143,140 @@ H5_DLLVAR hid_t H5E_BADVALUE_g;      /* Bad value */
 /* Plugin errors */
 #define H5E_OPENERROR        (H5OPEN H5E_OPENERROR_g)
 H5_DLLVAR hid_t H5E_OPENERROR_g;     /* Can't open directory or file */
+
+/* Generic low-level file I/O errors */
+#define H5E_SEEKERROR        (H5OPEN H5E_SEEKERROR_g)
+#define H5E_READERROR        (H5OPEN H5E_READERROR_g)
+#define H5E_WRITEERROR       (H5OPEN H5E_WRITEERROR_g)
+#define H5E_CLOSEERROR       (H5OPEN H5E_CLOSEERROR_g)
+#define H5E_OVERFLOW         (H5OPEN H5E_OVERFLOW_g)
+#define H5E_FCNTL            (H5OPEN H5E_FCNTL_g)
+H5_DLLVAR hid_t H5E_SEEKERROR_g;     /* Seek failed */
+H5_DLLVAR hid_t H5E_READERROR_g;     /* Read failed */
+H5_DLLVAR hid_t H5E_WRITEERROR_g;    /* Write failed */
+H5_DLLVAR hid_t H5E_CLOSEERROR_g;    /* Close failed */
+H5_DLLVAR hid_t H5E_OVERFLOW_g;      /* Address overflowed */
+H5_DLLVAR hid_t H5E_FCNTL_g;         /* File control (fcntl) failed */
+
+/* System level errors */
+#define H5E_SYSERRSTR        (H5OPEN H5E_SYSERRSTR_g)
+H5_DLLVAR hid_t H5E_SYSERRSTR_g;     /* System error message */
+
+/* I/O pipeline errors */
+#define H5E_NOFILTER         (H5OPEN H5E_NOFILTER_g)
+#define H5E_CALLBACK         (H5OPEN H5E_CALLBACK_g)
+#define H5E_CANAPPLY         (H5OPEN H5E_CANAPPLY_g)
+#define H5E_SETLOCAL         (H5OPEN H5E_SETLOCAL_g)
+#define H5E_NOENCODER        (H5OPEN H5E_NOENCODER_g)
+#define H5E_CANTFILTER       (H5OPEN H5E_CANTFILTER_g)
+H5_DLLVAR hid_t H5E_NOFILTER_g;      /* Requested filter is not available */
+H5_DLLVAR hid_t H5E_CALLBACK_g;      /* Callback failed */
+H5_DLLVAR hid_t H5E_CANAPPLY_g;      /* Error from filter 'can apply' callback */
+H5_DLLVAR hid_t H5E_SETLOCAL_g;      /* Error from filter 'set local' callback */
+H5_DLLVAR hid_t H5E_NOENCODER_g;     /* Filter present but encoding disabled */
+H5_DLLVAR hid_t H5E_CANTFILTER_g;    /* Filter operation failed */
+
+/* No error */
+#define H5E_NONE_MINOR       (H5OPEN H5E_NONE_MINOR_g)
+H5_DLLVAR hid_t H5E_NONE_MINOR_g;    /* No error */
+
+/* Asynchronous operation errors */
+#define H5E_CANTWAIT         (H5OPEN H5E_CANTWAIT_g)
+#define H5E_CANTCANCEL       (H5OPEN H5E_CANTCANCEL_g)
+H5_DLLVAR hid_t H5E_CANTWAIT_g;      /* Can't wait on operation */
+H5_DLLVAR hid_t H5E_CANTCANCEL_g;    /* Can't cancel operation */
+
+/* Resource errors */
+#define H5E_NOSPACE          (H5OPEN H5E_NOSPACE_g)
+#define H5E_CANTALLOC        (H5OPEN H5E_CANTALLOC_g)
+#define H5E_CANTCOPY         (H5OPEN H5E_CANTCOPY_g)
+#define H5E_CANTFREE         (H5OPEN H5E_CANTFREE_g)
+#define H5E_ALREADYEXISTS    (H5OPEN H5E_ALREADYEXISTS_g)
+#define H5E_CANTLOCK         (H5OPEN H5E_CANTLOCK_g)
+#define H5E_CANTUNLOCK       (H5OPEN H5E_CANTUNLOCK_g)
+#define H5E_CANTGC           (H5OPEN H5E_CANTGC_g)
+#define H5E_CANTGETSIZE      (H5OPEN H5E_CANTGETSIZE_g)
+#define H5E_OBJOPEN          (H5OPEN H5E_OBJOPEN_g)
+H5_DLLVAR hid_t H5E_NOSPACE_g;       /* No space available for allocation */
+H5_DLLVAR hid_t H5E_CANTALLOC_g;     /* Can't allocate space */
+H5_DLLVAR hid_t H5E_CANTCOPY_g;      /* Unable to copy object */
+H5_DLLVAR hid_t H5E_CANTFREE_g;      /* Unable to free object */
+H5_DLLVAR hid_t H5E_ALREADYEXISTS_g; /* Object already exists */
+H5_DLLVAR hid_t H5E_CANTLOCK_g;      /* Unable to lock object */
+H5_DLLVAR hid_t H5E_CANTUNLOCK_g;    /* Unable to unlock object */
+H5_DLLVAR hid_t H5E_CANTGC_g;        /* Unable to garbage collect */
+H5_DLLVAR hid_t H5E_CANTGETSIZE_g;   /* Unable to compute size */
+H5_DLLVAR hid_t H5E_OBJOPEN_g;       /* Object is already open */
+
+/* Object ID related errors */
+#define H5E_BADID            (H5OPEN H5E_BADID_g)
+#define H5E_BADGROUP         (H5OPEN H5E_BADGROUP_g)
+#define H5E_CANTREGISTER     (H5OPEN H5E_CANTREGISTER_g)
+#define H5E_CANTINC          (H5OPEN H5E_CANTINC_g)
+#define H5E_CANTDEC          (H5OPEN H5E_CANTDEC_g)
+#define H5E_NOIDS            (H5OPEN H5E_NOIDS_g)
+H5_DLLVAR hid_t H5E_BADID_g;         /* Unable to find ID information (already closed?) */
+H5_DLLVAR hid_t H5E_BADGROUP_g;      /* Unable to find ID group information */
+H5_DLLVAR hid_t H5E_CANTREGISTER_g;  /* Unable to register new ID */
+H5_DLLVAR hid_t H5E_CANTINC_g;       /* Unable to increment reference count */
+H5_DLLVAR hid_t H5E_CANTDEC_g;       /* Unable to decrement reference count */
+H5_DLLVAR hid_t H5E_NOIDS_g;         /* Out of IDs for group */
+
+/* B-tree related errors */
+#define H5E_NOTFOUND         (H5OPEN H5E_NOTFOUND_g)
+#define H5E_EXISTS           (H5OPEN H5E_EXISTS_g)
+#define H5E_CANTENCODE       (H5OPEN H5E_CANTENCODE_g)
+#define H5E_CANTDECODE       (H5OPEN H5E_CANTDECODE_g)
+#define H5E_CANTSPLIT        (H5OPEN H5E_CANTSPLIT_g)
+#define H5E_CANTREDISTRIBUTE (H5OPEN H5E_CANTREDISTRIBUTE_g)
+#define H5E_CANTSWAP         (H5OPEN H5E_CANTSWAP_g)
+#define H5E_CANTINSERT       (H5OPEN H5E_CANTINSERT_g)
+#define H5E_CANTLIST         (H5OPEN H5E_CANTLIST_g)
+#define H5E_CANTMODIFY       (H5OPEN H5E_CANTMODIFY_g)
+#define H5E_CANTREMOVE       (H5OPEN H5E_CANTREMOVE_g)
+#define H5E_CANTFIND         (H5OPEN H5E_CANTFIND_g)
+H5_DLLVAR hid_t H5E_NOTFOUND_g;      /* Object not found */
+H5_DLLVAR hid_t H5E_EXISTS_g;        /* Object already exists */
+H5_DLLVAR hid_t H5E_CANTENCODE_g;    /* Unable to encode value */
+H5_DLLVAR hid_t H5E_CANTDECODE_g;    /* Unable to decode value */
+H5_DLLVAR hid_t H5E_CANTSPLIT_g;     /* Unable to split node */
+H5_DLLVAR hid_t H5E_CANTREDISTRIBUTE_g; /* Unable to redistribute records */
+H5_DLLVAR hid_t H5E_CANTSWAP_g;      /* Unable to swap records */
+H5_DLLVAR hid_t H5E_CANTINSERT_g;    /* Unable to insert object */
+H5_DLLVAR hid_t H5E_CANTLIST_g;      /* Unable to list node */
+H5_DLLVAR hid_t H5E_CANTMODIFY_g;    /* Unable to modify record */
+H5_DLLVAR hid_t H5E_CANTREMOVE_g;    /* Unable to remove object */
+H5_DLLVAR hid_t H5E_CANTFIND_g;      /* Unable to check for record */
+
+/* Free space errors */
+#define H5E_CANTMERGE        (H5OPEN H5E_CANTMERGE_g)
+#define H5E_CANTREVIVE       (H5OPEN H5E_CANTREVIVE_g)
+#define H5E_CANTSHRINK       (H5OPEN H5E_CANTSHRINK_g)
+H5_DLLVAR hid_t H5E_CANTMERGE_g;     /* Can't merge objects */
+H5_DLLVAR hid_t H5E_CANTREVIVE_g;    /* Can't revive object */
+H5_DLLVAR hid_t H5E_CANTSHRINK_g;    /* Can't shrink container */
+
+/* Link related errors */
+#define H5E_TRAVERSE         (H5OPEN H5E_TRAVERSE_g)
+#define H5E_NLINKS           (H5OPEN H5E_NLINKS_g)
+#define H5E_NOTREGISTERED    (H5OPEN H5E_NOTREGISTERED_g)
+#define H5E_CANTMOVE         (H5OPEN H5E_CANTMOVE_g)
+#define H5E_CANTSORT         (H5OPEN H5E_CANTSORT_g)
+H5_DLLVAR hid_t H5E_TRAVERSE_g;      /* Link traversal failure */
+H5_DLLVAR hid_t H5E_NLINKS_g;        /* Too many soft links in path */
+H5_DLLVAR hid_t H5E_NOTREGISTERED_g; /* Link class not registered */
+H5_DLLVAR hid_t H5E_CANTMOVE_g;      /* Can't move object */
+H5_DLLVAR hid_t H5E_CANTSORT_g;      /* Can't sort objects */
+
+/* Group related errors */
+#define H5E_CANTOPENOBJ      (H5OPEN H5E_CANTOPENOBJ_g)
+#define H5E_CANTCLOSEOBJ     (H5OPEN H5E_CANTCLOSEOBJ_g)
+#define H5E_COMPLEN          (H5OPEN H5E_COMPLEN_g)
+#define H5E_PATH             (H5OPEN H5E_PATH_g)
+H5_DLLVAR hid_t H5E_CANTOPENOBJ_g;   /* Can't open object */
+H5_DLLVAR hid_t H5E_CANTCLOSEOBJ_g;  /* Can't close object */
+H5_DLLVAR hid_t H5E_COMPLEN_g;       /* Name component is too long */
+H5_DLLVAR hid_t H5E_PATH_g;          /* Problem with path to object */
 
 /* Function entry/exit interface errors */
 #define H5E_CANTINIT         (H5OPEN H5E_CANTINIT_g)
@@ -188,72 +342,6 @@ H5_DLLVAR hid_t H5E_LOGGING_g;       /* Failure in the cache logging framework *
 H5_DLLVAR hid_t H5E_CANTCORK_g;      /* Unable to cork an object */
 H5_DLLVAR hid_t H5E_CANTUNCORK_g;    /* Unable to uncork an object */
 
-/* System level errors */
-#define H5E_SYSERRSTR        (H5OPEN H5E_SYSERRSTR_g)
-H5_DLLVAR hid_t H5E_SYSERRSTR_g;     /* System error message */
-
-/* Parallel MPI errors */
-#define H5E_MPI              (H5OPEN H5E_MPI_g)
-#define H5E_MPIERRSTR        (H5OPEN H5E_MPIERRSTR_g)
-#define H5E_CANTRECV         (H5OPEN H5E_CANTRECV_g)
-#define H5E_CANTGATHER       (H5OPEN H5E_CANTGATHER_g)
-#define H5E_NO_INDEPENDENT   (H5OPEN H5E_NO_INDEPENDENT_g)
-H5_DLLVAR hid_t H5E_MPI_g;           /* Some MPI function failed */
-H5_DLLVAR hid_t H5E_MPIERRSTR_g;     /* MPI Error String */
-H5_DLLVAR hid_t H5E_CANTRECV_g;      /* Can't receive data */
-H5_DLLVAR hid_t H5E_CANTGATHER_g;    /* Can't gather data */
-H5_DLLVAR hid_t H5E_NO_INDEPENDENT_g; /* Can't perform independent IO */
-
-/* Free space errors */
-#define H5E_CANTMERGE        (H5OPEN H5E_CANTMERGE_g)
-#define H5E_CANTREVIVE       (H5OPEN H5E_CANTREVIVE_g)
-#define H5E_CANTSHRINK       (H5OPEN H5E_CANTSHRINK_g)
-H5_DLLVAR hid_t H5E_CANTMERGE_g;     /* Can't merge objects */
-H5_DLLVAR hid_t H5E_CANTREVIVE_g;    /* Can't revive object */
-H5_DLLVAR hid_t H5E_CANTSHRINK_g;    /* Can't shrink container */
-
-/* File accessibility errors */
-#define H5E_FILEEXISTS       (H5OPEN H5E_FILEEXISTS_g)
-#define H5E_FILEOPEN         (H5OPEN H5E_FILEOPEN_g)
-#define H5E_CANTCREATE       (H5OPEN H5E_CANTCREATE_g)
-#define H5E_CANTOPENFILE     (H5OPEN H5E_CANTOPENFILE_g)
-#define H5E_CANTCLOSEFILE    (H5OPEN H5E_CANTCLOSEFILE_g)
-#define H5E_NOTHDF5          (H5OPEN H5E_NOTHDF5_g)
-#define H5E_BADFILE          (H5OPEN H5E_BADFILE_g)
-#define H5E_TRUNCATED        (H5OPEN H5E_TRUNCATED_g)
-#define H5E_MOUNT            (H5OPEN H5E_MOUNT_g)
-#define H5E_UNMOUNT          (H5OPEN H5E_UNMOUNT_g)
-#define H5E_CANTDELETEFILE   (H5OPEN H5E_CANTDELETEFILE_g)
-#define H5E_CANTLOCKFILE     (H5OPEN H5E_CANTLOCKFILE_g)
-#define H5E_CANTUNLOCKFILE   (H5OPEN H5E_CANTUNLOCKFILE_g)
-H5_DLLVAR hid_t H5E_FILEEXISTS_g;    /* File already exists */
-H5_DLLVAR hid_t H5E_FILEOPEN_g;      /* File already open */
-H5_DLLVAR hid_t H5E_CANTCREATE_g;    /* Unable to create file */
-H5_DLLVAR hid_t H5E_CANTOPENFILE_g;  /* Unable to open file */
-H5_DLLVAR hid_t H5E_CANTCLOSEFILE_g; /* Unable to close file */
-H5_DLLVAR hid_t H5E_NOTHDF5_g;       /* Not an HDF5 file */
-H5_DLLVAR hid_t H5E_BADFILE_g;       /* Bad file ID accessed */
-H5_DLLVAR hid_t H5E_TRUNCATED_g;     /* File has been truncated */
-H5_DLLVAR hid_t H5E_MOUNT_g;         /* File mount error */
-H5_DLLVAR hid_t H5E_UNMOUNT_g;       /* File unmount error */
-H5_DLLVAR hid_t H5E_CANTDELETEFILE_g; /* Unable to delete file */
-H5_DLLVAR hid_t H5E_CANTLOCKFILE_g;  /* Unable to lock file */
-H5_DLLVAR hid_t H5E_CANTUNLOCKFILE_g; /* Unable to unlock file */
-
-/* Generic low-level file I/O errors */
-#define H5E_SEEKERROR        (H5OPEN H5E_SEEKERROR_g)
-#define H5E_READERROR        (H5OPEN H5E_READERROR_g)
-#define H5E_WRITEERROR       (H5OPEN H5E_WRITEERROR_g)
-#define H5E_CLOSEERROR       (H5OPEN H5E_CLOSEERROR_g)
-#define H5E_OVERFLOW         (H5OPEN H5E_OVERFLOW_g)
-#define H5E_FCNTL            (H5OPEN H5E_FCNTL_g)
-H5_DLLVAR hid_t H5E_SEEKERROR_g;     /* Seek failed */
-H5_DLLVAR hid_t H5E_READERROR_g;     /* Read failed */
-H5_DLLVAR hid_t H5E_WRITEERROR_g;    /* Write failed */
-H5_DLLVAR hid_t H5E_CLOSEERROR_g;    /* Close failed */
-H5_DLLVAR hid_t H5E_OVERFLOW_g;      /* Address overflowed */
-H5_DLLVAR hid_t H5E_FCNTL_g;         /* File control (fcntl) failed */
-
 /* Heap errors */
 #define H5E_CANTRESTORE      (H5OPEN H5E_CANTRESTORE_g)
 #define H5E_CANTCOMPUTE      (H5OPEN H5E_CANTCOMPUTE_g)
@@ -268,123 +356,17 @@ H5_DLLVAR hid_t H5E_CANTATTACH_g;    /* Can't attach object */
 H5_DLLVAR hid_t H5E_CANTUPDATE_g;    /* Can't update object */
 H5_DLLVAR hid_t H5E_CANTOPERATE_g;   /* Can't operate on object */
 
-/* I/O pipeline errors */
-#define H5E_NOFILTER         (H5OPEN H5E_NOFILTER_g)
-#define H5E_CALLBACK         (H5OPEN H5E_CALLBACK_g)
-#define H5E_CANAPPLY         (H5OPEN H5E_CANAPPLY_g)
-#define H5E_SETLOCAL         (H5OPEN H5E_SETLOCAL_g)
-#define H5E_NOENCODER        (H5OPEN H5E_NOENCODER_g)
-#define H5E_CANTFILTER       (H5OPEN H5E_CANTFILTER_g)
-H5_DLLVAR hid_t H5E_NOFILTER_g;      /* Requested filter is not available */
-H5_DLLVAR hid_t H5E_CALLBACK_g;      /* Callback failed */
-H5_DLLVAR hid_t H5E_CANAPPLY_g;      /* Error from filter 'can apply' callback */
-H5_DLLVAR hid_t H5E_SETLOCAL_g;      /* Error from filter 'set local' callback */
-H5_DLLVAR hid_t H5E_NOENCODER_g;     /* Filter present but encoding disabled */
-H5_DLLVAR hid_t H5E_CANTFILTER_g;    /* Filter operation failed */
-
-/* Group related errors */
-#define H5E_CANTOPENOBJ      (H5OPEN H5E_CANTOPENOBJ_g)
-#define H5E_CANTCLOSEOBJ     (H5OPEN H5E_CANTCLOSEOBJ_g)
-#define H5E_COMPLEN          (H5OPEN H5E_COMPLEN_g)
-#define H5E_PATH             (H5OPEN H5E_PATH_g)
-H5_DLLVAR hid_t H5E_CANTOPENOBJ_g;   /* Can't open object */
-H5_DLLVAR hid_t H5E_CANTCLOSEOBJ_g;  /* Can't close object */
-H5_DLLVAR hid_t H5E_COMPLEN_g;       /* Name component is too long */
-H5_DLLVAR hid_t H5E_PATH_g;          /* Problem with path to object */
-
-/* Object ID related errors */
-#define H5E_BADID            (H5OPEN H5E_BADID_g)
-#define H5E_BADGROUP         (H5OPEN H5E_BADGROUP_g)
-#define H5E_CANTREGISTER     (H5OPEN H5E_CANTREGISTER_g)
-#define H5E_CANTINC          (H5OPEN H5E_CANTINC_g)
-#define H5E_CANTDEC          (H5OPEN H5E_CANTDEC_g)
-#define H5E_NOIDS            (H5OPEN H5E_NOIDS_g)
-H5_DLLVAR hid_t H5E_BADID_g;         /* Unable to find ID information (already closed?) */
-H5_DLLVAR hid_t H5E_BADGROUP_g;      /* Unable to find ID group information */
-H5_DLLVAR hid_t H5E_CANTREGISTER_g;  /* Unable to register new ID */
-H5_DLLVAR hid_t H5E_CANTINC_g;       /* Unable to increment reference count */
-H5_DLLVAR hid_t H5E_CANTDEC_g;       /* Unable to decrement reference count */
-H5_DLLVAR hid_t H5E_NOIDS_g;         /* Out of IDs for group */
-
-/* No error */
-#define H5E_NONE_MINOR       (H5OPEN H5E_NONE_MINOR_g)
-H5_DLLVAR hid_t H5E_NONE_MINOR_g;    /* No error */
-
-/* Resource errors */
-#define H5E_NOSPACE          (H5OPEN H5E_NOSPACE_g)
-#define H5E_CANTALLOC        (H5OPEN H5E_CANTALLOC_g)
-#define H5E_CANTCOPY         (H5OPEN H5E_CANTCOPY_g)
-#define H5E_CANTFREE         (H5OPEN H5E_CANTFREE_g)
-#define H5E_ALREADYEXISTS    (H5OPEN H5E_ALREADYEXISTS_g)
-#define H5E_CANTLOCK         (H5OPEN H5E_CANTLOCK_g)
-#define H5E_CANTUNLOCK       (H5OPEN H5E_CANTUNLOCK_g)
-#define H5E_CANTGC           (H5OPEN H5E_CANTGC_g)
-#define H5E_CANTGETSIZE      (H5OPEN H5E_CANTGETSIZE_g)
-#define H5E_OBJOPEN          (H5OPEN H5E_OBJOPEN_g)
-H5_DLLVAR hid_t H5E_NOSPACE_g;       /* No space available for allocation */
-H5_DLLVAR hid_t H5E_CANTALLOC_g;     /* Can't allocate space */
-H5_DLLVAR hid_t H5E_CANTCOPY_g;      /* Unable to copy object */
-H5_DLLVAR hid_t H5E_CANTFREE_g;      /* Unable to free object */
-H5_DLLVAR hid_t H5E_ALREADYEXISTS_g; /* Object already exists */
-H5_DLLVAR hid_t H5E_CANTLOCK_g;      /* Unable to lock object */
-H5_DLLVAR hid_t H5E_CANTUNLOCK_g;    /* Unable to unlock object */
-H5_DLLVAR hid_t H5E_CANTGC_g;        /* Unable to garbage collect */
-H5_DLLVAR hid_t H5E_CANTGETSIZE_g;   /* Unable to compute size */
-H5_DLLVAR hid_t H5E_OBJOPEN_g;       /* Object is already open */
-
-/* Property list errors */
-#define H5E_CANTGET          (H5OPEN H5E_CANTGET_g)
-#define H5E_CANTSET          (H5OPEN H5E_CANTSET_g)
-#define H5E_DUPCLASS         (H5OPEN H5E_DUPCLASS_g)
-#define H5E_SETDISALLOWED    (H5OPEN H5E_SETDISALLOWED_g)
-H5_DLLVAR hid_t H5E_CANTGET_g;       /* Can't get value */
-H5_DLLVAR hid_t H5E_CANTSET_g;       /* Can't set value */
-H5_DLLVAR hid_t H5E_DUPCLASS_g;      /* Duplicate class name in parent class */
-H5_DLLVAR hid_t H5E_SETDISALLOWED_g; /* Disallowed operation */
-
-/* Datatype conversion errors */
-#define H5E_CANTCONVERT      (H5OPEN H5E_CANTCONVERT_g)
-#define H5E_BADSIZE          (H5OPEN H5E_BADSIZE_g)
-H5_DLLVAR hid_t H5E_CANTCONVERT_g;   /* Can't convert datatypes */
-H5_DLLVAR hid_t H5E_BADSIZE_g;       /* Bad size for object */
-
-/* Link related errors */
-#define H5E_TRAVERSE         (H5OPEN H5E_TRAVERSE_g)
-#define H5E_NLINKS           (H5OPEN H5E_NLINKS_g)
-#define H5E_NOTREGISTERED    (H5OPEN H5E_NOTREGISTERED_g)
-#define H5E_CANTMOVE         (H5OPEN H5E_CANTMOVE_g)
-#define H5E_CANTSORT         (H5OPEN H5E_CANTSORT_g)
-H5_DLLVAR hid_t H5E_TRAVERSE_g;      /* Link traversal failure */
-H5_DLLVAR hid_t H5E_NLINKS_g;        /* Too many soft links in path */
-H5_DLLVAR hid_t H5E_NOTREGISTERED_g; /* Link class not registered */
-H5_DLLVAR hid_t H5E_CANTMOVE_g;      /* Can't move object */
-H5_DLLVAR hid_t H5E_CANTSORT_g;      /* Can't sort objects */
-
-/* B-tree related errors */
-#define H5E_NOTFOUND         (H5OPEN H5E_NOTFOUND_g)
-#define H5E_EXISTS           (H5OPEN H5E_EXISTS_g)
-#define H5E_CANTENCODE       (H5OPEN H5E_CANTENCODE_g)
-#define H5E_CANTDECODE       (H5OPEN H5E_CANTDECODE_g)
-#define H5E_CANTSPLIT        (H5OPEN H5E_CANTSPLIT_g)
-#define H5E_CANTREDISTRIBUTE (H5OPEN H5E_CANTREDISTRIBUTE_g)
-#define H5E_CANTSWAP         (H5OPEN H5E_CANTSWAP_g)
-#define H5E_CANTINSERT       (H5OPEN H5E_CANTINSERT_g)
-#define H5E_CANTLIST         (H5OPEN H5E_CANTLIST_g)
-#define H5E_CANTMODIFY       (H5OPEN H5E_CANTMODIFY_g)
-#define H5E_CANTREMOVE       (H5OPEN H5E_CANTREMOVE_g)
-#define H5E_CANTFIND         (H5OPEN H5E_CANTFIND_g)
-H5_DLLVAR hid_t H5E_NOTFOUND_g;      /* Object not found */
-H5_DLLVAR hid_t H5E_EXISTS_g;        /* Object already exists */
-H5_DLLVAR hid_t H5E_CANTENCODE_g;    /* Unable to encode value */
-H5_DLLVAR hid_t H5E_CANTDECODE_g;    /* Unable to decode value */
-H5_DLLVAR hid_t H5E_CANTSPLIT_g;     /* Unable to split node */
-H5_DLLVAR hid_t H5E_CANTREDISTRIBUTE_g; /* Unable to redistribute records */
-H5_DLLVAR hid_t H5E_CANTSWAP_g;      /* Unable to swap records */
-H5_DLLVAR hid_t H5E_CANTINSERT_g;    /* Unable to insert object */
-H5_DLLVAR hid_t H5E_CANTLIST_g;      /* Unable to list node */
-H5_DLLVAR hid_t H5E_CANTMODIFY_g;    /* Unable to modify record */
-H5_DLLVAR hid_t H5E_CANTREMOVE_g;    /* Unable to remove object */
-H5_DLLVAR hid_t H5E_CANTFIND_g;      /* Unable to check for record */
+/* Parallel MPI errors */
+#define H5E_MPI              (H5OPEN H5E_MPI_g)
+#define H5E_MPIERRSTR        (H5OPEN H5E_MPIERRSTR_g)
+#define H5E_CANTRECV         (H5OPEN H5E_CANTRECV_g)
+#define H5E_CANTGATHER       (H5OPEN H5E_CANTGATHER_g)
+#define H5E_NO_INDEPENDENT   (H5OPEN H5E_NO_INDEPENDENT_g)
+H5_DLLVAR hid_t H5E_MPI_g;           /* Some MPI function failed */
+H5_DLLVAR hid_t H5E_MPIERRSTR_g;     /* MPI Error String */
+H5_DLLVAR hid_t H5E_CANTRECV_g;      /* Can't receive data */
+H5_DLLVAR hid_t H5E_CANTGATHER_g;    /* Can't gather data */
+H5_DLLVAR hid_t H5E_NO_INDEPENDENT_g; /* Can't perform independent IO */
 
 /* Dataspace errors */
 #define H5E_CANTCLIP         (H5OPEN H5E_CANTCLIP_g)
@@ -424,15 +406,33 @@ H5_DLLVAR hid_t H5E_CANTPACK_g;      /* Can't pack messages */
 H5_DLLVAR hid_t H5E_CANTRESET_g;     /* Can't reset object */
 H5_DLLVAR hid_t H5E_CANTRENAME_g;    /* Unable to rename object */
 
-/* Asynchronous operation errors */
-#define H5E_CANTWAIT         (H5OPEN H5E_CANTWAIT_g)
-#define H5E_CANTCANCEL       (H5OPEN H5E_CANTCANCEL_g)
-H5_DLLVAR hid_t H5E_CANTWAIT_g;      /* Can't wait on operation */
-H5_DLLVAR hid_t H5E_CANTCANCEL_g;    /* Can't cancel operation */
-
-/* Map related errors */
-#define H5E_CANTPUT          (H5OPEN H5E_CANTPUT_g)
-H5_DLLVAR hid_t H5E_CANTPUT_g;       /* Can't put value */
+/* File accessibility errors */
+#define H5E_FILEEXISTS       (H5OPEN H5E_FILEEXISTS_g)
+#define H5E_FILEOPEN         (H5OPEN H5E_FILEOPEN_g)
+#define H5E_CANTCREATE       (H5OPEN H5E_CANTCREATE_g)
+#define H5E_CANTOPENFILE     (H5OPEN H5E_CANTOPENFILE_g)
+#define H5E_CANTCLOSEFILE    (H5OPEN H5E_CANTCLOSEFILE_g)
+#define H5E_NOTHDF5          (H5OPEN H5E_NOTHDF5_g)
+#define H5E_BADFILE          (H5OPEN H5E_BADFILE_g)
+#define H5E_TRUNCATED        (H5OPEN H5E_TRUNCATED_g)
+#define H5E_MOUNT            (H5OPEN H5E_MOUNT_g)
+#define H5E_UNMOUNT          (H5OPEN H5E_UNMOUNT_g)
+#define H5E_CANTDELETEFILE   (H5OPEN H5E_CANTDELETEFILE_g)
+#define H5E_CANTLOCKFILE     (H5OPEN H5E_CANTLOCKFILE_g)
+#define H5E_CANTUNLOCKFILE   (H5OPEN H5E_CANTUNLOCKFILE_g)
+H5_DLLVAR hid_t H5E_FILEEXISTS_g;    /* File already exists */
+H5_DLLVAR hid_t H5E_FILEOPEN_g;      /* File already open */
+H5_DLLVAR hid_t H5E_CANTCREATE_g;    /* Unable to create file */
+H5_DLLVAR hid_t H5E_CANTOPENFILE_g;  /* Unable to open file */
+H5_DLLVAR hid_t H5E_CANTCLOSEFILE_g; /* Unable to close file */
+H5_DLLVAR hid_t H5E_NOTHDF5_g;       /* Not an HDF5 file */
+H5_DLLVAR hid_t H5E_BADFILE_g;       /* Bad file ID accessed */
+H5_DLLVAR hid_t H5E_TRUNCATED_g;     /* File has been truncated */
+H5_DLLVAR hid_t H5E_MOUNT_g;         /* File mount error */
+H5_DLLVAR hid_t H5E_UNMOUNT_g;       /* File unmount error */
+H5_DLLVAR hid_t H5E_CANTDELETEFILE_g; /* Unable to delete file */
+H5_DLLVAR hid_t H5E_CANTLOCKFILE_g;  /* Unable to lock file */
+H5_DLLVAR hid_t H5E_CANTUNLOCKFILE_g; /* Unable to unlock file */
 
 #ifdef __cplusplus
 }

--- a/hdf5/src/H5Eterm.h
+++ b/hdf5/src/H5Eterm.h
@@ -19,233 +19,233 @@
 
 /* Reset major error IDs */
     
-H5E_BTREE_g=    
-H5E_SOHM_g=    
-H5E_IO_g=    
-H5E_FARRAY_g=    
-H5E_ID_g=    
-H5E_DATATYPE_g=    
-H5E_VOL_g=    
-H5E_FILE_g=    
-H5E_REFERENCE_g=    
-H5E_CACHE_g=    
-H5E_PAGEBUF_g=    
-H5E_PLINE_g=    
-H5E_DATASET_g=    
-H5E_RESOURCE_g=    
-H5E_ERROR_g=    
-H5E_PLUGIN_g=    
-H5E_FSPACE_g=    
-H5E_NONE_MAJOR_g=    
-H5E_RS_g=    
-H5E_FUNC_g=    
-H5E_EFL_g=    
-H5E_TST_g=    
-H5E_EVENTSET_g=    
-H5E_VFL_g=    
-H5E_STORAGE_g=    
-H5E_DATASPACE_g=    
-H5E_OHDR_g=    
-H5E_LINK_g=    
-H5E_MAP_g=    
-H5E_HEAP_g=    
-H5E_ATTR_g=    
-H5E_EARRAY_g=    
-H5E_SLIST_g=    
-H5E_LIB_g=    
-H5E_PLIST_g=    
-H5E_ARGS_g=    
-H5E_INTERNAL_g=    
-H5E_SYM_g=    
-H5E_CONTEXT_g= (-1);
+H5E_ID_g=
+H5E_FUNC_g=
+H5E_PLIST_g=
+H5E_PLUGIN_g=
+H5E_EARRAY_g=
+H5E_CONTEXT_g=
+H5E_FILE_g=
+H5E_FARRAY_g=
+H5E_DATATYPE_g=
+H5E_TST_g=
+H5E_LIB_g=
+H5E_FSPACE_g=
+H5E_NONE_MAJOR_g=
+H5E_STORAGE_g=
+H5E_BTREE_g=
+H5E_REFERENCE_g=
+H5E_EVENTSET_g=
+H5E_INTERNAL_g=
+H5E_ERROR_g=
+H5E_SOHM_g=
+H5E_SLIST_g=
+H5E_DATASET_g=
+H5E_ATTR_g=
+H5E_HEAP_g=
+H5E_VOL_g=
+H5E_RS_g=
+H5E_PAGEBUF_g=
+H5E_SYM_g=
+H5E_EFL_g=
+H5E_OHDR_g=
+H5E_PLINE_g=
+H5E_ARGS_g=
+H5E_DATASPACE_g=
+H5E_VFL_g=
+H5E_RESOURCE_g=
+H5E_CACHE_g=
+H5E_MAP_g=
+H5E_IO_g=
+H5E_LINK_g= (-1);
 
 /* Reset minor error IDs */
 
 
-/* Argument errors */    
-H5E_UNINITIALIZED_g=    
-H5E_UNSUPPORTED_g=    
-H5E_BADTYPE_g=    
-H5E_BADRANGE_g=    
-H5E_BADVALUE_g=
-
-/* Plugin errors */    
-H5E_OPENERROR_g=
-
-/* Function entry/exit interface errors */    
-H5E_CANTINIT_g=    
-H5E_ALREADYINIT_g=    
-H5E_CANTRELEASE_g=
-
-/* Cache related errors */    
-H5E_CANTFLUSH_g=    
-H5E_CANTUNSERIALIZE_g=    
-H5E_CANTSERIALIZE_g=    
-H5E_CANTTAG_g=    
-H5E_CANTLOAD_g=    
-H5E_PROTECT_g=    
-H5E_NOTCACHED_g=    
-H5E_SYSTEM_g=    
-H5E_CANTINS_g=    
-H5E_CANTPROTECT_g=    
-H5E_CANTUNPROTECT_g=    
-H5E_CANTPIN_g=    
-H5E_CANTUNPIN_g=    
-H5E_CANTMARKDIRTY_g=    
-H5E_CANTMARKCLEAN_g=    
-H5E_CANTMARKUNSERIALIZED_g=    
-H5E_CANTMARKSERIALIZED_g=    
-H5E_CANTDIRTY_g=    
-H5E_CANTCLEAN_g=    
-H5E_CANTEXPUNGE_g=    
-H5E_CANTRESIZE_g=    
-H5E_CANTDEPEND_g=    
-H5E_CANTUNDEPEND_g=    
-H5E_CANTNOTIFY_g=    
-H5E_LOGGING_g=    
-H5E_CANTCORK_g=    
-H5E_CANTUNCORK_g=
-
-/* System level errors */    
-H5E_SYSERRSTR_g=
-
-/* Parallel MPI errors */    
-H5E_MPI_g=    
-H5E_MPIERRSTR_g=    
-H5E_CANTRECV_g=    
-H5E_CANTGATHER_g=    
-H5E_NO_INDEPENDENT_g=
-
-/* Free space errors */    
-H5E_CANTMERGE_g=    
-H5E_CANTREVIVE_g=    
-H5E_CANTSHRINK_g=
-
-/* File accessibility errors */    
-H5E_FILEEXISTS_g=    
-H5E_FILEOPEN_g=    
-H5E_CANTCREATE_g=    
-H5E_CANTOPENFILE_g=    
-H5E_CANTCLOSEFILE_g=    
-H5E_NOTHDF5_g=    
-H5E_BADFILE_g=    
-H5E_TRUNCATED_g=    
-H5E_MOUNT_g=    
-H5E_UNMOUNT_g=    
-H5E_CANTDELETEFILE_g=    
-H5E_CANTLOCKFILE_g=    
-H5E_CANTUNLOCKFILE_g=
-
-/* Generic low-level file I/O errors */    
-H5E_SEEKERROR_g=    
-H5E_READERROR_g=    
-H5E_WRITEERROR_g=    
-H5E_CLOSEERROR_g=    
-H5E_OVERFLOW_g=    
-H5E_FCNTL_g=
-
-/* Heap errors */    
-H5E_CANTRESTORE_g=    
-H5E_CANTCOMPUTE_g=    
-H5E_CANTEXTEND_g=    
-H5E_CANTATTACH_g=    
-H5E_CANTUPDATE_g=    
-H5E_CANTOPERATE_g=
-
-/* I/O pipeline errors */    
-H5E_NOFILTER_g=    
-H5E_CALLBACK_g=    
-H5E_CANAPPLY_g=    
-H5E_SETLOCAL_g=    
-H5E_NOENCODER_g=    
-H5E_CANTFILTER_g=
-
-/* Group related errors */    
-H5E_CANTOPENOBJ_g=    
-H5E_CANTCLOSEOBJ_g=    
-H5E_COMPLEN_g=    
-H5E_PATH_g=
-
-/* Object ID related errors */    
-H5E_BADID_g=    
-H5E_BADGROUP_g=    
-H5E_CANTREGISTER_g=    
-H5E_CANTINC_g=    
-H5E_CANTDEC_g=    
-H5E_NOIDS_g=
-
-/* No error */    
-H5E_NONE_MINOR_g=
-
-/* Resource errors */    
-H5E_NOSPACE_g=    
-H5E_CANTALLOC_g=    
-H5E_CANTCOPY_g=    
-H5E_CANTFREE_g=    
-H5E_ALREADYEXISTS_g=    
-H5E_CANTLOCK_g=    
-H5E_CANTUNLOCK_g=    
-H5E_CANTGC_g=    
-H5E_CANTGETSIZE_g=    
-H5E_OBJOPEN_g=
-
-/* Property list errors */    
-H5E_CANTGET_g=    
-H5E_CANTSET_g=    
-H5E_DUPCLASS_g=    
-H5E_SETDISALLOWED_g=
-
-/* Datatype conversion errors */    
-H5E_CANTCONVERT_g=    
+/* Datatype conversion errors */
+H5E_CANTCONVERT_g=
 H5E_BADSIZE_g=
 
-/* Link related errors */    
-H5E_TRAVERSE_g=    
-H5E_NLINKS_g=    
-H5E_NOTREGISTERED_g=    
-H5E_CANTMOVE_g=    
-H5E_CANTSORT_g=
+/* Map related errors */
+H5E_CANTPUT_g=
 
-/* B-tree related errors */    
-H5E_NOTFOUND_g=    
-H5E_EXISTS_g=    
-H5E_CANTENCODE_g=    
-H5E_CANTDECODE_g=    
-H5E_CANTSPLIT_g=    
-H5E_CANTREDISTRIBUTE_g=    
-H5E_CANTSWAP_g=    
-H5E_CANTINSERT_g=    
-H5E_CANTLIST_g=    
-H5E_CANTMODIFY_g=    
-H5E_CANTREMOVE_g=    
-H5E_CANTFIND_g=
+/* Property list errors */
+H5E_CANTGET_g=
+H5E_CANTSET_g=
+H5E_DUPCLASS_g=
+H5E_SETDISALLOWED_g=
 
-/* Dataspace errors */    
-H5E_CANTCLIP_g=    
-H5E_CANTCOUNT_g=    
-H5E_CANTSELECT_g=    
-H5E_CANTNEXT_g=    
-H5E_BADSELECT_g=    
-H5E_CANTCOMPARE_g=    
-H5E_INCONSISTENTSTATE_g=    
-H5E_CANTAPPEND_g=
+/* Argument errors */
+H5E_UNINITIALIZED_g=
+H5E_UNSUPPORTED_g=
+H5E_BADTYPE_g=
+H5E_BADRANGE_g=
+H5E_BADVALUE_g=
 
-/* Object header related errors */    
-H5E_LINKCOUNT_g=    
-H5E_VERSION_g=    
-H5E_ALIGNMENT_g=    
-H5E_BADMESG_g=    
-H5E_CANTDELETE_g=    
-H5E_BADITER_g=    
-H5E_CANTPACK_g=    
-H5E_CANTRESET_g=    
-H5E_CANTRENAME_g=
+/* Plugin errors */
+H5E_OPENERROR_g=
 
-/* Asynchronous operation errors */    
-H5E_CANTWAIT_g=    
+/* Generic low-level file I/O errors */
+H5E_SEEKERROR_g=
+H5E_READERROR_g=
+H5E_WRITEERROR_g=
+H5E_CLOSEERROR_g=
+H5E_OVERFLOW_g=
+H5E_FCNTL_g=
+
+/* System level errors */
+H5E_SYSERRSTR_g=
+
+/* I/O pipeline errors */
+H5E_NOFILTER_g=
+H5E_CALLBACK_g=
+H5E_CANAPPLY_g=
+H5E_SETLOCAL_g=
+H5E_NOENCODER_g=
+H5E_CANTFILTER_g=
+
+/* No error */
+H5E_NONE_MINOR_g=
+
+/* Asynchronous operation errors */
+H5E_CANTWAIT_g=
 H5E_CANTCANCEL_g=
 
-/* Map related errors */    
-H5E_CANTPUT_g= (-1);
+/* Resource errors */
+H5E_NOSPACE_g=
+H5E_CANTALLOC_g=
+H5E_CANTCOPY_g=
+H5E_CANTFREE_g=
+H5E_ALREADYEXISTS_g=
+H5E_CANTLOCK_g=
+H5E_CANTUNLOCK_g=
+H5E_CANTGC_g=
+H5E_CANTGETSIZE_g=
+H5E_OBJOPEN_g=
+
+/* Object ID related errors */
+H5E_BADID_g=
+H5E_BADGROUP_g=
+H5E_CANTREGISTER_g=
+H5E_CANTINC_g=
+H5E_CANTDEC_g=
+H5E_NOIDS_g=
+
+/* B-tree related errors */
+H5E_NOTFOUND_g=
+H5E_EXISTS_g=
+H5E_CANTENCODE_g=
+H5E_CANTDECODE_g=
+H5E_CANTSPLIT_g=
+H5E_CANTREDISTRIBUTE_g=
+H5E_CANTSWAP_g=
+H5E_CANTINSERT_g=
+H5E_CANTLIST_g=
+H5E_CANTMODIFY_g=
+H5E_CANTREMOVE_g=
+H5E_CANTFIND_g=
+
+/* Free space errors */
+H5E_CANTMERGE_g=
+H5E_CANTREVIVE_g=
+H5E_CANTSHRINK_g=
+
+/* Link related errors */
+H5E_TRAVERSE_g=
+H5E_NLINKS_g=
+H5E_NOTREGISTERED_g=
+H5E_CANTMOVE_g=
+H5E_CANTSORT_g=
+
+/* Group related errors */
+H5E_CANTOPENOBJ_g=
+H5E_CANTCLOSEOBJ_g=
+H5E_COMPLEN_g=
+H5E_PATH_g=
+
+/* Function entry/exit interface errors */
+H5E_CANTINIT_g=
+H5E_ALREADYINIT_g=
+H5E_CANTRELEASE_g=
+
+/* Cache related errors */
+H5E_CANTFLUSH_g=
+H5E_CANTUNSERIALIZE_g=
+H5E_CANTSERIALIZE_g=
+H5E_CANTTAG_g=
+H5E_CANTLOAD_g=
+H5E_PROTECT_g=
+H5E_NOTCACHED_g=
+H5E_SYSTEM_g=
+H5E_CANTINS_g=
+H5E_CANTPROTECT_g=
+H5E_CANTUNPROTECT_g=
+H5E_CANTPIN_g=
+H5E_CANTUNPIN_g=
+H5E_CANTMARKDIRTY_g=
+H5E_CANTMARKCLEAN_g=
+H5E_CANTMARKUNSERIALIZED_g=
+H5E_CANTMARKSERIALIZED_g=
+H5E_CANTDIRTY_g=
+H5E_CANTCLEAN_g=
+H5E_CANTEXPUNGE_g=
+H5E_CANTRESIZE_g=
+H5E_CANTDEPEND_g=
+H5E_CANTUNDEPEND_g=
+H5E_CANTNOTIFY_g=
+H5E_LOGGING_g=
+H5E_CANTCORK_g=
+H5E_CANTUNCORK_g=
+
+/* Heap errors */
+H5E_CANTRESTORE_g=
+H5E_CANTCOMPUTE_g=
+H5E_CANTEXTEND_g=
+H5E_CANTATTACH_g=
+H5E_CANTUPDATE_g=
+H5E_CANTOPERATE_g=
+
+/* Parallel MPI errors */
+H5E_MPI_g=
+H5E_MPIERRSTR_g=
+H5E_CANTRECV_g=
+H5E_CANTGATHER_g=
+H5E_NO_INDEPENDENT_g=
+
+/* Dataspace errors */
+H5E_CANTCLIP_g=
+H5E_CANTCOUNT_g=
+H5E_CANTSELECT_g=
+H5E_CANTNEXT_g=
+H5E_BADSELECT_g=
+H5E_CANTCOMPARE_g=
+H5E_INCONSISTENTSTATE_g=
+H5E_CANTAPPEND_g=
+
+/* Object header related errors */
+H5E_LINKCOUNT_g=
+H5E_VERSION_g=
+H5E_ALIGNMENT_g=
+H5E_BADMESG_g=
+H5E_CANTDELETE_g=
+H5E_BADITER_g=
+H5E_CANTPACK_g=
+H5E_CANTRESET_g=
+H5E_CANTRENAME_g=
+
+/* File accessibility errors */
+H5E_FILEEXISTS_g=
+H5E_FILEOPEN_g=
+H5E_CANTCREATE_g=
+H5E_CANTOPENFILE_g=
+H5E_CANTCLOSEFILE_g=
+H5E_NOTHDF5_g=
+H5E_BADFILE_g=
+H5E_TRUNCATED_g=
+H5E_MOUNT_g=
+H5E_UNMOUNT_g=
+H5E_CANTDELETEFILE_g=
+H5E_CANTLOCKFILE_g=
+H5E_CANTUNLOCKFILE_g= (-1);
 
 #endif /* H5Eterm_H */

--- a/hdf5/src/H5FDfamily.c
+++ b/hdf5/src/H5FDfamily.c
@@ -479,6 +479,14 @@ H5FD__family_fapl_copy(const void *_old_fa)
         if (NULL == (plist = (H5P_genplist_t *)H5I_object(old_fa->memb_fapl_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a file access property list");
         new_fa->memb_fapl_id = H5P_copy_plist(plist, FALSE);
+#if 1 /* JRM */
+        /* failure to increment the ref count on new_fa->memb_fapl_id was always a bug, but 
+         * it was not exposed until we ceased itterating through index entries in creation 
+         * order.
+         */
+        if (H5I_inc_ref(new_fa->memb_fapl_id, FALSE) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTINC, NULL, "unable to increment ref count on VFL driver");
+#endif /* JRM */
     } /* end else */
 
     /* Set return value */

--- a/hdf5/src/H5Idbg.c
+++ b/hdf5/src/H5Idbg.c
@@ -62,6 +62,131 @@ static int H5I__id_dump_cb(void *_item, void *_key, void *_udata);
 /* Local Variables */
 /*******************/
 
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__id_dump_cb
+ *
+ * Purpose:     Dump the contents of an ID to stderr for debugging.
+ *
+ *              Updated for multi-thread.  
+ *
+ *              Note new code to grab the global mutex for the duration of 
+ *              call if it is not already held by the current thread.
+ *
+ * Return:      H5_ITER_CONT (always)
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5I__id_dump_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
+{
+    hbool_t                 have_global_mutex = TRUE;  /* Trivially true in single thread builds */
+    hbool_t                 drop_global_mutex = FALSE; /* Trivially false in single thread builds */
+    H5I_mt_id_info_kernel_t info_k;
+    H5I_mt_id_info_t       *id_info_ptr   = (H5I_mt_id_info_t *)_item; /* Pointer to the ID node */
+    H5I_type_t              type          = *(H5I_type_t *)_udata;  /* User data */
+    const H5G_name_t       *path          = NULL;                   /* Path to file object */
+    void                   *object        = NULL;                   /* Pointer to VOL connector object */
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+
+    if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
+
+        /* eventually, H5TS_have_mutex() should never fail.  But until this 
+         * is true, trigger an assertion failure if it does.
+         */
+        assert(FALSE);
+
+#endif /* defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD) */
+
+    if ( ! have_global_mutex ) {
+
+        H5_API_LOCK
+        drop_global_mutex = TRUE;
+    }
+
+    info_k = atomic_load(&(id_info_ptr->k));
+
+    fprintf(stderr, "         id = %" PRIdHID "\n", id_info_ptr->id);
+    fprintf(stderr, "         count = %u\n", info_k.count);
+    fprintf(stderr, "         obj   = 0x%8p\n", info_k.object);
+    fprintf(stderr, "         marked = %d\n", info_k.marked);
+
+    /* Get the group location, so we get get the name */
+    switch (type) {
+        case H5I_GROUP: {
+            const H5VL_object_t *vol_obj = (const H5VL_object_t *)info_k.object;
+
+            object = H5VL_object_data(vol_obj);
+            if (H5_VOL_NATIVE == vol_obj->connector->cls->value)
+                path = H5G_nameof(object);
+            break;
+        }
+
+        case H5I_DATASET: {
+            const H5VL_object_t *vol_obj = (const H5VL_object_t *)info_k.object;
+
+            object = H5VL_object_data(vol_obj);
+            if (H5_VOL_NATIVE == vol_obj->connector->cls->value)
+                path = H5D_nameof(object);
+            break;
+        }
+
+        case H5I_DATATYPE: {
+            const H5T_t *dt = (const H5T_t *)info_k.object;
+
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            object = (void *)H5T_get_actual_type((H5T_t *)dt);
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+            path = H5T_nameof(object);
+            break;
+        }
+
+        /* TODO: Maps will have to be added when they are supported in the
+         *       native VOL connector.
+         */
+        case H5I_MAP:
+
+        case H5I_UNINIT:
+        case H5I_BADID:
+        case H5I_FILE:
+        case H5I_DATASPACE:
+        case H5I_ATTR:
+        case H5I_VFL:
+        case H5I_VOL:
+        case H5I_GENPROP_CLS:
+        case H5I_GENPROP_LST:
+        case H5I_ERROR_CLASS:
+        case H5I_ERROR_MSG:
+        case H5I_ERROR_STACK:
+        case H5I_SPACE_SEL_ITER:
+        case H5I_EVENTSET:
+        case H5I_NTYPES:
+        default:
+            break; /* Other types of IDs are not stored in files */
+    }
+
+    if (path) {
+        if (path->user_path_r)
+            fprintf(stderr, "                user_path = %s\n", H5RS_get_str(path->user_path_r));
+        if (path->full_path_r)
+            fprintf(stderr, "                full_path = %s\n", H5RS_get_str(path->full_path_r));
+    }
+
+    if ( drop_global_mutex ) {
+
+        H5_API_UNLOCK
+    }
+
+    FUNC_LEAVE_NOAPI(H5_ITER_CONT)
+} /* end H5I__id_dump_cb() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__id_dump_cb
  *
@@ -151,6 +276,76 @@ H5I__id_dump_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
     FUNC_LEAVE_NOAPI(H5_ITER_CONT)
 } /* end H5I__id_dump_cb() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_dump_ids_for_type
+ *
+ * Purpose:     Dump the contents of a type to stderr for debugging.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_dump_ids_for_type(H5I_type_t type)
+{
+    H5I_mt_type_info_t *type_info_ptr = NULL;
+
+    FUNC_ENTER_NOAPI_NOERR
+
+    fprintf(stderr, "Dumping ID type %d\n", (int)type);
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( type_info_ptr ) {
+
+        H5I_mt_id_info_t *id_info_ptr = NULL;
+        unsigned long long int id;
+        void * value;
+
+        /* Header */
+        fprintf(stderr, "     init_count = %u\n", atomic_load(&(type_info_ptr->init_count)));
+        fprintf(stderr, "     reserved   = %u\n", type_info_ptr->cls->reserved);
+        fprintf(stderr, "     id_count   = %llu\n", (unsigned long long)atomic_load(&(type_info_ptr->id_count)));
+        fprintf(stderr, "     nextid     = %llu\n", (unsigned long long)atomic_load(&(type_info_ptr->nextid)));
+
+        /* List */
+        if ( atomic_load(&(type_info_ptr->id_count)) > 0 ) {
+
+            fprintf(stderr, "     List:\n");
+
+            /* Normally we care about the callback's return value
+             * (H5I_ITER_CONT, etc.), but this is an iteration over all
+             * the IDs so we don't care.
+             *
+             * XXX: Update this to emit an error message on errors?
+             */
+            fprintf(stderr, "     (HASH TABLE)\n");
+
+            if ( lfht_get_first(&(type_info_ptr->lfht), &id, &value) ) {
+
+                do {
+                    id_info_ptr = (H5I_mt_id_info_t *)value;
+
+                    H5I__id_dump_cb((void *)id_info_ptr, NULL, (void *)&type);
+
+                } while (lfht_get_next(&(type_info_ptr->lfht), id, &id, &value));
+            }
+        }
+    }
+    else {
+
+        fprintf(stderr, "Global type info/tracking pointer for that type is NULL\n");
+    }
+
+    FUNC_LEAVE_NOAPI(SUCCEED)
+
+} /* end H5I_dump_ids_for_type() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_dump_ids_for_type
  *
@@ -173,7 +368,12 @@ H5I_dump_ids_for_type(H5I_type_t type)
     if (type_info) {
 
         H5I_id_info_t *item = NULL;
+#if H5_HAVE_MULTITHREAD
+        unsigned long long int id;
+        void * value;
+#else /* H5_HAVE_MULTITHREAD */
         H5I_id_info_t *tmp  = NULL;
+#endif /* H5_HAVE_MULTITHREAD */
 
         /* Header */
         fprintf(stderr, "     init_count = %u\n", type_info->init_count);
@@ -191,10 +391,22 @@ H5I_dump_ids_for_type(H5I_type_t type)
              * XXX: Update this to emit an error message on errors?
              */
             fprintf(stderr, "     (HASH TABLE)\n");
+#if H5_HAVE_MULTITHREAD
+            if ( lfht_get_first(&(type_info->lfht), &id, &value) ) {
+
+                do {
+                    item = (H5I_id_info_t *)value;
+
+                    H5I__id_dump_cb((void *)item, NULL, (void *)&type);
+
+                } while (lfht_get_next(&(type_info->lfht), id, &id, &value));
+            }
+#else /* H5_HAVE_MULTITHREAD */
             HASH_ITER(hh, type_info->hash_table, item, tmp)
             {
                 H5I__id_dump_cb((void *)item, NULL, (void *)&type);
             }
+#endif /* H5_HAVE_MULTITHREAD */
         }
     }
     else
@@ -202,3 +414,6 @@ H5I_dump_ids_for_type(H5I_type_t type)
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5I_dump_ids_for_type() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+

--- a/hdf5/src/H5Iint.c
+++ b/hdf5/src/H5Iint.c
@@ -31,9 +31,56 @@
 #include "H5Tprivate.h"  /* Datatypes                                */
 #include "H5VLprivate.h" /* Virtual Object Layer                     */
 
+#if H5_HAVE_MULTITHREAD 
+#include "lfht.c" 
+#endif /* H5_HAVE_MULTITHREAD */
+
 /****************/
 /* Local Macros */
 /****************/
+
+#if H5_HAVE_MULTITHREAD
+
+#define H5I_MT_DEBUG                    0
+#define H5I_MT_DEBUG_DO_NOT_DISTURB     0
+
+/* The multi-thread version of H5I uses the do_not_distub field in instances of 
+ * H5I_mt_id_info_t to maintain mutual exclusion on kernels of the host instance
+ * of H5I_mt_id_info_t while performing operations that can't be rolled back -- 
+ * specifically user provided callbacks.  
+ *
+ * The correct solution is to require that user provided callbacks be multi-
+ * thread safe, and be able to handle duplicate calls gracefully.  Were this
+ * the case, the do_not_disturb flag sould not be necessary.
+ *
+ * Unfortunately, this solution can't be applied to the existing HDF5 library
+ * without retro-fitting multi-thread support.  While this is desireable, the
+ * necessary resources are nto available at present.
+ *
+ * To make matters worse, the HDF5 library makes recursive visits to index 
+ * entries in some callback functions provided to H5I.  This results in 
+ * deadlocks as the recursive call waits forever for the do_not_disturb flag
+ * be reset.
+ *
+ * An obvious solution it to make the lock implemented with the do_not_disturb
+ * flag recursive.  The easy way to do this would be to store the id of the
+ * locking thread in the instance of H5I_mt_id_info_t.  While I may go this 
+ * way eventually, C11 threads are not universally available yet,  Rather tnan
+ * commit to a thread library, I decided to avoid this solution for now.
+ *
+ * Instead, observe that until the HDF5 library is made multithread safe, 
+ * the global lock must be held by any thread that is active in any section
+ * that is not multi-thread safe.  Thus, it should be safe to ignore the 
+ * do_not_disturb flag whenever the global mutex is held.
+ *
+ * The H5I__HAVE_GLOBAL_MUTEX #define is set up to simulate this until such 
+ * time as the mutex is moved below H5I.  In the serial build, the global 
+ * mutex is held by default -- and thus for now the H5I__HAVE_GLOBAL_MUTEX
+ * #define is set to TRUE.
+ */
+#define H5I__HAVE_GLOBAL_MUTEX          1
+
+#endif /* H5_HAVE_MULTITHREAD */
 
 /* Combine a Type number and an ID index into an ID */
 #define H5I_MAKE(g, i) ((((hid_t)(g)&TYPE_MASK) << ID_BITS) | ((hid_t)(i)&ID_MASK))
@@ -49,6 +96,19 @@ typedef struct {
     hid_t       ret_id;   /* ID returned */
 } H5I_get_id_ud_t;
 
+#if H5_HAVE_MULTITHREAD
+
+/* User data for iterator callback for ID iteration */
+typedef struct {
+    H5I_search_func_t user_func;  /* 'User' function to invoke */
+    void             *user_udata; /* User data to pass to 'user' function */
+    hbool_t           app_ref;    /* Whether this is an appl. ref. call */
+    H5I_type_t        obj_type;   /* Type of object we are iterating over */
+    hbool_t           have_global_mutex; /* whether the global mutex is held by this thread */
+} H5I_iterate_ud_t;
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /* User data for iterator callback for ID iteration */
 typedef struct {
     H5I_search_func_t user_func;  /* 'User' function to invoke */
@@ -57,12 +117,22 @@ typedef struct {
     H5I_type_t        obj_type;   /* Type of object we are iterating over */
 } H5I_iterate_ud_t;
 
+#endif /* H5_HAVE_MULTITHREAD */
+
 /* User data for H5I__clear_type_cb */
+#if H5_HAVE_MULTITHREAD
+typedef struct {
+    H5I_mt_type_info_t *type_info; /* Pointer to the type's info to be cleared */
+    hbool_t          force;     /* Whether to always remove the ID */
+    hbool_t          app_ref;   /* Whether this is an appl. ref. call */
+} H5I_mt_clear_type_ud_t;
+#else /* H5_HAVE_MULTITHREAD */
 typedef struct {
     H5I_type_info_t *type_info; /* Pointer to the type's info to be cleared */
     hbool_t          force;     /* Whether to always remove the ID */
     hbool_t          app_ref;   /* Whether this is an appl. ref. call */
 } H5I_clear_type_ud_t;
+#endif /* H5_HAVE_MULTITHREAD */
 
 /********************/
 /* Package Typedefs */
@@ -72,19 +142,48 @@ typedef struct {
 /* Local Prototypes */
 /********************/
 
-static void  *H5I__unwrap(void *object, H5I_type_t type);
 static herr_t H5I__mark_node(void *_id, void *key, void *udata);
 static void  *H5I__remove_common(H5I_type_info_t *type_info, hid_t id);
+
+#if H5_HAVE_MULTITHREAD
+
+static herr_t H5I__unwrap(void *object, H5I_type_t type, void **unwrapped_object_ptr);
+static int    H5I__dec_ref(hid_t id, void **request, hbool_t app);
+
+#else /* H5_HAVE_MULTITHREAD */
+
+static void  *H5I__unwrap(void *object, H5I_type_t type);
 static int    H5I__dec_ref(hid_t id, void **request);
+
+#endif /* H5_HAVE_MULTITHREAD */
+
 static int    H5I__dec_app_ref(hid_t id, void **request);
 static int    H5I__dec_app_ref_always_close(hid_t id, void **request);
 static int    H5I__find_id_cb(void *_item, void *_key, void *_udata);
+
+#if H5_HAVE_MULTITHREAD
+
+static herr_t H5I__clear_mt_id_info_free_list(void);
+static herr_t H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr);
+static H5I_mt_id_info_t * H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * object, 
+                                              hbool_t is_future, H5I_future_realize_func_t realize_cb, 
+                                              H5I_future_discard_func_t discard_cb);
+static herr_t H5I__clear_mt_type_info_free_list(void);
+static herr_t H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr);
+static H5I_mt_type_info_t * H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved);
+#endif /* H5_HAVE_MULTITHREAD */
 
 /*********************/
 /* Package Variables */
 /*********************/
 
 /* Declared extern in H5Ipkg.h and documented there */
+#if H5_HAVE_MULTITHREAD
+
+H5I_mt_t              H5I_mt_g;
+
+#else /* H5_HAVE_MULTITHREAD */
+
 H5I_type_info_t *H5I_type_info_array_g[H5I_MAX_NUM_TYPES];
 int              H5I_next_type_g = (int)H5I_NTYPES;
 
@@ -94,6 +193,8 @@ H5FL_DEFINE_STATIC(H5I_id_info_t);
 /* Whether deletes are actually marks (for mark-and-sweep) */
 static hbool_t H5I_marking_s = FALSE;
 
+#endif /* H5_HAVE_MULTITHREAD */
+
 /*****************************/
 /* Library Private Variables */
 /*****************************/
@@ -101,6 +202,354 @@ static hbool_t H5I_marking_s = FALSE;
 /*******************/
 /* Local Variables */
 /*******************/
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_init
+ *
+ * Purpose:     Initialize the interface from some other layer.
+ *
+ *              At present, this function performs initializations needed
+ *              for the multi-thread build of H5I.  Thus it need not be 
+ *              called in other contexts.
+ *
+ * Return:      Success:    Positive if any action was taken that might
+ *                          affect some other interface; zero otherwise.
+ *
+ *              Failure:    Negative
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_init(void)
+{
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+#if H5_HAVE_MULTITHREAD
+    int i;
+    H5I_mt_id_info_sptr_t init_id_sptr = {NULL, 0ULL};
+    H5I_mt_id_info_sptr_t id_sptr;
+    H5I_mt_id_info_t * id_info_ptr;
+    H5I_mt_type_info_sptr_t init_type_sptr = {NULL, 0ULL};
+    H5I_mt_type_info_sptr_t type_sptr;
+    H5I_mt_type_info_t * type_info_ptr;
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__init() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* initialize cognates of existing globals in H5I_mt_g */
+
+    for ( i = 0; i < H5I_MAX_NUM_TYPES; i++) {
+
+        atomic_init(&(H5I_mt_g.type_info_array[i]), NULL);
+
+        if ( i < H5I_NTYPES ) {
+
+            atomic_init(&(H5I_mt_g.type_info_allocation_table[i]), TRUE);
+
+        } else {
+
+            atomic_init(&(H5I_mt_g.type_info_allocation_table[i]), FALSE);
+        }
+    }
+    atomic_init(&(H5I_mt_g.next_type), (int)H5I_NTYPES);
+    atomic_init(&(H5I_mt_g.marking), (int)0);
+
+
+    /* initialized new globals needed by the MT version of H5I */
+
+    atomic_init(&(H5I_mt_g.active_threads), 0);
+
+
+    /* initialize the id info free list */
+
+    atomic_init(&(H5I_mt_g.id_info_fl_shead), init_id_sptr);
+    atomic_init(&(H5I_mt_g.id_info_fl_stail), init_id_sptr);
+    atomic_init(&(H5I_mt_g.id_info_fl_len), 0ULL);
+    atomic_init(&(H5I_mt_g.max_desired_id_info_fl_len), H5I__MAX_DESIRED_ID_INFO_FL_LEN);
+
+    /* allocate the initial entry in the id info free list and initialize the id info free list */
+    id_info_ptr = H5I__new_mt_id_info(0, 0, 0, NULL, FALSE, NULL, NULL);
+    if ( NULL == id_info_ptr) 
+        HGOTO_ERROR(H5E_ID, H5E_CANTINIT, FAIL, "Can't initialize id info free list");
+
+    atomic_store(&(id_info_ptr->re_allocable), FALSE);
+    atomic_store(&(id_info_ptr->on_fl), TRUE);
+
+    id_sptr.ptr = id_info_ptr;
+    id_sptr.sn = 1ULL;
+
+    atomic_store(&(H5I_mt_g.id_info_fl_shead), id_sptr);
+    atomic_store(&(H5I_mt_g.id_info_fl_stail), id_sptr);
+    atomic_store(&(H5I_mt_g.id_info_fl_len), 1ULL);
+
+
+    /* allocate the initial entry in the type info free list and initialize the type info free list */
+
+    atomic_init(&(H5I_mt_g.type_info_fl_shead), init_type_sptr);
+    atomic_init(&(H5I_mt_g.type_info_fl_stail), init_type_sptr);
+    atomic_init(&(H5I_mt_g.type_info_fl_len), 0ULL);
+    atomic_init(&(H5I_mt_g.max_desired_type_info_fl_len), H5I__MAX_DESIRED_TYPE_INFO_FL_LEN);
+
+    /* allocate the initial entry in the id info free list and initialize the id info free list */
+    type_info_ptr = H5I__new_mt_type_info(NULL, 0);
+    if ( NULL == type_info_ptr) 
+        HGOTO_ERROR(H5E_ID, H5E_CANTINIT, FAIL, "Can't initialize type info free list");
+
+    /* H5I__new_mt_type_info() sets up the lock free hash table -- must take it 
+     * back down before we insert the new instance of H5I_mt_type_info_t on the
+     * type info free list.
+     */
+    lfht_clear(&(type_info_ptr->lfht));
+    atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
+
+    atomic_store(&(type_info_ptr->re_allocable), FALSE);
+    atomic_store(&(type_info_ptr->on_fl), TRUE);
+
+    type_sptr.ptr = type_info_ptr;
+    type_sptr.sn = 1ULL;
+
+    atomic_store(&(H5I_mt_g.type_info_fl_shead), type_sptr);
+    atomic_store(&(H5I_mt_g.type_info_fl_stail), type_sptr);
+    atomic_store(&(H5I_mt_g.type_info_fl_len), 1ULL);
+
+
+    /* initialize stats */
+
+    atomic_init(&(H5I_mt_g.dump_stats_on_shutdown), FALSE);
+
+    atomic_init(&(H5I_mt_g.init_type_registrations), 0ULL);
+    atomic_init(&(H5I_mt_g.duplicate_type_registrations), 0ULL);
+    atomic_init(&(H5I_mt_g.type_registration_collisions), 0ULL);
+
+    atomic_init(&(H5I_mt_g.max_id_info_fl_len), 1ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_structs_alloced_from_heap), 1ULL); 
+    atomic_init(&(H5I_mt_g.num_id_info_structs_alloced_from_fl), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_structs_freed), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_structs_added_to_fl), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_head_update_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_append_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_structs_marked_reallocatable), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty), 0ULL);
+    atomic_init(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_head_not_reallocable), 0ULL);
+
+    atomic_init(&(H5I_mt_g.max_type_info_fl_len), 1ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_structs_alloced_from_heap), 1ULL); 
+    atomic_init(&(H5I_mt_g.num_type_info_structs_alloced_from_fl), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_structs_freed), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_structs_added_to_fl), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_head_update_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_append_cols), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_structs_marked_reallocatable), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty), 0ULL);
+    atomic_init(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_head_not_reallocable), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I__mark_node__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__already_marked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__marked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__marked_by_another_thread), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__no_ops), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_marked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__discard_cb_successes), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__free_func_failures_marked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__free_func_failures_unmarked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__free_func_successes), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__mark_node__retries), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I__remove_common__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__remove_common__already_marked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__remove_common__marked_by_another_thread), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__remove_common__marked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__remove_common__target_not_in_lfht), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__remove_common__retries), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I__find_id__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__num_calls_with_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__num_calls_with_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__ids_found), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__num_calls_to_realize_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__num_calls_to_discard_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__future_id_conversions_attempted), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__future_id_conversions_completed), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__find_id__retries), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I_register_using_existing_id__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_register_using_existing_id__num_failures), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I_subst__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_subst__marked_on_entry), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_subst__marked_during_call), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_subst__retries), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_subst__failures), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__num_app_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__marked_on_entry), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__marked_during_call), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__marked), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__decremented), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__app_decremented), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__calls_to_free_func), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__free_func_failed), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__dec_ref__retries), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I__inc_ref__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__inc_ref__num_app_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__inc_ref__marked_on_entry), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__inc_ref__marked_during_call), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__inc_ref__incremented), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__inc_ref__app_incremented), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__inc_ref__retries), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__marked_during_call), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_user_func_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__iterate_cb__num_retries), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I__unwrap__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T), 0ULL);
+
+    atomic_init(&(H5I_mt_g.H5I_is_file_object__num_calls), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named), 0ULL);
+    atomic_init(&(H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named), 0ULL);
+
+    atomic_init(&(H5I_mt_g.num_do_not_disturb_yields), 0ULL);
+    atomic_init(&(H5I_mt_g.num_successful_do_not_disturb_sets), 0ULL);
+    atomic_init(&(H5I_mt_g.num_failed_do_not_disturb_sets), 0ULL);
+    atomic_init(&(H5I_mt_g.num_do_not_disturb_resets), 0ULL);
+
+    atomic_init(&(H5I_mt_g.num_H5I_entries_via_public_API), 0ULL);
+    atomic_init(&(H5I_mt_g.num_H5I_entries_via_internal_API), 0ULL);
+    atomic_init(&(H5I_mt_g.num_H5I_entries_via_internal_API), 0ULL);
+    atomic_init(&(H5I_mt_g.times_active_threads_is_zero), 0ULL);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+#else /* H5I__ MT */
+
+    FUNC_ENTER_NOAPI_NOINIT_NOERR
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+} /* H5I_init() */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_term_package
+ *
+ * Purpose:     Terminate the H5I interface: release all memory, reset all
+ *              global variables to initial values. This only happens if all
+ *              types have been destroyed from other interfaces.
+ *
+ *              Modified for MT operation
+ *
+ * Return:      Success:    Positive if any action was taken that might
+ *                          affect some other interface; zero otherwise.
+ *
+ *              Failure:    Negative
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+H5I_term_package(void)
+{
+    int in_use = 0; /* Number of ID types still in use */
+
+    FUNC_ENTER_NOAPI_NOINIT_NOERR
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_term_package() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    H5I_mt_type_info_t *type_info_ptr = NULL; /* Pointer to ID type */
+    int              i;
+
+    /* Count the number of types still in use */
+
+    for (i = 0; i < atomic_load(&(H5I_mt_g.next_type)); i++) {
+        if ((type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[i]))) && ! atomic_load(&(type_info_ptr->lfht_cleared))) {
+
+            in_use++;
+        }
+    }
+
+    /* If no types are still being used then clean up */
+    if (0 == in_use) {
+        for (i = 0; i <  atomic_load(&(H5I_mt_g.next_type)); i++) {
+            type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[i]));
+            if (type_info_ptr) {
+                assert(atomic_load(&(type_info_ptr->lfht_cleared)));
+#if 1 /* JRM */
+                H5I__discard_mt_type_info(type_info_ptr);
+                type_info_ptr = NULL;
+#else /* JRM */
+                type_info_ptr                = H5MM_xfree(type_info_ptr);
+#endif /* JRM */
+                atomic_store(&(H5I_mt_g.type_info_array[i]), NULL);
+                in_use++;
+            }
+        }
+
+        /* discard the contents of the id and type info free lists */
+        assert( H5I__clear_mt_id_info_free_list() >= 0 );
+        assert( H5I__clear_mt_type_info_free_list() >= 0 );
+
+        if ( atomic_load(&(H5I_mt_g.dump_stats_on_shutdown)) ) {
+
+            H5I_dump_stats(stdout);
+        }
+
+        H5I_clear_stats();
+    }
+
+    FUNC_LEAVE_NOAPI(in_use)
+} /* end H5I_term_package() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_term_package
@@ -146,6 +595,1245 @@ H5I_term_package(void)
 
     FUNC_LEAVE_NOAPI(in_use)
 } /* end H5I_term_package() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_clear_stats
+ *
+ * Purpose:     Reset the stats maintained in the H5I_mt_g global structure.
+ *
+ *              Note that these statistics are only maintained in the multi-
+ *              thread implementation of H5I.
+ *
+ * Return:      void
+ *
+ * Changes:     None.
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+H5I_clear_stats(void)
+{
+    FUNC_ENTER_NOAPI_NOERR
+
+    atomic_store(&(H5I_mt_g.init_type_registrations), 0ULL);
+    atomic_store(&(H5I_mt_g.duplicate_type_registrations), 0ULL);
+    atomic_store(&(H5I_mt_g.type_registration_collisions), 0ULL);
+
+    atomic_store(&(H5I_mt_g.max_id_info_fl_len), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_structs_alloced_from_heap), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_structs_alloced_from_fl), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_structs_freed), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_structs_added_to_fl), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_head_update_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_append_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_structs_marked_reallocatable), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty), 0ULL);
+    atomic_store(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_head_not_reallocable), 0ULL);
+
+    atomic_store(&(H5I_mt_g.max_type_info_fl_len), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_structs_alloced_from_heap), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_structs_alloced_from_fl), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_structs_freed), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_structs_added_to_fl), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_head_update_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_append_cols), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_structs_marked_reallocatable), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty), 0ULL);
+    atomic_store(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_head_not_reallocable), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I__mark_node__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__already_marked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__marked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__marked_by_another_thread), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__no_ops), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_marked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__discard_cb_successes), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__free_func_failures_marked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__free_func_failures_unmarked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__free_func_successes), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__mark_node__retries), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I__remove_common__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__remove_common__already_marked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__remove_common__marked_by_another_thread), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__remove_common__marked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__remove_common__target_not_in_lfht), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__remove_common__retries), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I__find_id__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__num_calls_with_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__num_calls_without_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__ids_found), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__num_calls_to_realize_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__num_calls_to_discard_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__future_id_conversions_attempted), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__future_id_conversions_completed), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__find_id__retries), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I_register_using_existing_id__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_register_using_existing_id__num_failures), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I_subst__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_subst__marked_on_entry), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_subst__marked_during_call), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_subst__retries), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_subst__failures), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__num_app_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__marked_on_entry), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__marked_during_call), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__marked), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__decremented), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__app_decremented), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__calls_to_free_func), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__free_func_failed), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__dec_ref__retries), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I__inc_ref__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__inc_ref__num_app_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__inc_ref__marked_on_entry), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__inc_ref__marked_during_call), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__inc_ref__incremented), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__inc_ref__app_incremented), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__inc_ref__retries), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__marked_during_call), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_user_func_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__iterate_cb__num_retries), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I__unwrap__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T), 0ULL);
+
+    atomic_store(&(H5I_mt_g.H5I_is_file_object__num_calls), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named), 0ULL);
+    atomic_store(&(H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named), 0ULL);
+
+    atomic_store(&(H5I_mt_g.num_do_not_disturb_yields), 0ULL);
+    atomic_store(&(H5I_mt_g.num_successful_do_not_disturb_sets), 0ULL);
+    atomic_store(&(H5I_mt_g.num_failed_do_not_disturb_sets), 0ULL);
+    atomic_store(&(H5I_mt_g.num_do_not_disturb_resets), 0ULL);
+
+    atomic_store(&(H5I_mt_g.num_H5I_entries_via_public_API), 0ULL);
+    atomic_store(&(H5I_mt_g.num_H5I_entries_via_internal_API), 0ULL);
+    atomic_store(&(H5I_mt_g.max_active_threads), 0ULL);
+    atomic_store(&(H5I_mt_g.times_active_threads_is_zero), 0ULL);
+
+    FUNC_LEAVE_NOAPI_VOID;
+
+} /* H5I_clear_stats() */
+
+#endif /* H5I__INIT() */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_dump_stats
+ *
+ * Purpose:     Dump the stats maintained in the H5I_mt_g global structure
+ *              to the specified file.
+ *
+ *              Note that these statistics are only maintained in the multi-
+ *              thread implementation of H5I.
+ *
+ * Return:      void
+ *
+ * Changes:     None.
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+H5I_dump_stats(FILE * file_ptr)
+{
+    FUNC_ENTER_NOAPI_NOERR
+
+    fprintf(file_ptr, "\n\nH5I Multi-Thread STATS:\n\n");
+
+    fprintf(file_ptr, "H5I_mt_g.init_type_registrations                                       = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.init_type_registrations))));
+    fprintf(file_ptr, "H5I_mt_g.duplicate_type_registrations                                  = %lld\n",
+            (unsigned long long)(atomic_load(&(H5I_mt_g.duplicate_type_registrations))));
+    fprintf(file_ptr, "H5I_mt_g.type_registration_collisions                                  = %lld\n\n",
+            (unsigned long long)(atomic_load(&(H5I_mt_g.type_registration_collisions))));
+
+    fprintf(file_ptr, "H5I_mt_g.max_id_info_fl_len                                            = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.max_id_info_fl_len))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_alloced_from_heap                         = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_heap))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_alloced_from_fl                           = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_fl))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_freed                                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_freed))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_added_to_fl                               = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_added_to_fl))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_head_update_cols                               = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_head_update_cols))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_tail_update_cols                               = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_tail_update_cols))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_append_cols                                    = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_append_cols))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_marked_reallocatable                      = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_marked_reallocatable))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty                  = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable   = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty))));
+    fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_frees_skipped_due_to_head_not_reallocable      = %lld\n\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_head_not_reallocable))));
+
+    fprintf(file_ptr, "H5I_mt_g.max_type_info_fl_len                                          = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.max_type_info_fl_len))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_alloced_from_heap                       = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_heap))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_alloced_from_fl                         = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_fl))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_freed                                   = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_freed))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_added_to_fl                             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_added_to_fl))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_head_update_cols                             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_head_update_cols))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_tail_update_cols                             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_tail_update_cols))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_append_cols                                  = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_append_cols))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_marked_reallocatable                    = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_marked_reallocatable))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty                   = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty))));
+    fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_frees_skipped_due_to_head_not_reallocable    = %lld\n\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_head_not_reallocable))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__num_calls                                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex                   = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__already_marked                                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__already_marked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__marked                                        = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__marked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__marked_by_another_thread                      = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__marked_by_another_thread))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__no_ops                                        = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__no_ops))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb           = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__discard_cb_failures_marked                    = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_marked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked                  = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__discard_cb_successes                          = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_successes))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func              = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func            = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__free_func_failures_marked                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_failures_marked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__free_func_failures_unmarked                   = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_failures_unmarked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__free_func_successes                           = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_successes))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__retries                                       = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__retries))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__num_calls                                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__already_marked                            = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__already_marked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__marked_by_another_thread                  = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__marked_by_another_thread))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__marked                                    = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__marked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__target_not_in_lfht                        = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__target_not_in_lfht))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__retries                                   = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__retries))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls                                       = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_with_global_mutex                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_with_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_without_global_mutex                  = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_without_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__ids_found                                       = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__ids_found))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_to_realize_cb                         = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_to_realize_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb               = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_to_discard_cb                         = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_to_discard_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb               = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__future_id_conversions_attempted                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__future_id_conversions_attempted))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__future_id_conversions_completed                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__future_id_conversions_completed))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__find_id__retries                                         = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__retries))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_calls                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_marked_only               = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use         = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_failures                  = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_failures))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_calls                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_marked_only               = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use         = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_failures                  = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_failures))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I_subst__num_calls                                          = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_subst__marked_on_entry                                    = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__marked_on_entry))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_subst__marked_during_call                                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__marked_during_call))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_subst__retries                                            = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__retries))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_subst__failures                                           = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__failures))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_calls                                       = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_app_calls                                   = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_app_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex                  = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__marked_on_entry                                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked_on_entry))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__marked_during_call                              = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked_during_call))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__marked                                          = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__decremented                                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__decremented))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__app_decremented                                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__app_decremented))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__calls_to_free_func                              = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__calls_to_free_func))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func              = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__free_func_failed                                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__free_func_failed))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__retries                                         = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__retries))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__num_calls                                       = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__num_app_calls                                   = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__num_app_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__marked_on_entry                                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__marked_on_entry))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__marked_during_call                              = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__marked_during_call))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__incremented                                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__incremented))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__app_incremented                                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__app_incremented))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__retries                                         = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__retries))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_calls                                    = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex              = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__marked_during_call                           = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__marked_during_call))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_calls                          = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func           = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_successes                      = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_fails                          = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_skips                          = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_retries                                  = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_retries))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__num_calls                                        = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex                      = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex                   = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL               = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL             = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T))));
+    fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T              = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T))));
+
+    fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__num_calls                                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__num_calls))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named                 = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named       = %lld\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named))));
+    fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named     = %lld\n\n", 
+            (unsigned long long)
+            (atomic_load(&(H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named))));
+
+    fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_yields                                     = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_yields))));
+    fprintf(file_ptr, "H5I_mt_g.num_successful_do_not_disturb_sets                            = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_successful_do_not_disturb_sets))));
+    fprintf(file_ptr, "H5I_mt_g.num_failed_do_not_disturb_sets                                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_failed_do_not_disturb_sets))));
+    fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_resets                                     = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_resets))));
+
+    fprintf(file_ptr, "H5I_mt_g.num_H5I_entries_via_public_API                                = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_H5I_entries_via_public_API))));
+    fprintf(file_ptr, "H5I_mt_g.num_H5I_entries_via_internal_API                              = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.num_H5I_entries_via_internal_API))));
+    fprintf(file_ptr, "H5I_mt_g.max_active_threads                                            = %lld\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.max_active_threads))));
+    fprintf(file_ptr, "H5I_mt_g.times_active_threads_is_zero                                  = %lld\n\n", 
+            (unsigned long long)(atomic_load(&(H5I_mt_g.times_active_threads_is_zero))));
+
+#if 0
+    fprintf(file_ptr, " = %lld\n", 
+            (unsigned long long)(atomic_load(&())));
+#endif
+
+    FUNC_LEAVE_NOAPI_VOID;
+
+} /* H5I_dump_stats() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_dump_nz_stats
+ *
+ * Purpose:     Dump the stats maintained in the H5I_mt_g global structure
+ *              that have non-zero values to the specified file.
+ *
+ *              Note that these statistics are only maintained in the multi-
+ *              thread implementation of H5I.
+ *
+ * Return:      void
+ *
+ * Changes:     None.
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+H5I_dump_nz_stats(FILE * file_ptr, const char * tag)
+{
+    FUNC_ENTER_NOAPI_NOERR
+
+    fprintf(file_ptr, "\n\nH5I Multi-Thread Non-Zero STATS: (%s)\n\n", tag);
+
+
+    /* type registration stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.init_type_registrations))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.init_type_registrations                                       = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.init_type_registrations))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.duplicate_type_registrations))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.duplicate_type_registrations                                  = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.duplicate_type_registrations))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.type_registration_collisions))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.type_registration_collisions                                  = %lld\n",
+                (unsigned long long)(atomic_load(&(H5I_mt_g.type_registration_collisions))));
+
+
+    /* ID info free list stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.max_id_info_fl_len))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.max_id_info_fl_len                                            = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.max_id_info_fl_len))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_heap))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_alloced_from_heap                         = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_heap))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_fl))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_alloced_from_fl                           = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_alloced_from_fl))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_freed))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_freed                                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_freed))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_added_to_fl))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_added_to_fl                               = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_added_to_fl))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_head_update_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_head_update_cols                               = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_head_update_cols))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_tail_update_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_tail_update_cols                               = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_tail_update_cols))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_append_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_append_cols                                    = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_append_cols))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_marked_reallocatable))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_structs_marked_reallocatable                      = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_structs_marked_reallocatable))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable)))
+         > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable   = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_empty))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_head_not_reallocable))) 
+         > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_id_info_fl_frees_skipped_due_to_head_not_reallocable      = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_id_info_fl_frees_skipped_due_to_head_not_reallocable))));
+
+
+    /* type info free list stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.max_type_info_fl_len))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.max_type_info_fl_len                                          = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.max_type_info_fl_len))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_heap))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_alloced_from_heap                       = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_heap))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_fl))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_alloced_from_fl                         = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_alloced_from_fl))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_freed))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_freed                                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_freed))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_added_to_fl))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_added_to_fl                             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_added_to_fl))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_head_update_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_head_update_cols                             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_head_update_cols))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_tail_update_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_tail_update_cols                             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_tail_update_cols))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_append_cols))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_append_cols                                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_append_cols))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_marked_reallocatable))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_structs_marked_reallocatable                    = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_structs_marked_reallocatable))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty                = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable)))
+         > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_empty))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_head_not_reallocable)))
+         > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_type_info_fl_frees_skipped_due_to_head_not_reallocable    = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.num_type_info_fl_frees_skipped_due_to_head_not_reallocable))));
+
+
+    /* H5I__mark_node() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__num_calls                                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex                = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__already_marked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__already_marked                                = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__already_marked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__marked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__marked                                        = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__marked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__marked_by_another_thread))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__marked_by_another_thread                      = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__marked_by_another_thread))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__no_ops))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__no_ops                                        = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__no_ops))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb           = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_marked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__discard_cb_failures_marked                    = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_marked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_successes))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__discard_cb_successes                          = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__discard_cb_successes))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func              = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func            = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_failures_marked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__free_func_failures_marked                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_failures_marked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_failures_unmarked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__free_func_failures_unmarked                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_failures_unmarked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_successes))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__free_func_successes                           = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__free_func_successes))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__retries))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__mark_node__retries                                       = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__mark_node__retries))));
+
+
+    /* H5I__remove_common() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__num_calls                                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__already_marked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__already_marked                            = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__already_marked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__marked_by_another_thread))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__marked_by_another_thread                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__marked_by_another_thread))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__marked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__marked                                    = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__marked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__target_not_in_lfht))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__target_not_in_lfht                        = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__target_not_in_lfht))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__retries))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__remove_common__retries                                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__remove_common__retries))));
+
+
+    /* H5I__find_id() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls                                       = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_with_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_with_global_mutex                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_with_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_without_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_without_global_mutex                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_without_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__ids_found))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__ids_found                                       = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__ids_found))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_to_realize_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_to_realize_cb                         = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_to_realize_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb               = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_realize_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_to_discard_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__num_calls_to_discard_cb                         = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__num_calls_to_discard_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb               = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__future_id_conversions_attempted))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__future_id_conversions_attempted                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__future_id_conversions_attempted))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__future_id_conversions_completed))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__future_id_conversions_completed                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__future_id_conversions_completed))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__retries))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__find_id__retries                                         = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__find_id__retries))));
+
+
+    /* H5I_register() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_calls                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_calls))));
+
+    if ( (unsigned long long) (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_marked_only               = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use)))
+         > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use         = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_failures))) > 0ULL ) 
+        fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_failures                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_failures))));
+
+
+    /* H5I_register_using_existing_id() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_calls                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only))) > 0ULL )
+         fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_marked_only               = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use)))
+          > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use         = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_failures))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_register_using_existing_id__num_failures                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_register_using_existing_id__num_failures))));
+
+
+    /* H5I_subst() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_subst__num_calls                                          = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__marked_on_entry))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_subst__marked_on_entry                                    = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__marked_on_entry))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__marked_during_call))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_subst__marked_during_call                                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__marked_during_call))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__retries))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_subst__retries                                            = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__retries))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__failures))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_subst__failures                                           = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_subst__failures))));
+
+
+    /* H5I__dec_ref() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_calls                                       = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_app_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_app_calls                                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_app_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked_on_entry))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__marked_on_entry                                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked_on_entry))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked_during_call))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__marked_during_call                              = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked_during_call))));
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__marked                                          = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__marked))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__decremented))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__decremented                                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__decremented))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__app_decremented))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__app_decremented                                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__app_decremented))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__calls_to_free_func))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__calls_to_free_func                              = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__calls_to_free_func))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func                = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func              = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__free_func_failed))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__free_func_failed                                = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__free_func_failed))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__retries))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__dec_ref__retries                                         = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__dec_ref__retries))));
+
+
+    /* H5I__inc_ref() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__num_calls))) > 0ULL ) 
+        fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__num_calls                                       = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__num_app_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__num_app_calls                                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__num_app_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__marked_on_entry))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__marked_on_entry                                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__marked_on_entry))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__marked_during_call))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__marked_during_call                              = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__marked_during_call))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__incremented))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__incremented                                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__incremented))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__app_incremented))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__app_incremented                                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__app_incremented))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__retries))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__inc_ref__retries                                         = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__inc_ref__retries))));
+
+
+    /* H5I__iterate_cb_stats() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_calls                                    = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex              = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__marked_during_call))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__marked_during_call                           = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__marked_during_call))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_calls                          = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func           = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_successes                      = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_fails                          = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_user_func_skips                          = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_retries))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__iterate_cb__num_retries                                  = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__iterate_cb__num_retries))));
+
+
+    /* H5I__unwrap() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__num_calls                                        = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex                      = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex))) > 0 )
+        fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex                   = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL               = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL             = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T                = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T              = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T))));
+
+
+    /* H5I_is_file_object() stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__num_calls))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__num_calls                                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__num_calls))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named                 = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named))) 
+         > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named       = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named)))
+         > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named     = %lld\n", 
+                (unsigned long long)
+                (atomic_load(&(H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named))));
+
+
+    /* do_not_disturb stats */
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_yields))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_yields                                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_yields))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_successful_do_not_disturb_sets))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_successful_do_not_disturb_sets                            = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_successful_do_not_disturb_sets))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_failed_do_not_disturb_sets))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_failed_do_not_disturb_sets                                = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_failed_do_not_disturb_sets))));
+
+    if ( (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_resets))) > 0ULL )
+        fprintf(file_ptr, "H5I_mt_g.num_do_not_disturb_resets                                     = %lld\n", 
+                (unsigned long long)(atomic_load(&(H5I_mt_g.num_do_not_disturb_resets))));
+
+    FUNC_LEAVE_NOAPI_VOID;
+
+} /* H5I_dump_nz_stats() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_register_type
+ *
+ * Purpose:     Creates a new type of ID's to give out.
+ *              The class is initialized or its reference count is incremented
+ *              (if it is already initialized).
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * Changes:     Modified to support multi-thread operation in H5I.
+ *
+ *                                            JRM -- 08/26/23
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_register_type(const H5I_class_t *cls)
+{
+    H5I_mt_type_info_t *type_info_ptr  = NULL;    /* Pointer to the ID type*/
+    H5I_mt_type_info_t *expected_ptr   = NULL;    /* Pointer to the ID type*/
+    herr_t              ret_value      = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n   H5I_register_type() called. cls->type = %d\n", (int)(cls->type));
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert(cls);
+    assert(cls->type > 0);
+    assert((int)cls->type < H5I_MAX_NUM_TYPES);
+    assert(atomic_load(&(H5I_mt_g.type_info_allocation_table[(int)(cls->type)])));
+
+    /* Initialize the type */
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[cls->type]));
+
+    if ( NULL == type_info_ptr ) {
+
+        /* allocate and initialize an instance of H5I_type_info_t */
+#if 1 /* JRM */
+        if (NULL == (type_info_ptr = H5I__new_mt_type_info(cls, 0)))
+
+            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, FAIL, "ID type allocation failed");
+
+        atomic_fetch_add(&(type_info_ptr->init_count), 1);
+#else /* JRM  */
+        if (NULL == (type_info_ptr = (H5I_mt_type_info_t *)H5MM_calloc(sizeof(H5I_mt_type_info_t))))
+            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, FAIL, "ID type allocation failed");
+
+        type_info_ptr->cls = cls;
+        atomic_init(&(type_info_ptr->init_count), 0);
+        atomic_init(&(type_info_ptr->id_count), 0ULL);
+        atomic_init(&(type_info_ptr->nextid), cls->reserved);
+        atomic_init(&(type_info_ptr->last_id_info), NULL);
+        atomic_init(&(type_info_ptr->lfht_cleared), FALSE);
+        lfht_init(&(type_info_ptr->lfht));
+#endif /* JRM */
+
+        /* now attempt to insert it into H5I_mt_g.type_info_array_[cls->type].  It is possible
+         * that another thread has done the initialization while we were allocating and 
+         * and initializing the instance of H5I_type_info_t.  If so, we will discard the
+         * instance just initialized and simply increment the init_count on the instance 
+         * that was created, initialized, and inserted by another thread.
+         *
+         * Recall that expected_ptr is initialized to NULL, but will be set to the current
+         * value of H5I_mt_g.type_info_array[class->type] if it is not NULL.
+         */
+        if ( atomic_compare_exchange_strong(&(H5I_mt_g.type_info_array[cls->type]), &expected_ptr, type_info_ptr) ) {
+
+            /* We inserted the new instance of H5I_type_info_t into H5I_mt_g.type_info_array[cls->type].
+             * Update stats and goto done.
+             */
+            atomic_fetch_add(&(H5I_mt_g.init_type_registrations), 1);
+            HGOTO_DONE(SUCCEED);
+
+        } else {
+
+            /* the atomic_compare_exchange_strong() failed because H5I_mt_g.type_info_array[cls->type] is
+             * no longer NULL -- which means that another thread beat us to creating and installing 
+             * the new instance of H5I_type_info_t.
+             *
+             * Thus we must discard the instance we just created, and increment the init_count field
+             * of the existing instance of H5I_type_info_t.
+             */
+            assert(type_info_ptr != expected_ptr);
+
+            atomic_fetch_sub(&(type_info_ptr->init_count), 1);
+
+            lfht_clear(&(type_info_ptr->lfht));
+            atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
+#if 1
+            assert(H5I__discard_mt_type_info(type_info_ptr) >= 0);
+#else 
+            H5MM_free(type_info_ptr);
+#endif
+
+            /* If I read the specs on atomic_compare_exchange_strong() correctly, expected_ptr should 
+             * equal H5I_mt_g.type_info_array[cls->type] at this point.  Verify this.
+             */
+            assert(expected_ptr);
+            assert(expected_ptr == atomic_load(&(H5I_mt_g.type_info_array[cls->type])));
+
+            /* Having looked at the higher level code, I expect this will fail, although a deep
+             * comparison of type_info->cls and cls should succeed.  Leave it for now to see
+             * what happens.
+             */
+            assert(expected_ptr->cls == cls);
+
+            /* Increment the number of type registration collisions.  Note that
+             * we will also increment the number of duplicate type registrations.
+             */
+            atomic_fetch_add(&(H5I_mt_g.type_registration_collisions), 1);
+
+            /* set type_info_ptr to expected_ptr so that we can increment the number
+             * of registrations below.
+             */
+            type_info_ptr = expected_ptr;
+        }
+    }
+
+    assert(type_info_ptr);
+    assert(H5I__TYPE_INFO == type_info_ptr->tag);
+
+    atomic_fetch_add(&(type_info_ptr->init_count), 1);
+
+    /* update stats for a duplicate type registration*/
+    atomic_fetch_add(&(H5I_mt_g.duplicate_type_registrations), 1);
+
+done:
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n   H5I_register_type() returns %d\n", (int)(ret_value));
+#endif /* H5I_MT_DEBUG */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_register_type() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_register_type
@@ -203,6 +1891,58 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_register_type() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_nmembers
+ *
+ * Purpose:     Returns the number of members in a type.
+ *
+ *              Updated for MT operation.
+ *
+ * Return:      Success:    Number of members; zero if the type is empty
+ *                          or has been deleted.
+ *
+ *              Failure:    Negative
+ *
+ * Programmer:  Robb Matzke
+ *              Wednesday, March 24, 1999
+ *
+ *-------------------------------------------------------------------------
+ */
+int64_t
+H5I_nmembers(H5I_type_t type)
+{
+    H5I_mt_type_info_t *type_info = NULL; /* Pointer to the ID type */
+    int64_t             ret_value = 0;    /* Return value */
+
+    FUNC_ENTER_NOAPI((-1))
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_nmembers() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Validate parameter */
+
+    if ( ( type <= H5I_BADID ) || ( ((int)type) >= atomic_load(&H5I_mt_g.next_type) ) )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "invalid type number");
+
+    if ( ( NULL == (type_info = atomic_load(&(H5I_mt_g.type_info_array[type]))) ) || 
+         ( atomic_load(&(type_info->init_count)) <= 0 ) )
+        HGOTO_DONE(0);
+
+    /* Set return value */
+    H5_CHECKED_ASSIGN(ret_value, int64_t, atomic_load(&(type_info->id_count)), uint64_t);
+
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5I_nmembers() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_nmembers
  *
@@ -212,6 +1952,9 @@ done:
  *                          or has been deleted.
  *
  *              Failure:    Negative
+ *
+ * Programmer:  Robb Matzke
+ *              Wednesday, March 24, 1999
  *
  *-------------------------------------------------------------------------
  */
@@ -236,6 +1979,123 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_nmembers() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__unwrap
+ *
+ * Purpose:     Unwraps the object pointer for the 'item' that corresponds
+ *              to an ID.
+ *
+ *              For the multi-thread case, it may be necessary for us to 
+ *              grab the global mutex before invoking either 
+ *              H5VL_object_data(), or H5T_get_actual_type().  This creates
+ *              at least the technical possibility of flagging an error,
+ *              which in turns requires a rework of the function call.
+ *
+ *              As a result, the un-wrapped pointer is returned in 
+ *              *unwrapped_object_ptr, and the function returns either 
+ *              SUCCEED or FAIL.  In the latter case, *unwrapped_object_ptr
+ *              is undefined.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * Programmer:  Quincey Koziol
+ *              Friday, October 19, 2018
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5I__unwrap(void *object, H5I_type_t type, void **unwrapped_object_ptr)
+{
+    hbool_t have_global_mutex = TRUE; /* Trivially true in single thread builds */
+    void *unwrapped_object;
+    herr_t ret_value = SUCCEED;; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    atomic_fetch_add(&(H5I_mt_g.H5I__unwrap__num_calls), 1);
+
+    /* Sanity checks */
+    assert(object);
+    assert(unwrapped_object_ptr);
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+
+    if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
+
+        HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "Can't determine whether we have the global mutex");
+        
+#endif /* defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD) */
+
+    if ( have_global_mutex ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__unwrap__num_calls_with_global_mutex), 1);
+
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__unwrap__num_calls_without_global_mutex), 1);
+    }
+
+    /* The stored object pointer might be an H5VL_object_t, in which
+     * case we'll need to get the wrapped object struct (H5F_t *, etc.).
+     */
+    if (H5I_FILE == type || H5I_GROUP == type || H5I_DATASET == type || H5I_ATTR == type) {
+
+        const H5VL_object_t *vol_obj;
+
+        vol_obj   = (const H5VL_object_t *)object;
+
+        if ( ! have_global_mutex ) {
+
+            /* must wrap call to H5VL_object_data() in global mutex */
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5VL), 1);
+            H5_API_LOCK
+            unwrapped_object = H5VL_object_data(vol_obj);
+            H5_API_UNLOCK
+            atomic_fetch_add(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5VL), 1);
+
+        } else {
+
+            unwrapped_object = H5VL_object_data(vol_obj);
+        }
+    } else if (H5I_DATATYPE == type) {
+
+        H5T_t *dt = (H5T_t *)object;
+
+        if ( ! have_global_mutex ) {
+
+            /* must wrap call to H5T_get_actual_type() in global mutex */
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__unwrap__times_global_mutex_locked_for_H5T), 1);
+            H5_API_LOCK
+            unwrapped_object = (void *)H5T_get_actual_type(dt);
+            H5_API_UNLOCK
+            atomic_fetch_add(&(H5I_mt_g.H5I__unwrap__times_global_mutex_unlocked_for_H5T), 1);
+
+        } else {
+
+            unwrapped_object = (void *)H5T_get_actual_type(dt);
+        }
+    }
+    else {
+
+        unwrapped_object = object;
+    }
+
+    *unwrapped_object_ptr = unwrapped_object;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__unwrap() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__unwrap
  *
@@ -243,6 +2103,9 @@ done:
  *              to an ID.
  *
  * Return:      Pointer to the unwrapped pointer (can't fail)
+ *
+ * Programmer:  Quincey Koziol
+ *              Friday, October 19, 2018
  *
  *-------------------------------------------------------------------------
  */
@@ -263,7 +2126,7 @@ H5I__unwrap(void *object, H5I_type_t type)
         const H5VL_object_t *vol_obj;
 
         vol_obj   = (const H5VL_object_t *)object;
-        ret_value = H5VL_object_data(vol_obj);
+        ret_value = H5VL_object_data(vol_obj); 
     }
     else if (H5I_DATATYPE == type) {
         H5T_t *dt = (H5T_t *)object;
@@ -276,6 +2139,10 @@ H5I__unwrap(void *object, H5I_type_t type)
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__unwrap() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_clear_type
  *
@@ -283,6 +2150,125 @@ H5I__unwrap(void *object, H5I_type_t type)
  *              function for each object regardless of the reference count.
  *
  * Return:      SUCCEED/FAIL
+ *
+ * Programmer:  Robb Matzke
+ *              Wednesday, March 24, 1999
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_clear_type(H5I_type_t type, hbool_t force, hbool_t app_ref)
+{
+    H5I_mt_clear_type_ud_t     udata; /* udata struct for callback */
+    H5I_mt_id_info_kernel_t    info_k;
+    H5I_mt_id_info_t          *id_info_ptr = NULL;
+    unsigned long long         id;
+    void                      *value;
+    herr_t                     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_clear_type() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Validate parameters */
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "invalid type number");
+
+    udata.type_info = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( ( udata.type_info == NULL ) || ( atomic_load(&(udata.type_info->init_count)) <= 0 ) )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, FAIL, "invalid type");
+
+    /* Finish constructing udata */
+    udata.force   = force;
+    udata.app_ref = app_ref;
+
+    /* Clearing a type is done in two phases (mark-and-sweep). This is because
+     * the type's free callback can free other IDs, potentially corrupting
+     * the data structure during the traversal.
+     */
+
+    /* Set marking flag */
+    atomic_fetch_add(&(H5I_mt_g.marking), 1);
+
+    /* Mark nodes for deletion */
+    if ( lfht_get_first(&(udata.type_info->lfht), &id, &value) ) {
+
+        do {
+            /* the single thread version of the code checks to see if the instance of 
+             * H5I_id_info_t returned by either lfht_get_first() or lfht_get_next() is 
+             * marked, and only calls H5I__mark_node() it it is not.  
+             *
+             * However, checking to see if *id_info_ptr is marked has become more expensive, 
+             * as we must do an atomic_load to obtain the kernel, and then read the marked field.
+             *
+             * Further, H5I__mark_node() has to check the marked field anyway in its 
+             * do-while loop.  Thus we now call H5I__mark_node() unconditionally.
+             *
+             * Recall that value is a pointer to H5I_id_info_t which has been cast to void *.
+             */
+            if (H5I__mark_node(value, NULL, (void *)&udata) < 0) {
+
+                HGOTO_ERROR(H5E_ID, H5E_BADITER, FAIL, "iteration failed while clearing the ID type");
+            }
+        } while (lfht_get_next(&(udata.type_info->lfht), id, &id, &value));
+    }
+
+    /* Unset marking flag */
+    atomic_fetch_sub(&(H5I_mt_g.marking), 1);
+    assert(atomic_load(&(H5I_mt_g.marking)) >= 0);
+
+    /* Perform sweep */
+    if ( lfht_get_first(&(udata.type_info->lfht), &id, &value) ) {
+
+        do {
+            id_info_ptr = (H5I_mt_id_info_t *)value;
+
+            info_k = atomic_load(&(id_info_ptr->k));
+
+            /* Only delete the id from the hash table if the marking flag is false and the id is marked
+             * for deletion.  Note that it is possible that another  thread will increment or decrement 
+             * H5I_mt_g.marking while this loop is running.  However, this should not matter since 
+             * marking an id for deletion is a one way process, and the operations will appear to have
+             * been executed in some order.
+             */
+            if ( ( ! atomic_load(&(H5I_mt_g.marking) ) && ( info_k.marked ) ) ) {
+
+                /* this delete may fail, as it is possible that another thread will have beaten 
+                 * us to the actual deletion of the entry from the lock free hash table.  Thus 
+                 * don't flag an error if lfht_delete() fails, but don't discard *id_info_ptr 
+                 * unless it succeeds.
+                 */
+                if ( lfht_delete(&(udata.type_info->lfht), id) ) {
+
+                    if ( H5I__discard_mt_id_info(id_info_ptr) < 0 )
+
+                        HGOTO_ERROR(H5E_ID, H5E_CANTFREE, FAIL, "Can't add id info to free list");
+                }
+            }
+        } while (lfht_get_next(&(udata.type_info->lfht), id, &id, &value));
+    }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5I_clear_type() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_clear_type
+ *
+ * Purpose:     Removes all objects from the type, calling the free
+ *              function for each object regardless of the reference count.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * Programmer:  Robb Matzke
+ *              Wednesday, March 24, 1999
  *
  *-------------------------------------------------------------------------
  */
@@ -340,6 +2326,508 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_clear_type() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__mark_node
+ *
+ * Purpose:     Attempts to mark the node for freeing and calls the free
+ *              function for the object, if any
+ *
+ *              Addendum 9/6/23:
+ *
+ *              A more detailed description of the action of this function
+ *              is necessary for the multi-thread conversion.  From reading 
+ *              the code of the single thread version, I get the following.
+ *
+ *              if udata->force is set, or 
+ *
+ *                 udata->app_ref is TRUE and info_ptr->count <= 1, or
+ *
+ *                 udata->app_ref is FALSE and 
+ *                  info_ptr->count - info_ptr->count <= 1
+ *
+ *              *info_ptr (the node in the original comment) is considered
+ *              for marking.
+ *
+ *              If an instance of *info_ptr is considered for marking, it 
+ *              will actually be marked if either:
+ *
+ *              1) info_ptr->is_future is TRUE, and either 
+ *                 (info_ptr->discard_cb)((void *)info->object) succeeds or
+ *                 udata->force is TRUE.
+ *
+ *              2) udata->type_info->cls->free_func is NULL, or either
+ *                 (udata->type_info->cls->free_func)((void *)info_ptr->object, 
+ *                 H5_REQUEST_NULL) succeeds or udata->force is TRUE.
+ *
+ *              Note that in both cases, the failed call to the discard_cb 
+ *              or free_func is ignored.  Further, if udata->force is false, 
+ *              *info_ptr with its possibly corrupted *object is left in 
+ *              the index.
+ *
+ *              This seems questionable to me, but since this is what the
+ *              single thread version of the code does, we will stay with
+ *              it for now.  Obviously, this decision should be revisited
+ *              once the prototype is up and running.
+ *
+ *                                                   -- JRM
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * Programmer:  Neil Fortner
+ *              Friday, July 10, 2015
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
+{
+    hbool_t                 is_candidate;
+    hbool_t                 cant_roll_back;
+    hbool_t                 do_not_disturb_set;
+    hbool_t                 mark;
+    hbool_t                 done = FALSE;
+    hbool_t                 have_global_mutex = TRUE; /*trivially so for single thread builds */
+    hbool_t                 cls_is_mt_safe;
+    int                     pass = 0;
+    H5I_mt_id_info_kernel_t info_k;
+    H5I_mt_id_info_kernel_t mod_info_k;
+    H5I_mt_id_info_t       *id_info_ptr  = (H5I_mt_id_info_t *)_info;        /* Current ID info being worked with */
+    H5I_mt_clear_type_ud_t *udata        = (H5I_mt_clear_type_ud_t *)_udata; /* udata struct */
+    herr_t                  result;
+    herr_t                  ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__mark_node() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity checks */
+    assert(id_info_ptr);
+    assert(udata);
+    assert(udata->type_info);
+
+    atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__num_calls), 1ULL);
+
+    cls_is_mt_safe = ((udata->type_info->cls->flags & H5I_CLASS_IS_MT_SAFE) != 0);
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+
+    if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
+
+        HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "Can't determine whether we have the global mutex");
+        
+#endif /* defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD) */
+
+    if ( have_global_mutex ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__num_calls_with_global_mutex), 1ULL);
+
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__num_calls_without_global_mutex), 1ULL);
+    }
+
+    do {
+
+        /* If another thread modified id_info_ptr-k while we are preparing our modified copy,
+         * or if we need to set the do not disturb flag to prevent simultaneous calls to 
+         * the future id discard_cb callback or the regular id free_func, we will have to 
+         * re-run this do-while loop.  Since we start each pass fresh, start by reseting 
+         * all the flags to their initial values.
+         */
+        is_candidate       = FALSE;
+        cant_roll_back     = FALSE;
+        do_not_disturb_set = FALSE;
+        mark               = FALSE;
+
+        /* increment the pass and log retries */
+        if ( pass++ >= 1 ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__retries), 1ULL);
+        }
+
+        /* load the atomic kernel from *id_info_ptr into info_k.  Note that this is a snapshot of the 
+         * state of *id_info_ptr, and can be changed before we get to writing it back.
+         */
+        info_k = atomic_load(&(id_info_ptr->k));
+
+        if ( info_k.marked ) {
+
+            /* this is is already marked for deletion -- nothing to do here */
+
+            /* update stats */
+            if ( pass <= 1 ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__already_marked), 1ULL);
+
+            } else {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__marked_by_another_thread), 1ULL);
+            }
+            break;
+        }
+
+        if ( info_k.do_not_disturb ) {
+
+            /* Another thread is in the process of performing an operation on the info kernel
+             * that can't be rolled back -- either a future id realize_cb or discard_cb, or a 
+             * regular id free_func.  
+             *
+             * Thus we must wait until that thread is done and then re-start the operation -- which
+             * may be moot by that point.
+             */
+
+            /* update stats */
+            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+            /* need to do better than this.  Want to call pthread_yield(),
+             * but that call doesn't seem to be supported anymore.
+             */
+            sleep(1);
+
+            continue;
+        }
+
+        if ( ( udata->force ) || ( (info_k.count - ((!udata->app_ref) * info_k.app_count)) <= 1 ) ) {
+
+            is_candidate = TRUE;
+
+            if ( ( info_k.is_future ) || ( udata->type_info->cls->free_func ) ) {
+
+                cant_roll_back = TRUE;
+            }
+        }
+
+        if ( ! is_candidate ) {
+
+            /* we have nothing to do -- just break out of the while loop */
+
+            /* update stats */
+            atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__no_ops), 1ULL);
+
+            break;
+        }
+
+        if ( cant_roll_back ) {
+
+            mod_info_k.count             = info_k.count;
+            mod_info_k.app_count         = info_k.app_count;
+            mod_info_k.object            = info_k.object;
+
+            mod_info_k.marked            = info_k.marked;
+            mod_info_k.do_not_disturb    = TRUE;
+            mod_info_k.is_future         = info_k.is_future;
+            mod_info_k.have_global_mutex = have_global_mutex;
+
+            /* We don't want multiple threads trying to either realize or dispose of the 
+             * data associated with the future id or trying to free the data associated 
+             * with a regular id at the same time.
+             *
+             * To serialize such actions, we will attempt to set the do not disturb
+             * flag.  If successful, this will prevent any other threads from modifying 
+             * id_info_ptr->k until after it is set back to FALSE.
+             */
+            if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k ) ) {
+
+                /* Some other thread changed the value of id_info_ptr->k since we last read
+                 * it.  Thus we must return to the beginning of the do loop and start 
+                 * again.  Note that it is possible that by that time, there will be 
+                 * nothing left to do.
+                 */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_failed_do_not_disturb_sets), 1ULL);
+
+                continue;
+
+            } else {
+
+                do_not_disturb_set = TRUE;
+
+#if 0 /* JRM */
+                /* make info_k into a copy of the global kernel */
+                info_k.do_not_disturb = TRUE;
+#else /* JTM */
+                /* On the face of it, it would seem that we could just update info_k
+                 * to match mod_info_k, and use it in the next atomic_compare_exchange_strong()
+                 * call.  However, for reason or reasons unknown, this doesn't work.
+                 *
+                 * Instead, we reload info_k after the atomic_compare_exchange_strong(),
+                 * and verify that it contains the expected values.
+                 */
+                info_k = atomic_load(&(id_info_ptr->k));
+
+                assert(info_k.count             == mod_info_k.count);
+                assert(info_k.app_count         == mod_info_k.app_count);
+                assert(info_k.object            == mod_info_k.object);
+
+                assert(info_k.marked            == mod_info_k.marked);
+                assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
+                assert(info_k.is_future         == mod_info_k.is_future);
+                assert(info_k.have_global_mutex == mod_info_k.have_global_mutex);
+#endif /* JRM */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_successful_do_not_disturb_sets), 1ULL);
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+                fprintf(stdout, "H5I__mark_node() set do not disturb on id = 0x%llx.\n",
+                          (unsigned long long)(id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+            }
+        }
+
+        assert( ( do_not_disturb_set ) || ( ! cant_roll_back ) );
+
+        if ( info_k.is_future ) {
+
+            assert(do_not_disturb_set);
+
+            /* Discard the future object */
+            if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_discard_cb), 1ULL);
+                H5_API_LOCK
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                result = (id_info_ptr->discard_cb)((void *)info_k.object);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+                H5_API_UNLOCK
+                atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_discard_cb), 1ULL);
+
+            } else {
+
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                result = (id_info_ptr->discard_cb)((void *)info_k.object);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+            }
+
+            if ( result < 0 ) {
+
+                /* discard_cb has failed -- ignore the failure -- but update stats below*/
+
+                if (udata->force) {
+
+                    /* if the force flag is set, mark the *id_info_ptr for deletion */
+#ifdef H5I_DEBUG
+                    if (H5DEBUG(I)) {
+                        fprintf(H5DEBUG(I),
+                                  "H5I: discard type=%d obj=0x%08lx "
+                                  "failure ignored\n",
+                                  (int)udata->type_info->cls->type, (unsigned long)(info_k.object));
+                    }
+#endif /* H5I_DEBUG */
+
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_marked), 1ULL);
+
+                    /* Indicate node should be removed from list */
+                    mark = TRUE;
+
+                } else {
+
+                    /* If the force flag is not set, we leave *info_ptr alone and don't mark it 
+                     * for deletion.  
+                     *
+                     * This seems questionable to me, since now info_ptr->object is potentially 
+                     * corrupted.  However, that is what the single thread code does, so keep 
+                     * it that way for now.  Obviously, this decision should be reviewed once 
+                     * we have the prototype up and running.
+                     *                                                JRM -- 9/8/23
+                     */
+                    atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__discard_cb_failures_unmarked), 1ULL);
+                }
+            }
+            else { /* discard_cb succeeded */
+                
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__discard_cb_successes), 1ULL);
+
+                /* Indicate node should be removed from list */
+                mark = TRUE;
+            }
+        }
+        else { /* it is a regular ID */
+
+            /* Check for a 'free' function and call it, if it exists */
+            if ( udata->type_info->cls->free_func ) {
+
+                assert(do_not_disturb_set);
+
+                if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_locks_for_free_func), 1ULL);
+                    H5_API_LOCK
+                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                    result = (udata->type_info->cls->free_func)((void *)info_k.object, H5_REQUEST_NULL);
+                    H5_GCC_CLANG_DIAG_ON("cast-qual")
+                    H5_API_UNLOCK
+                    atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__global_mutex_unlocks_for_free_func), 1ULL);
+
+                } else {
+
+                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                    result = (udata->type_info->cls->free_func)((void *)info_k.object, H5_REQUEST_NULL);
+                    H5_GCC_CLANG_DIAG_ON("cast-qual")
+                }
+
+                if ( result < 0 ) {
+
+                    /* the free function failed */
+
+#if 0 /* JRM */
+                    fprintf(stdout, "H5I__mark_node(): The free function failed.\n");
+#endif /* JRM */
+
+                    if (udata->force) {
+#ifdef H5I_DEBUG
+                        if (H5DEBUG(I)) {
+                            fprintf(H5DEBUG(I),
+                                      "H5I: free type=%d obj=0x%08lx "
+                                      "failure ignored\n",
+                                      (int)udata->type_info->cls->type, (unsigned long)(info_k.object));
+                        }
+#endif /* H5I_DEBUG */
+
+                        /* update stats */
+                        atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__free_func_failures_marked), 1ULL);
+
+                        /* Indicate node should be removed from list */
+                        mark = TRUE;
+
+                    } else {
+
+                        /* If the force flag is not set, we leave *info_ptr alone and don't mark it 
+                         * for deletion.  
+                         *
+                         * This seems questionable to me, since now info_ptr->object is potentially 
+                         * corrupted.  However, that is what the single thread code does, so keep 
+                         * it that way for now.  Obviously, this decision should be reviewed once 
+                         * we have the prototype up and running.
+                         *                                                JRM -- 9/8/23
+                         */
+                        atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__free_func_failures_unmarked), 1ULL);
+                    }
+                }
+                else { /* free function succeeded */
+
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__free_func_successes), 1ULL);
+
+                    /* Indicate node should be removed from list */
+                    mark = TRUE;
+#if 0 /* JRM */
+                    fprintf(stdout, "H5I__mark_node(): The free function succeeded -- mark = %d.\n", (int)mark);
+#endif /* JRM */
+                }
+            }
+        }
+
+        if ( ( mark ) || ( do_not_disturb_set ) ) {
+
+            /* If we have set marked to TRUE, or if we have set the do_not_disturb flag, we 
+             * must attempt to replace the current value of info_ptr->k with our modified 
+             * version.
+             *
+             * First setup mod_info_k.  The only fields we will touch are do_not_disturb
+             * and / or marked.  All other value are drawn from info_k that we read at the
+             * top of the do/while loop.
+             *
+             * If mark == TRUE, set mod_info_k.count and mod_info_k.app_count to zero, and 
+             * set info_k.object to FALSE. Similarly, set info_k.is_future to FALSE.  Do this
+             * because the instance of H5I_mt_id_info_t and its associated id are effectively
+             * deleted as soon as id_info_ptr->k.marked is set to TRUE.
+             */
+            if ( mark ) {
+
+                mod_info_k.count             = 0;
+                mod_info_k.app_count         = 0;
+                mod_info_k.object            = NULL;
+
+                mod_info_k.marked            = TRUE;
+                mod_info_k.do_not_disturb    = FALSE;  
+                mod_info_k.is_future         = FALSE;
+                mod_info_k.have_global_mutex = FALSE;
+
+            } else {
+
+                mod_info_k.count             = info_k.count;
+                mod_info_k.app_count         = info_k.app_count;
+                mod_info_k.object            = info_k.object;
+
+                mod_info_k.marked            = info_k.marked;
+                mod_info_k.do_not_disturb    = FALSE;  
+                mod_info_k.is_future         = info_k.is_future;
+                mod_info_k.have_global_mutex = FALSE;
+            }
+
+            /* now attempt to overwrite the value of info_ptr->k.  If do_not_disturb_set is TRUE,
+             * this must succeed -- hence we do it in an assert.  If do_not_disturb_set is FALSE,
+             * it may or may not succeed.  On success we set done to TRUE.  Otherwise, some other 
+             * therad has modified id_info_ptr->k since we read it, and we must try again.
+             */
+            if ( do_not_disturb_set ) {
+
+                assert( info_k.do_not_disturb );
+                assert( ! mod_info_k.do_not_disturb );
+
+                assert(atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k));
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+
+                 done = TRUE;
+
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+                fprintf(stdout, "H5I__mark_node() reset do not disturb on id = 0x%llx.\n",
+                          (unsigned long long)(id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+        
+            } else if ( atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+
+                /* no need to update update stats here -- will increment H5I_mt_g.H5I__mark_node__marked
+                 * after we exit the do/while loop
+                 */
+
+                done = TRUE;
+
+            } else {
+
+                /* the atomic compare exchange strong failed -- try again */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__retries), 1ULL);
+            }
+        } else {
+
+            /* no action required -- just set done to TRUE */
+
+            /* update stats */
+
+            done = TRUE;
+        }
+    } while ( ! done );
+
+    if ( mark ) {
+
+        /* update stats */
+        atomic_fetch_add(&(H5I_mt_g.H5I__mark_node__marked), 1ULL);
+
+        /* Decrement the number of IDs in the type */
+        atomic_fetch_sub(&(udata->type_info->id_count), 1);
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__mark_node() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__mark_node
  *
@@ -347,6 +2835,9 @@ done:
  *              function for the object, if any
  *
  * Return:      SUCCEED/FAIL
+ *
+ * Programmer:  Neil Fortner
+ *              Friday, July 10, 2015
  *
  *-------------------------------------------------------------------------
  */
@@ -377,9 +2868,9 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 #ifdef H5I_DEBUG
                     if (H5DEBUG(I)) {
                         fprintf(H5DEBUG(I),
-                                "H5I: discard type=%d obj=%p "
-                                "failure ignored\n",
-                                (int)udata->type_info->cls->type, info->object);
+                                  "H5I: discard type=%d obj=0x%08lx "
+                                  "failure ignored\n",
+                                  (int)udata->type_info->cls->type, (unsigned long)(info->object));
                     }
 #endif /* H5I_DEBUG */
 
@@ -400,9 +2891,9 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
 #ifdef H5I_DEBUG
                     if (H5DEBUG(I)) {
                         fprintf(H5DEBUG(I),
-                                "H5I: free type=%d obj=%p "
-                                "failure ignored\n",
-                                (int)udata->type_info->cls->type, info->object);
+                                  "H5I: free type=%d obj=0x%08lx "
+                                  "failure ignored\n",
+                                  (int)udata->type_info->cls->type, (unsigned long)(info->object));
                     }
 #endif /* H5I_DEBUG */
 
@@ -430,6 +2921,10 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5I__mark_node() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__destroy_type
  *
@@ -439,6 +2934,79 @@ H5I__mark_node(void *_info, void H5_ATTR_UNUSED *key, void *_udata)
  *              then adding the ID struct to the ID free list.
  *
  * Return:      SUCCEED/FAIL
+ *
+ * Programmer:  Nathaniel Furrer
+ *              James Laird
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I__destroy_type(H5I_type_t type)
+{
+    hbool_t             expected  = TRUE;
+    H5I_mt_type_info_t *type_info_ptr = NULL;    /* Pointer to the ID type */
+    herr_t              ret_value = SUCCEED;     /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_destroy_type() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Validate parameter */
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "invalid type number");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+    
+    if (type_info_ptr == NULL || atomic_load(&(type_info_ptr->init_count)) <= 0)
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, FAIL, "invalid type");
+
+    /* Close/clear/destroy all IDs for this type */
+    H5E_BEGIN_TRY
+    {
+        H5I_clear_type(type, TRUE, FALSE);
+    }
+    H5E_END_TRY /* don't care about errors */
+
+    /* Check if we should release the ID class */
+    if (type_info_ptr->cls->flags & H5I_CLASS_IS_APPLICATION)
+        type_info_ptr->cls = H5MM_xfree_const(type_info_ptr->cls);
+
+    atomic_store(&(type_info_ptr->init_count), 0);
+
+    lfht_clear(&(type_info_ptr->lfht));
+
+    atomic_store(&(type_info_ptr->lfht_cleared), TRUE);
+
+    assert(atomic_compare_exchange_strong(&(H5I_mt_g.type_info_array[type]), &type_info_ptr, NULL));
+    assert(atomic_compare_exchange_strong(&(H5I_mt_g.type_info_allocation_table[type]), &expected, FALSE));
+
+#if 1 /* JRM */
+    H5I__discard_mt_type_info(type_info_ptr);
+    type_info_ptr = NULL;
+#else /* JRM */
+    type_info_ptr = H5MM_xfree(type_info_ptr); /************************************* need a free list here */
+#endif /* JRM */
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5I__destroy_type() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__destroy_type
+ *
+ * Purpose:     Destroys a type along with all IDs in that type
+ *              regardless of their reference counts. Destroying IDs
+ *              involves calling the free-func for each ID's object and
+ *              then adding the ID struct to the ID free list.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * Programmer:  Nathaniel Furrer
+ *              James Laird
  *
  *-------------------------------------------------------------------------
  */
@@ -465,11 +3033,12 @@ H5I__destroy_type(H5I_type_t type)
     }
     H5E_END_TRY /* don't care about errors */
 
-    /* Check if we should release the ID class */
-    if (type_info->cls->flags & H5I_CLASS_IS_APPLICATION)
-        type_info->cls = H5MM_xfree_const(type_info->cls);
+        /* Check if we should release the ID class */
+        if (type_info->cls->flags & H5I_CLASS_IS_APPLICATION)
+            type_info->cls = H5MM_xfree_const(type_info->cls);
 
     HASH_CLEAR(hh, type_info->hash_table);
+
     type_info->hash_table = NULL;
 
     type_info = H5MM_xfree(type_info);
@@ -479,6 +3048,108 @@ H5I__destroy_type(H5I_type_t type)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__destroy_type() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__register
+ *
+ * Purpose:     Registers an OBJECT in a TYPE and returns an ID for it.
+ *              This routine does _not_ check for unique-ness of the objects,
+ *              if you register an object twice, you will get two different
+ *              IDs for it.  This routine does make certain that each ID in a
+ *              type is unique.  IDs are created by getting a unique number
+ *              for the type the ID is in and incorporating the TYPE into
+ *              the ID which is returned to the user.
+ *
+ *              IDs are marked as "future" if the realize_cb and discard_cb
+ *              parameters are non-NULL.
+ *
+ * Return:      Success:    New object ID
+ *              Failure:    H5I_INVALID_HID
+ *
+ *-------------------------------------------------------------------------
+ */
+hid_t
+H5I__register(H5I_type_t type, const void *object, hbool_t app_ref, H5I_future_realize_func_t realize_cb,
+              H5I_future_discard_func_t discard_cb)
+{
+    H5I_mt_type_info_t *type_info_ptr = NULL;            /* Pointer to the type */
+    H5I_mt_id_info_t   *id_info_ptr   = NULL;            /* Pointer to the new ID information */
+    hid_t               new_id        = H5I_INVALID_HID; /* New ID */
+    hid_t               ret_value     = H5I_INVALID_HID; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__register() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Check arguments */
+    if ( ( type <= H5I_BADID ) || ( (int)type >= atomic_load(&(H5I_mt_g.next_type)) ) )
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, H5I_INVALID_HID, "invalid type number");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( ( NULL == type_info_ptr ) || ( atomic_load(&(type_info_ptr->init_count)) <= 0 ) )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, H5I_INVALID_HID, "invalid type");
+
+    new_id = H5I_MAKE(type, atomic_fetch_add(&(type_info_ptr->nextid), 1ULL));
+
+    /* strictly speaking there is a race condition here, but it doesn't matter which thread 
+     * incremented nextid beyond its limit as long as we catch it.
+     */
+    assert(atomic_load(&(type_info_ptr->nextid)) <= ID_MASK); 
+
+    id_info_ptr = H5I__new_mt_id_info(new_id, 1, !!app_ref, object, 
+                                      (NULL != realize_cb), realize_cb, discard_cb);
+
+    if ( NULL == id_info_ptr )
+
+        HGOTO_ERROR(H5E_ID, H5E_NOSPACE, H5I_INVALID_HID, "allocation and init of new H5I_mt_type_info_t failed");
+
+    /* Note that the insertion if the new ID is not completely atomic -- as we have three 
+     * operations:
+     *
+     * 1) increment type_info_ptr->id_count.
+     *
+     * 2) insert into the lock free hash table.
+     *
+     * 3) set type_info_ptr->last_id_info.
+     *
+     * At present, these actions are performed in the above order.  
+     *
+     * The rational for incrementing the id_count first is that it will keep the index from 
+     * being closed in some corner cases.
+     *
+     * I can't make a strong arguement for either ordering of the second two items, so please
+     * view it as arbitrary until we come up with an argument to the contrary.
+     */
+
+    /* increment the id_count */
+    atomic_fetch_add(&(type_info_ptr->id_count), 1ULL);
+
+    /* Insert into the lock free hash table */
+    /* todo -- make this throw and error */
+    assert(lfht_add(&(type_info_ptr->lfht), (unsigned long long int)new_id, (void *)id_info_ptr));
+
+    /* Set the most recent ID to this object */
+    atomic_store(&(type_info_ptr->last_id_info), id_info_ptr);
+
+    /* Set return value */
+    ret_value = new_id;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__register() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I__register
@@ -532,6 +3203,7 @@ H5I__register(H5I_type_t type, const void *object, hbool_t app_ref, H5I_future_r
 
     /* Insert into the type */
     HASH_ADD(hh, type_info->hash_table, id, sizeof(hid_t), info);
+
     type_info->id_count++;
     type_info->nextid++;
 
@@ -548,10 +3220,14 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__register() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_register
  *
  * Purpose:     Library-private wrapper for H5I__register.
+ *
+ *              No changes required for multi-thread.
  *
  * Return:      Success:    New object ID
  *              Failure:    H5I_INVALID_HID
@@ -565,6 +3241,13 @@ H5I_register(H5I_type_t type, const void *object, hbool_t app_ref)
 
     FUNC_ENTER_NOAPI(H5I_INVALID_HID)
 
+#if H5_HAVE_MULTITHREAD 
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_register(type = %d, object = 0x%llx, app_ref = %d) called. \n", 
+              (int)type, (unsigned long long)object, (int)app_ref);
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
+
     /* Sanity checks */
     assert(type >= H5I_FILE && type < H5I_NTYPES);
     assert(object);
@@ -574,8 +3257,169 @@ H5I_register(H5I_type_t type, const void *object, hbool_t app_ref)
         HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register object");
 
 done:
+
+#if H5_HAVE_MULTITHREAD 
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_register(type = %d, object = 0x%llx, app_ref = %d) returns %llx. \n", 
+              (int)type, (unsigned long long)object, (int)app_ref, (unsigned long long)ret_value);
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
+
     FUNC_LEAVE_NOAPI(ret_value)
+
 } /* end H5I_register() */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_register_using_existing_id
+ *
+ * Purpose:     Registers an OBJECT in a TYPE with the supplied ID for it.
+ *              This routine will check to ensure the supplied ID is not already
+ *              in use, and ensure that it is a valid ID for the given type,
+ *              but will NOT check to ensure the OBJECT is not already
+ *              registered (thus, it is possible to register one object under
+ *              multiple IDs).
+ *
+ *              Re-worked for multi-thread.
+ *
+ * NOTE:        Intended for use in refresh calls, where we have to close
+ *              and re-open the underlying data, then hook the object back
+ *              up to the original ID.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_register_using_existing_id(H5I_type_t type, void *object, hbool_t app_ref, hid_t existing_id)
+{
+    H5I_mt_id_info_kernel_t info_k;
+    H5I_mt_type_info_t     *type_info_ptr    = NULL;    /* Pointer to the type */
+    H5I_mt_id_info_t       *old_id_info_ptr  = NULL;    /* Pointer to the old ID information */
+    H5I_mt_id_info_t       *new_id_info_ptr  = NULL;    /* Pointer to the new ID information */
+    herr_t                  ret_value        = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_register_using_existing_id() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    atomic_fetch_add(&(H5I_mt_g.H5I_register_using_existing_id__num_calls), 1ULL);
+
+    /* Check arguments */
+    assert(object);
+
+    /* Make sure ID is not already in use.
+     *
+     * Because of the H5I_mt_g.marking flag, it is possible that an entry with the specified ID
+     * will exist in the lock free hash table, but be marked as deleted.
+     *
+     * This couldn't happen in the single thread version, but it becomes possible in multi-thread.
+     *
+     * The correct solution is probably to get rid of the H5I_mt_g.marking flag -- however that
+     * doesn't seem prudent until the initial version is up and running, and I have a good 
+     * understanding of why the mark and sweep approach was thought necessary.
+     *
+     * Thus, at present, it seems best to code around the issue, and be able to handle IDs that 
+     * are still in the index but are marked as deleted.
+     */
+    if (NULL != (old_id_info_ptr = H5I__find_id(existing_id))) {
+
+        info_k = atomic_load(&(old_id_info_ptr->k));
+
+        if ( info_k.marked ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I_register_using_existing_id__num_marked_only), 1ULL);
+
+        } else {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I_register_using_existing_id__num_id_already_in_use), 1ULL);
+            HGOTO_ERROR(H5E_ID, H5E_BADRANGE, FAIL, "ID already in use");
+        }
+    }
+
+    /* Make sure type number is valid */
+    if ( ( type <= H5I_BADID ) || ( (int)type >= atomic_load(&(H5I_mt_g.next_type)) ) )
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "invalid type number");
+
+    /* Get type pointer from list of types */
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( ( NULL == type_info_ptr ) || ( atomic_load(&(type_info_ptr->init_count)) <= 0 ) )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, FAIL, "invalid type");
+
+    /* Make sure requested ID belongs to object's type */
+    if ( H5I_TYPE(existing_id) != type )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADRANGE, FAIL, "invalid type for provided ID");
+
+    /* This API call is only used by the native VOL connector, which is not 
+     * asynchronous -- for now at least.
+     *
+     * Hence is_future is FALSE, and both realize_cb and discard_cb are NULL
+     */
+    new_id_info_ptr = H5I__new_mt_id_info(existing_id, 1, !!app_ref, object, FALSE, NULL, NULL);
+
+    if ( ! new_id_info_ptr )
+
+        HGOTO_ERROR(H5E_ID, H5E_NOSPACE, FAIL, "memory allocation and init of new id info failed");
+
+    /* Now insert the ID into the index.  The H5I_mt_g.marking flag makes this more 
+     * painful than it should be as it is possible that the id info for the existing ID
+     * has only been marked for deletion, but not actually deleted from the lock free hash
+     * table.  To make things more interesting, in the multi-thread case, it is possible that
+     * another thread has beaten us to the insertion.
+     *
+     * Supposedly, this API call is used only by the native VOL.  If so, this latter item
+     * is not an issue until the relevant portions of the native VOL are made multi-thread.
+     *
+     * Thus for now, it should be sufficient to delete the marked ID info from the lock free 
+     * hash table before inserting the new ID info.  However, for the long term, we need 
+     * a compare and swap call for the lock free hash table instead of the existing 
+     * unconditional swap value call.
+     *
+     * In the absence of the compare and swap for the lock free hash table, we will 
+     * simply try to delete the existing ID from the lock free hash table, and then 
+     * insert the new id info with the same ID.
+     *
+     * Note that the delete from the hash table may fail, as it is possible that some
+     * other thread will have swept the marked IDs in the time since we looked it up.
+     */
+    if ( old_id_info_ptr ) {
+
+        /* no point in checking the return value here, as it is possible 
+         * that another thread has deleted the lock free hash table entry
+         * in the time since we looked up the old_id_info_ptr.
+         *
+         * As discussed above, this really should be a compare and swap, 
+         * but is should be safe for now.
+         */
+        lfht_delete(&(type_info_ptr->lfht), (unsigned long long)existing_id);
+    } 
+
+    /* return an error on failure here */
+    assert(lfht_add(&(type_info_ptr->lfht), (unsigned long long int)existing_id, (void *)new_id_info_ptr));
+     
+    atomic_fetch_add(&(type_info_ptr->id_count), 1);
+
+    atomic_store(&(type_info_ptr->last_id_info), new_id_info_ptr);
+
+done:
+
+    if ( FAIL == ret_value ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I_register_using_existing_id__num_failures), 1ULL);
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_register_using_existing_id() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_register_using_existing_id
@@ -643,7 +3487,12 @@ H5I_register_using_existing_id(H5I_type_t type, void *object, hbool_t app_ref, h
     info->marked     = FALSE;
 
     /* Insert into the type */
+#if H5_HAVE_MULTITHREAD
+    /* todo -- make this throw an error */
+    assert(lfht_add(&(type_info->lfht), (unsigned long long int)existing_id, (void *)info));
+#else /* H5_HAVE_MULTITHREAD */
     HASH_ADD(hh, type_info->hash_table, id, sizeof(hid_t), info);
+#endif /* H5_HAVE_MULTITHREAD */
     type_info->id_count++;
 
     /* Set the most recent ID to this object */
@@ -653,6 +3502,142 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_register_using_existing_id() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_subst
+ *
+ * Purpose:     Substitute a new object pointer for the specified ID.
+ *
+ *              Re-written for multi-thread.
+ *
+ * Return:      Success:    Non-NULL previous object pointer associated
+ *                          with the specified ID.
+ *              Failure:    NULL
+ *
+ * Programmer:  Quincey Koziol
+ *              Saturday, February 27, 2010
+ *
+ *-------------------------------------------------------------------------
+ */
+void *
+H5I_subst(hid_t id, const void *new_object)
+{
+    hbool_t                 done = FALSE;
+    int                     pass = 0;
+    H5I_mt_id_info_kernel_t info_k;
+    H5I_mt_id_info_kernel_t mod_info_k;
+    H5I_mt_id_info_t       *id_info_ptr  = NULL; /* Pointer to the ID's info */
+    const void             *old_object;
+    void                   *ret_value = NULL; /* Return value */
+
+    FUNC_ENTER_NOAPI(NULL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_subst() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    atomic_fetch_add(&(H5I_mt_g.H5I_subst__num_calls), 1ULL);
+
+    do {
+
+        id_info_ptr = NULL;
+        old_object = NULL;
+
+        /* increment the pass and log retries */
+        if ( pass++ >= 1 ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I_subst__retries), 1ULL);
+        }
+
+        if ( NULL == (id_info_ptr = H5I__find_id(id)) )
+
+            HGOTO_ERROR(H5E_ID, H5E_NOTFOUND, NULL, "can't find ID");
+
+        info_k = atomic_load(&(id_info_ptr->k));
+
+        if ( info_k.marked ) {
+
+            /* this is is already marked for deletion -- nothing to do here */
+
+            /* update stats */
+            if ( pass <= 1 ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I_subst__marked_on_entry), 1ULL);
+
+            } else {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I_subst__marked_during_call), 1ULL);
+            }
+            break;
+        }
+
+        if ( info_k.do_not_disturb ) {
+
+            /* Another thread is in the process of performing an operation on the info kernel
+             * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+             * regular id free_func.
+             *
+             * Thus we must wait until that thread is done and then re-start the operation -- which
+             * may be moot by that point.
+             */
+
+            /* update stats */
+            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+            /* need to do better than this.  Want to call pthread_yield(),
+             * but that call doesn't seem to be supported anymore.
+             */
+            sleep(1);
+
+            continue;
+        }
+
+        old_object = info_k.object;
+
+        /* setup the modified version of the id info kernel */
+        mod_info_k.count          = info_k.count;
+        mod_info_k.app_count      = info_k.app_count;
+        mod_info_k.object         = new_object;
+
+        mod_info_k.marked         = info_k.marked;;
+        mod_info_k.do_not_disturb = info_k.do_not_disturb;;
+        mod_info_k.is_future      = info_k.is_future;
+
+        mod_info_k.object = new_object;
+
+        if ( atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+
+            done = TRUE;
+
+        } else {
+
+            /* the atomic compare exchange strong failed -- try again */
+
+        }
+    } while ( ! done );
+
+    if ( done ) {
+
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        ret_value = (void *)old_object;
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I_subst__failures), 1ULL);
+    } 
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_subst() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_subst
  *
@@ -661,6 +3646,9 @@ done:
  * Return:      Success:    Non-NULL previous object pointer associated
  *                          with the specified ID.
  *              Failure:    NULL
+ *
+ * Programmer:  Quincey Koziol
+ *              Saturday, February 27, 2010
  *
  *-------------------------------------------------------------------------
  */
@@ -687,6 +3675,60 @@ H5I_subst(hid_t id, const void *new_object)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_subst() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_object
+ *
+ * Purpose:     Find an object pointer for the specified ID.
+ *
+ *              Modified for multi-thread.
+ *
+ * Return:      Success:    Non-NULL object pointer associated with the
+ *                          specified ID
+ *
+ *              Failure:    NULL
+ *
+ *-------------------------------------------------------------------------
+ */
+void *
+H5I_object(hid_t id)
+{
+    H5I_mt_id_info_kernel_t info_k;
+    H5I_mt_id_info_t       *info_ptr      = NULL; /* Pointer to the ID info */
+    void                   *ret_value = NULL; /* Return value */
+
+    FUNC_ENTER_NOAPI_NOERR
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_object(0x%llx) called. \n", (unsigned long long)id);
+#endif /* H5I_MT_DEBUG */
+
+    /* General lookup of the ID */
+    if (NULL != (info_ptr = H5I__find_id(id))) {
+
+        /* Get the object pointer to return */
+
+        info_k = atomic_load(&(info_ptr->k));
+
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        ret_value = (void *)info_k.object;
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+    }
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_object(0x%llx) returns 0x%llx. \n", 
+              (unsigned long long)id, (unsigned long long)ret_value);
+#endif /* H5I_MT_DEBUG */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_object() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_object
@@ -719,6 +3761,66 @@ H5I_object(hid_t id)
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_object() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_object_verify
+ *
+ * Purpose:     Find an object pointer for the specified ID, verifying that
+ *              its in a particular type.
+ *
+ *              Updated for multi-thread.
+ *
+ * Return:      Success:    Non-NULL object pointer associated with the
+ *                          specified ID.
+ *              Failure:    NULL
+ *
+ * Programmer:  Quincey Koziol
+ *              Wednesday, July 31, 2002
+ *
+ *-------------------------------------------------------------------------
+ */
+void *
+H5I_object_verify(hid_t id, H5I_type_t type)
+{
+    H5I_mt_id_info_kernel_t  info_k;
+    H5I_mt_id_info_t        *info_ptr      = NULL; /* Pointer to the ID info */
+    void                    *ret_value     = NULL; /* Return value */
+
+    FUNC_ENTER_NOAPI_NOERR
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_object_verify(id = 0x%llx, type = %d) called. \n", 
+              (unsigned long long)id, (int)type);
+#endif /* H5I_MT_DEBUG */
+
+    assert( ( type >= 1 ) && ( (int)type < atomic_load(&(H5I_mt_g.next_type)) ) );
+
+    /* Verify that the type of the ID is correct & lookup the ID */
+    if ( ( type == H5I_TYPE(id) ) && ( NULL != (info_ptr = H5I__find_id(id)) ) ) {
+
+        /* Get the object pointer to return */
+
+        info_k = atomic_load(&(info_ptr->k));
+
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        ret_value = (void *)info_k.object;
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+    }
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_object_verify(id = 0x%llx, type = %d) returns 0x%llx. \n", 
+              (unsigned long long)id, (int)type, (unsigned long long)ret_value);
+#endif /* H5I_MT_DEBUG */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I_object_verify() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_object_verify
  *
@@ -728,6 +3830,9 @@ H5I_object(hid_t id)
  * Return:      Success:    Non-NULL object pointer associated with the
  *                          specified ID.
  *              Failure:    NULL
+ *
+ * Programmer:  Quincey Koziol
+ *              Wednesday, July 31, 2002
  *
  *-------------------------------------------------------------------------
  */
@@ -752,6 +3857,8 @@ H5I_object_verify(hid_t id, H5I_type_t type)
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5I_object_verify() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_get_type
  *
@@ -765,6 +3872,9 @@ H5I_object_verify(hid_t id, H5I_type_t type)
  *                          ID types).
  *              Failure:    H5I_BADID
  *
+ * Programmer:  Robb Matzke
+ *              Friday, February 19, 1999
+ *
  *-------------------------------------------------------------------------
  */
 H5I_type_t
@@ -774,13 +3884,147 @@ H5I_get_type(hid_t id)
 
     FUNC_ENTER_NOAPI_NOERR
 
+#if H5_HAVE_MULTITHREAD 
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_get_type() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
+
     if (id > 0)
         ret_value = H5I_TYPE(id);
 
+#if H5_HAVE_MULTITHREAD 
+    assert(ret_value >= H5I_BADID && (int)ret_value < H5I_mt_g.next_type);
+#else /* H5_HAVE_MULTITHREAD */
     assert(ret_value >= H5I_BADID && (int)ret_value < H5I_next_type_g);
+#endif /* H5_HAVE_MULTITHREAD */
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_get_type() */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_is_file_object
+ *
+ * Purpose:     Convenience function to determine if an ID represents
+ *              a file object.
+ *
+ *              In H5O calls, you can't use object_verify to ensure
+ *              the ID was of the correct class since there's no
+ *              H5I_OBJECT ID class.
+ *
+ *              Updated for multi-thread.
+ *
+ * Return:      Success:    TRUE/FALSE
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+htri_t
+H5I_is_file_object(hid_t id)
+{
+    H5I_type_t          type      = H5I_get_type(id);
+    htri_t              ret_value = FAIL;
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    atomic_fetch_add(&(H5I_mt_g.H5I_is_file_object__num_calls), 1ULL);
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_is_file_object() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Fail if the ID type is out of range */
+    if (type < 1 || type >= H5I_NTYPES)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "ID type out of range");
+
+    /* Return TRUE if the ID is a file object (dataset, group, map, or committed
+     * datatype), FALSE otherwise.
+     */
+    if ( ( H5I_DATASET == type ) || ( H5I_GROUP == type ) || ( H5I_MAP == type ) ) {
+
+        ret_value = TRUE;
+
+    } else if ( H5I_DATATYPE == type ) {
+
+        hbool_t             have_global_mutex = TRUE; /*trivially so for single thread builds */
+        H5T_t              *dt = NULL;
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+        /* test to see whether this thread currently holds the global mutex.  Store the
+         * the result for later use.
+         */
+        if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
+
+            HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "Can't determine whether we have the global mutex");
+
+#endif /* defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD) */
+
+        /* In the multi-thread case, it is possible that id could be deleted between 
+         * the call to H5I_object() and the call to H5T_is_named().  
+         *
+         * The correct way of solving this is to modify H5T to be multi-thread, and 
+         * in particular to keep deleted data types on a free list until all references
+         * to the datatype have been deleted.
+         *
+         * However, that isn't an option for now.  Thus, to prevent this, increment the 
+         * reference count on id before we call H5I_object() and decrement it after 
+         * H5T_is_named() returns.
+         *
+         * Note that this isn't bullet proof at present -- there are routines that delete
+         * IDs without checking the ID reference counts.  These should only be run on 
+         * shutdown when there is only one thread active, but this is a point to consider
+         * in debugging.
+         *
+         * Further, note that the current implementation is very in-efficient due to the
+         * ref count increment and decrement.  Think on converting this to a single 
+         * function using the do not disturb flag to avoid the possiblity of the ID
+         * being deleted out from under the H5T_id_named() call.
+         */
+
+        if ( -1 == H5I_inc_ref(id, FALSE) )
+
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "unable to increment id ref count");
+
+        if ( NULL == ( dt = (H5T_t *)H5I_object(id) ) ) 
+
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "unable to get underlying datatype struct");
+
+        atomic_fetch_add(&(H5I_mt_g.H5I_is_file_object__num_calls_to_H5T_is_named), 1ULL);
+
+        /* If this thread doesn't alread have the global mutex, we must grab it before 
+         * the call to H5T_is_named() and drop it afterwards.
+         */
+        if ( ! have_global_mutex ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I_is_file_object__global_mutex_locks_for_H5T_is_named), 1ULL);
+            H5_API_LOCK
+            ret_value = H5T_is_named(dt); 
+            H5_API_UNLOCK
+            atomic_fetch_add(&(H5I_mt_g.H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named), 1ULL);
+
+        } else {
+
+            ret_value = H5T_is_named(dt); 
+        }
+
+        if ( -1 == H5I_dec_ref(id) ) 
+
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "unable to decrement id ref count");
+
+    } else {
+
+        ret_value = FALSE;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I_is_file_object() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_is_file_object
@@ -821,7 +4065,7 @@ H5I_is_file_object(hid_t id)
         if (NULL == (dt = (H5T_t *)H5I_object(id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "unable to get underlying datatype struct");
 
-        ret_value = H5T_is_named(dt);
+        ret_value = H5T_is_named(dt); /* will hit global mutex -- JRM */
     }
     else
         ret_value = FALSE;
@@ -829,6 +4073,8 @@ H5I_is_file_object(hid_t id)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5I_is_file_object() */
+
+#endif /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I__remove_verify
@@ -841,6 +4087,9 @@ done:
  *                          calling H5I_object().
  *              Failure:    NULL
  *
+ * Programmer:  James Laird
+ *              Nat Furrer
+ *
  *-------------------------------------------------------------------------
  */
 void *
@@ -849,6 +4098,12 @@ H5I__remove_verify(hid_t id, H5I_type_t type)
     void *ret_value = NULL; /*return value            */
 
     FUNC_ENTER_PACKAGE_NOERR
+
+#if H5_HAVE_MULTITHREAD 
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__remove_verify() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
 
     /* Argument checking will be performed by H5I_remove() */
 
@@ -859,6 +4114,189 @@ H5I__remove_verify(hid_t id, H5I_type_t type)
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__remove_verify() */
 
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__remove_common
+ *
+ * Purpose:     Common code to remove a specified ID from its type.
+ *
+ *              Modified for MT.
+ *
+ * Return:      Success:    A pointer to the object that was removed, the
+ *                          same pointer which would have been found by
+ *                          calling H5I_object().
+ *              Failure:    NULL
+ *
+ * Programmer:  Quincey Koziol
+ *              October 3, 2013
+ *
+ *-------------------------------------------------------------------------
+ */
+static void *
+H5I__remove_common(H5I_type_info_t *type_info_ptr, hid_t id)
+{
+    hbool_t                 done = FALSE;
+    int                     pass = 0;
+    H5I_mt_id_info_t       *id_info_ptr  = NULL; /* Pointer to the current ID */
+    H5I_mt_id_info_t       *dup_id_info_ptr;     /* Pointer to the current ID */
+    H5I_mt_id_info_kernel_t info_k;
+    H5I_mt_id_info_kernel_t mod_info_k;
+    void                   *ret_value = NULL;    /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__remove_common() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert(type_info_ptr);
+    assert(atomic_load(&(type_info_ptr->init_count)) > 0);
+
+    atomic_fetch_add(&(H5I_mt_g.H5I__remove_common__num_calls), 1ULL);
+
+    /* Delete or mark the node */
+    do {
+
+        /* increment the pass and log retries */
+        if ( pass++ >= 1 ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__remove_common__retries), 1ULL);
+        }
+
+        lfht_find(&(type_info_ptr->lfht), (unsigned long long int)id, (void **)&id_info_ptr);
+
+        if ( id_info_ptr ) {
+
+            info_k = atomic_load(&(id_info_ptr->k)); 
+
+            if ( info_k.marked ) {
+
+                /* update stats */
+                if ( pass <= 1 ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__remove_common__already_marked), 1ULL);
+
+                } else {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__remove_common__marked_by_another_thread), 1ULL);
+                }
+
+                /* the target ID has been logically deleted from the index.
+                 * Thus set id_info_ptr = NULL, and flag an error.
+                 *
+                 * Note that for now at least, we don't distinguish between the case in which the 
+                 * ID is logically deleted on entry vs. the case in which the ID is logically 
+                 * deleted by another thread at a later point.
+                 */
+                id_info_ptr = NULL;
+                done = TRUE;
+
+            } else if ( info_k.do_not_disturb ) {
+
+                /* Another thread is in the process of performing an operation on the info kernel
+                 * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+                 * regular id callback that must be serialized.
+                 *
+                 * Thus we must wait until that thread is done and then re-start the operation -- which
+                 * may be moot by that point.
+                 */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+                /* need to do better than this.  Want to call pthread_yield(),
+                 * but that call doesn't seem to be supported anymore.
+                 */
+                sleep(1);
+
+                continue;
+
+            } else {
+
+                /* The id and the associated instance of H5I_mt_id_info_t is logically deleted 
+                 * as soon as we set id_info_ptr->k.marked to TRUE -- thus update the remaining 
+                 * fields of id_info_ptr->k accordingly.
+                 */
+
+                mod_info_k.count             = 0;
+                mod_info_k.app_count         = 0;
+                mod_info_k.object            = NULL;
+
+                mod_info_k.marked            = TRUE;
+                mod_info_k.do_not_disturb    = FALSE;
+                mod_info_k.is_future         = FALSE;
+                mod_info_k.have_global_mutex = FALSE;
+
+               if ( atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.H5I__remove_common__marked), 1ULL);
+
+                    done = TRUE;
+
+                } else {
+
+                    /* the atomic compare exchange strong failed -- try again */
+
+                    /* done is false, so nothing to do to trigger the retry */
+                }
+            }
+        } else { /* id_info_ptr is NULL */
+
+            /* target entry doesn't exist in the lock free hash table, so can't proceed.
+             * will flag an error later.
+             */
+            /* update stats */
+            atomic_fetch_add(&(H5I_mt_g.H5I__remove_common__target_not_in_lfht), 1ULL);
+
+            done = TRUE;
+        }
+    } while ( ! done );
+
+    if ( ! id_info_ptr ) {
+
+        HGOTO_ERROR(H5E_ID, H5E_CANTDELETE, NULL, "can't mark ID for removal from hash table");
+
+    } else {
+
+        /* if this was the last ID accessed, set type_info_ptr->last_id_info to NULL.
+         * Do this with a call to atomic_compare_exchange_strong().  This call will NULL
+         * type_info_ptr->last_id_info if it is currently set to id_info_ptr, and leave it 
+         * unchanged otherwise.  If type_info_ptr->last_id_info is not id_info_ptr, 
+         * atomic_compare_exchange_strong() will return its current value in the second 
+         * parameter -- hence the need for dup_id_info_ptr.
+         */
+        dup_id_info_ptr = id_info_ptr;
+        atomic_compare_exchange_strong(&(type_info_ptr->last_id_info), &dup_id_info_ptr, NULL);
+
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        ret_value = (void *)info_k.object;
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+        atomic_fetch_sub(&(type_info_ptr->id_count), 1ULL);
+
+        if ( ! atomic_load(&(H5I_mt_g.marking)) ) {
+            
+            if ( ( ! lfht_delete(&(type_info_ptr->lfht), (unsigned long long int)id)) )
+
+                HGOTO_ERROR(H5E_ID, H5E_CANTDELETE, NULL, "can't remove ID node from hash table");
+
+            if ( H5I__discard_mt_id_info(id_info_ptr) < 0 )
+
+                HGOTO_ERROR(H5E_ID, H5E_CANTDELETE, NULL, "can't release ID info to free list");
+        }
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__remove_common() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__remove_common
  *
@@ -868,6 +4306,9 @@ H5I__remove_verify(hid_t id, H5I_type_t type)
  *                          same pointer which would have been found by
  *                          calling H5I_object().
  *              Failure:    NULL
+ *
+ * Programmer:  Quincey Koziol
+ *              October 3, 2013
  *
  *-------------------------------------------------------------------------
  */
@@ -912,6 +4353,60 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__remove_common() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_remove
+ *
+ * Purpose:     Removes the specified ID from its type.
+ *
+ *              Updated for multi-thread
+ *
+ * Return:      Success:    A pointer to the object that was removed, the
+ *                          same pointer which would have been found by
+ *                          calling H5I_object().
+ *              Failure:    NULL
+ *
+ *-------------------------------------------------------------------------
+ */
+void *
+H5I_remove(hid_t id)
+{
+    H5I_mt_type_info_t *type_info_ptr = NULL;      /* Pointer to the ID type */
+    H5I_type_t          type          = H5I_BADID; /* ID's type */
+    void               *ret_value     = NULL;      /* Return value */
+
+    FUNC_ENTER_NOAPI(NULL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_remove() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Check arguments */
+    type = H5I_TYPE(id);
+
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)) )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "invalid type number");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if (type_info_ptr == NULL || atomic_load(&(type_info_ptr->init_count)) <= 0)
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, NULL, "invalid type");
+
+    /* Remove the node from the type */
+    if (NULL == (ret_value = H5I__remove_common(type_info_ptr, id)))
+        HGOTO_ERROR(H5E_ID, H5E_CANTDELETE, NULL, "can't remove ID node");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_remove() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_remove
  *
@@ -948,6 +4443,473 @@ H5I_remove(hid_t id)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_remove() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__dec_ref
+ *
+ * Purpose:     This will fail if the type is not a reference counted type.
+ *              The ID type's 'free' function will be called for the ID
+ *              if the reference count for the ID reaches 0 and a free
+ *              function has been defined at type creation time.
+ *
+ *              Reworked for multi-thread.  Changes were major, as to 
+ *              preserve atomicity, I had two options -- either greatly 
+ *              extend H5I__remove_common(), or incorporate it 
+ *              functionality into this function.
+ *
+ *              For now at least, the latter seems the most appropriate,
+ *              althought refactoring will be in order once the prototype
+ *              is up and running.
+ *
+ *              Further, to make app_count and count decrements atomic, 
+ *              added the app boolean parameter.  When set, both 
+ *              id_info_ptr->k.count and id_info_ptr->k.app_count fields
+ *              are decrementd, and, if id_info_ptr->k.count is still 
+ *              positive, the new value of id_info_ptr->k.app_count is 
+ *              returned.  Note that the ID is still marked for 
+ *              deletion if id_info_ptr->k.count drops to zero, and 
+ *              in that case, 0 is returned unless an error is detected.
+ *
+ *                                              JRM -- 9/18/23
+ *
+ * Note:        Allows for asynchronous 'close' operation on object, with
+ *              request != H5_REQUEST_NULL.
+ *
+ * Return:      Success:    New reference count
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5I__dec_ref(hid_t id, void **request, hbool_t app)
+{
+    hbool_t                  done                = FALSE;
+    hbool_t                  do_not_disturb_set;
+    hbool_t                  marked_for_deletion;
+    hbool_t                  have_global_mutex = TRUE; /* trivially so in single thread builds */
+    hbool_t                  cls_is_mt_safe;
+    int                      pass                = 0;
+    H5I_mt_id_info_kernel_t  info_k;
+    H5I_mt_id_info_kernel_t  mod_info_k;
+    H5I_mt_id_info_t        *id_info_ptr         = NULL; /* Pointer to the ID */
+    H5I_mt_type_info_t      *type_info_ptr;              /* ptr to the type   */
+    herr_t                   result;
+    int                      ret_value           = 0;    /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I__dec_ref(0x%llx, reguest, app) called. \n", (unsigned long long)id);
+#endif /* H5I_MT_DEBUG */
+
+    atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__num_calls), 1ULL);
+
+    if ( app ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__num_app_calls), 1ULL);
+    }
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+
+    if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
+
+        HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "Can't determine whether we have the global mutex");
+        
+#endif /* defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD) */
+
+    if ( have_global_mutex ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__num_calls_with_global_mutex), 1ULL);
+
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__num_calls_without_global_mutex), 1ULL);
+    }
+
+    /* Get the ID's type */
+    if ( NULL == (type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[H5I_TYPE(id)]))) )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "can't locate ID type");
+
+    /* test the class flags to see if the class is multi-thread safe, and make note of the result */
+    cls_is_mt_safe = ((type_info_ptr->cls->flags & H5I_CLASS_IS_MT_SAFE) != 0);
+
+    /* General lookup of the ID -- note that if successful, this call will convert 
+     * future IDs to regular IDs.
+     *
+     * Note that there is no need to repeat this search at the beginning of each 
+     * pass through the do/while loop, as any changes will be reflected in *id_info_ptr.
+     */
+    if (NULL == (id_info_ptr = H5I__find_id(id)))
+
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "can't locate ID");
+
+    /* Sanity check */
+    assert(id >= 0);
+
+    do {
+
+        do_not_disturb_set  = FALSE;
+        marked_for_deletion = FALSE;
+
+        /* increment the pass and log retries */
+        if ( pass++ >= 1 ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__retries), 1ULL);
+        }
+
+        info_k = atomic_load(&(id_info_ptr->k));
+
+        if ( info_k.marked ) {
+
+            /* this is is already marked for deletion -- nothing to do here */
+
+            /* update stats */
+            if ( pass <= 1 ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__marked_on_entry), 1ULL);
+
+            } else {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__marked_during_call), 1ULL);
+            }
+
+            HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "can't locate ID");
+        }
+
+        if ( info_k.do_not_disturb ) {
+
+            /* Another thread is in the process of performing an operation on the info kernel
+             * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+             * regular id callback that must be serialized.
+             *
+             * Thus we must wait until that thread is done and then re-start the operation -- which
+             * may be moot by that point.
+             */
+
+            /* update stats */
+            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+            /* need to do better than this.  Want to call pthread_yield(),
+             * but that call doesn't seem to be supported anymore.
+             */
+            sleep(1);
+
+            continue;
+        }
+
+        if ( ( info_k.count > 1 ) || ( NULL == type_info_ptr->cls->free_func ) ) {
+
+            /* Either count > 1 or the free function for the class is undefined.
+             * In either case, we can roll back the operation an re-try if the 
+             * global copy of the kernel has changed since we read it at the 
+             * top of the do/while loop. 
+             */
+            mod_info_k.count             = info_k.count;
+            mod_info_k.app_count         = info_k.app_count;
+            mod_info_k.object            = info_k.object;
+
+            mod_info_k.marked            = info_k.marked;
+            mod_info_k.do_not_disturb    = info_k.do_not_disturb;
+            mod_info_k.is_future         = info_k.is_future;
+            mod_info_k.have_global_mutex = FALSE;
+
+            if ( info_k.count > 1 ) {
+
+                mod_info_k.count--;
+
+                if ( app ) {
+
+                    mod_info_k.app_count--;
+
+                    assert(mod_info_k.count >= mod_info_k.app_count);
+                }
+            } else {
+                
+                assert( NULL == type_info_ptr->cls->free_func );
+
+                /* id_info_ptr->k.count is about to drop to zero, and as a result, the 
+                 * the ID and *id_info_ptr are about to be removed from the idex at least
+                 * logically, and probably physically as well.  Since the free function 
+                 * is undefined, all we need to do is setup mod_info_k accordingly and 
+                 * try to replace id_info_ptr->k with mod_info_k.
+                 */
+                mod_info_k.count             = 0;
+                mod_info_k.app_count         = 0;
+                mod_info_k.object            = NULL;
+
+                mod_info_k.marked            = TRUE;
+                mod_info_k.do_not_disturb    = FALSE;
+                mod_info_k.is_future         = FALSE;
+                mod_info_k.have_global_mutex = FALSE;
+
+                marked_for_deletion = TRUE;
+            }
+
+            if ( atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+
+                if ( marked_for_deletion ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__marked), 1ULL);
+                    ret_value = 0;
+
+                } else {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__decremented), 1ULL);
+
+                    if ( app ) {
+
+                        atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__app_decremented), 1ULL);
+
+                        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                        ret_value = (int)(mod_info_k.app_count);
+                        H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+                    } else {
+
+                        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                        ret_value = (int)(mod_info_k.count);
+                        H5_GCC_CLANG_DIAG_ON("cast-qual")
+                    }
+                }
+
+                done = TRUE;
+
+            } else {
+
+                /* the atomic compare exchange strong failed -- try again */
+
+                /* done is false, so nothing to do to trigger the retry */
+                assert( ! done );
+            }
+        } else {
+
+            assert(info_k.count <= 1);
+            assert(type_info_ptr->cls->free_func);
+
+            cls_is_mt_safe = ((type_info_ptr->cls->flags & H5I_CLASS_IS_MT_SAFE) != 0);
+
+            /* The ref count has dropped to 1, and the class free_func is defined.  
+             * Proceed as follows:
+             *
+             *    1) Set the do_not_disturb_flag
+             *
+             *       In passing set the have_global_mutex flag to true if either we currently
+             *       have the global mutex, or if the H5I_CLASS_IS_MT_SAFE is set in 
+             *       type_info_ptr->cls->flags.  Do this because we must obtain the global 
+             *       mutex before calling the free_func() and drop if after the call if we 
+             *       don't have the mutex already.
+             *
+             *    2) Call the free_func().  If the class is not multi-thread safe and
+             *       we don't already hold the globla mutex, we must obtain it before the 
+             *       call, and drop it afterwards.
+             * 
+             *       On success, go on to 3) below.  
+             *
+             *       On failure, reset the do_not_disturb flag and return -1.  Do
+             *       not flag an error
+             *
+             *    3) Set the marked flag, reset the do_not_disturb flag, and set
+             *       the return value to zero.
+             * 
+             *    4) If H5I_mt_g.marking is FALSE, remove the ID from the lock
+             *       free hash table, and release the associated instance of 
+             *       H5I_mt_id_info_t to the free list.
+             *
+             * Note the failure to flag an error if the free function fails.
+             * This is the same behaviour seen in the single thread version of
+             * H5I__mark_node().  While the notion of leaving an entry in the 
+             * index after its free function has failed seems questionable at 
+             * best, as per H5I__mark_node, I have chosen to follow this lead
+             * at least for the initial prototype.
+             */
+
+            /* attempt to set the do_not_disturb flag */
+            mod_info_k.count             = info_k.count;
+            mod_info_k.app_count         = info_k.app_count;
+            mod_info_k.object            = info_k.object;
+
+            mod_info_k.marked            = info_k.marked;
+            mod_info_k.do_not_disturb    = TRUE;
+            mod_info_k.is_future         = info_k.is_future;
+            mod_info_k.have_global_mutex = ((have_global_mutex) || (! cls_is_mt_safe));
+
+            /* We want to call the free function, and then mark the id for deletion.  
+             * Since we can't roll this action back, we need exclusive access to the 
+             * kernel of the instance of H5I_mt_id_info_t associated with the ID.
+             *
+             * To get this, try to set the do_not_disturb flag in the kernl.   If 
+             * successful, this will prevent any other threads from modifying
+             * id_info_ptr->k until after it is set back to FALSE.
+             */
+            if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+
+                /* Some other thread changed the value of id_info_ptr->k since we last read
+                 * it.  Thus we must return to the beginning of the do loop and start
+                 * again.  Note that it is possible that by that time, there will be
+                 * nothing left to do.
+                 */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_failed_do_not_disturb_sets), 1ULL);
+
+                continue;
+
+            } else {
+
+                do_not_disturb_set = TRUE;
+
+#if 0 /* JRM */
+                /* make info_k into a copy of the global kernel */
+                info_k.do_not_disturb = TRUE;
+#else /* JTM */
+                /* On the face of it, it would seem that we could just update info_k
+                 * to match mod_info_k, and use it in the next atomic_compare_exchange_strong()
+                 * call.  However, for reason or reasons unknown, this doesn't work.  
+                 *
+                 * Instead, we reload info_k after the atomic_compare_exchange_strong(),
+                 * and verify that it contains the expected values.
+                 */
+                info_k = atomic_load(&(id_info_ptr->k));
+
+                assert(info_k.count             == mod_info_k.count);
+                assert(info_k.app_count         == mod_info_k.app_count);
+                assert(info_k.object            == mod_info_k.object);
+
+                assert(info_k.marked            == mod_info_k.marked);
+                assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
+                assert(info_k.is_future         == mod_info_k.is_future);
+                assert(info_k.have_global_mutex == mod_info_k.have_global_mutex);
+#endif /* JRM */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_successful_do_not_disturb_sets), 1ULL);
+
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+                fprintf(stdout, "H5I__dec_ref() set do not disturb on id = 0x%llx.\n",
+                          (unsigned long long)(id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+            }
+
+            assert( do_not_disturb_set );
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__calls_to_free_func), 1ULL);
+
+            /* Note that the free_func may call back into H5I.  As long as it doesn't try
+             * to access this ID, either directly or indirectly, there shouldn't be a problem.
+             *
+             * In the case of indexes maintained by the HDF5 library proper, this should be
+             * manageable as we have access to the code.  For external users (either user 
+             * programmer or VOL connectors), we must document this.
+             */
+            if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__global_mutex_locks_for_free_func), 1ULL);
+                H5_API_LOCK
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                result = type_info_ptr->cls->free_func((void *)info_k.object, request);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+                H5_API_UNLOCK
+                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__global_mutex_unlocks_for_free_func), 1ULL);
+
+            } else {
+
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                result = type_info_ptr->cls->free_func((void *)info_k.object, request);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+            }
+
+            if ( result >= 0 ) {
+
+                /* The free_func() succeeded -- reset the do_not_disturb flag, and set marked to TRUE.
+                 * Since the ID and the associated instance of H5I_mt_id_info_t will be logically 
+                 * deleted as soon as we overwrite id_info_ptr->k with mod_info_k, set the remaining 
+                 * fields to reflect this.
+                 */
+                mod_info_k.count             = 0;
+                mod_info_k.app_count         = 0;
+                mod_info_k.object            = NULL;
+
+                mod_info_k.marked            = TRUE;
+                mod_info_k.do_not_disturb    = FALSE;
+                mod_info_k.is_future         = FALSE;
+                mod_info_k.have_global_mutex = FALSE;
+
+                marked_for_deletion       = TRUE;
+
+                ret_value = 0;
+
+            } else {
+
+                /* The free_func() failed -- just update stats, reset the do not disturb flag, 
+                 * and set ret_value = -1 
+                 */
+                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__free_func_failed), 1ULL);
+
+                mod_info_k.do_not_disturb    = FALSE;
+                mod_info_k.have_global_mutex = FALSE;
+                ret_value = -1;
+
+            }
+
+            /* since we have the do_not_disturb flag, the following atomic_compare_exchange_strong()
+             * must succeed.
+             */
+            assert(atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k));
+
+            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+            fprintf(stdout, "H5I__dec_ref() reset do not disturb on id = 0x%llx.\n",
+                      (unsigned long long)(id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+ 
+            /* Whether we succeeded or failed, we are done with the do/while loop */
+            done = TRUE;
+        }
+    } while ( ! done );
+
+    if ( marked_for_deletion ) {
+
+        assert( 0 == ret_value );
+        assert( id_info_ptr );
+
+        atomic_fetch_sub(&(type_info_ptr->id_count), 1ULL);
+
+        if ( ! atomic_load(&(H5I_mt_g.marking)) ) {
+
+            /* attempt to remove the ID from the lock free hash table and release the 
+             * instance of H5I_mt_id_info_t to the free list.
+             */
+
+            if ( ( ! lfht_delete(&(type_info_ptr->lfht), (unsigned long long int)id)) )
+
+                HGOTO_ERROR(H5E_ID, H5E_CANTDELETE, (-1), "can't remove ID node from hash table");
+
+            if ( H5I__discard_mt_id_info(id_info_ptr) < 0 )
+
+                HGOTO_ERROR(H5E_ID, H5E_CANTDELETE, (-1), "can't release ID info to free list");
+        }
+    }
+
+    assert ( ( ret_value >= 1 ) || ( marked_for_deletion && ( 0 == ret_value ) ) || ( -1 == ret_value ) ||
+             ( ( app ) && ( 0 == ret_value ) && ( mod_info_k.count >= 1 ) ) );
+
+done:
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I__dec_ref(0x%llx, reguest, app) returns %d. \n", (unsigned long long)id, ret_value);
+#endif /* H5I_MT_DEBUG */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__dec_ref */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I__dec_ref
@@ -1020,6 +4982,52 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__dec_ref */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_dec_ref
+ *
+ * Purpose:     Decrements the number of references outstanding for an ID.
+ *
+ *              Updated for multi-thread
+ *
+ * Return:      Success:    New reference count
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+H5I_dec_ref(hid_t id)
+{
+    int ret_value = 0; /* Return value */
+
+    FUNC_ENTER_NOAPI((-1))
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_dec_ref(0x%llx) called. \n", (unsigned long long)id);
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert(id >= 0);
+
+    /* Synchronously decrement refcount on ID */
+    if ((ret_value = H5I__dec_ref(id, H5_REQUEST_NULL, FALSE)) < 0)
+        HGOTO_ERROR(H5E_ID, H5E_CANTDEC, (-1), "can't decrement ID ref count");
+
+done:
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_dec_ref(0x%llx) returns %d. \n", (unsigned long long)id, ret_value);
+#endif /* H5I_MT_DEBUG */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_dec_ref() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_dec_ref
  *
@@ -1047,6 +5055,54 @@ H5I_dec_ref(hid_t id)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_dec_ref() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__dec_app_ref
+ *
+ * Purpose:     Wrapper for case of modifying the application ref.
+ *              count for an ID as well as normal reference count.
+ *
+ *              Updated for multi-thread.  To maintain atomicity, 
+ *              decrement of the app_count was moved to H5I__dec_ref()
+ *
+ * Note:        Allows for asynchronous 'close' operation on object, with
+ *              request != H5_REQUEST_NULL.
+ *
+ * Return:      Success:    New app. reference count
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5I__dec_app_ref(hid_t id, void **request)
+{
+    int ret_value = 0; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__dec_app_ref() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert(id >= 0);
+
+    /* Call regular decrement reference count routine */
+    if ((ret_value = H5I__dec_ref(id, request, TRUE)) < 0)
+
+        HGOTO_ERROR(H5E_ID, H5E_CANTDEC, (-1), "can't decrement ID ref count");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__dec_app_ref() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I__dec_app_ref
@@ -1096,6 +5152,8 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__dec_app_ref() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_dec_app_ref
  *
@@ -1105,6 +5163,9 @@ done:
  * Return:      Success:    New app. reference count
  *              Failure:    -1
  *
+ * Programmer:  Quincey Koziol
+ *              Sept 16, 2010
+ *
  *-------------------------------------------------------------------------
  */
 int
@@ -1113,6 +5174,12 @@ H5I_dec_app_ref(hid_t id)
     int ret_value = 0; /* Return value */
 
     FUNC_ENTER_NOAPI((-1))
+
+#if H5_HAVE_MULTITHREAD
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_dec_app_ref() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
 
     /* Sanity check */
     assert(id >= 0);
@@ -1137,6 +5204,9 @@ done:
  * Return:      Success:    New app. reference count
  *              Failure:    -1
  *
+ * Programmer:  Houjun Tang
+ *              Oct 21, 2019
+ *
  *-------------------------------------------------------------------------
  */
 int
@@ -1145,6 +5215,12 @@ H5I_dec_app_ref_async(hid_t id, void **token)
     int ret_value = 0; /* Return value */
 
     FUNC_ENTER_NOAPI((-1))
+
+#if H5_HAVE_MULTITHREAD
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_dec_app_ref_async() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
 
     /* Sanity check */
     assert(id >= 0);
@@ -1156,6 +5232,7 @@ H5I_dec_app_ref_async(hid_t id, void **token)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_dec_app_ref_async() */
+
 
 /*-------------------------------------------------------------------------
  * Function:    H5I__dec_app_ref_always_close
@@ -1177,6 +5254,12 @@ H5I__dec_app_ref_always_close(hid_t id, void **request)
     int ret_value = 0; /* Return value */
 
     FUNC_ENTER_PACKAGE
+
+#if H5_HAVE_MULTITHREAD
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__dec_app_ref_always_close() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
 
     /* Sanity check */
     assert(id >= 0);
@@ -1201,6 +5284,7 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__dec_app_ref_always_close() */
 
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_dec_app_ref_always_close
  *
@@ -1218,6 +5302,12 @@ H5I_dec_app_ref_always_close(hid_t id)
     int ret_value = 0; /* Return value */
 
     FUNC_ENTER_NOAPI((-1))
+
+#if H5_HAVE_MULTITHREAD
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_dec_app_ref_always_close() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
 
     /* Sanity check */
     assert(id >= 0);
@@ -1251,6 +5341,12 @@ H5I_dec_app_ref_always_close_async(hid_t id, void **token)
 
     FUNC_ENTER_NOAPI((-1))
 
+#if H5_HAVE_MULTITHREAD
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_dec_app_ref_always_close_async() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+#endif /* H5_HAVE_MULTITHREAD */
+
     /* Sanity check */
     assert(id >= 0);
 
@@ -1261,6 +5357,164 @@ H5I_dec_app_ref_always_close_async(hid_t id, void **token)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_dec_app_ref_always_close_async() */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_inc_ref
+ *
+ * Purpose:     Increment the reference count for an object.
+ *
+ *              Modified for multi-thread
+ *
+ * Return:      Success:    The new reference count
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+H5I_inc_ref(hid_t id, hbool_t app_ref)
+{
+    hbool_t                  done                = FALSE;
+    int                      pass                = 0;
+    H5I_mt_id_info_kernel_t  info_k;
+    H5I_mt_id_info_kernel_t  mod_info_k;
+    H5I_mt_id_info_t        *id_info_ptr = NULL; /* Pointer to the ID info */
+    int                      ret_value = 0;      /* Return value */
+
+    FUNC_ENTER_NOAPI((-1))
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_inc_ref((id = 0x%llx, app_ref = %d) called. \n", 
+              (unsigned long long)id, (int)app_ref);
+#endif /* H5I_MT_DEBUG */
+
+    atomic_fetch_add(&(H5I_mt_g.H5I__inc_ref__num_calls), 1ULL);
+
+    if ( app_ref ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__inc_ref__num_app_calls), 1ULL);
+    }
+
+    /* Sanity check */
+    assert(id >= 0);
+
+    /* General lookup of the ID -- note that if successful, this call will convert
+     * future IDs to regular IDs.
+     *
+     * Note that there is no need to repeat this search at the beginning of each
+     * pass through the do/while loop, as any changes will be reflected in *id_info_ptr.
+     */
+    if (NULL == (id_info_ptr = H5I__find_id(id)))
+
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "can't locate ID");
+
+    do {
+
+        /* increment the pass and log retries */
+        if ( pass++ >= 1 ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__inc_ref__retries), 1ULL);
+        }
+
+        info_k = atomic_load(&(id_info_ptr->k));
+
+        if ( info_k.marked ) {
+
+            /* this is is already marked for deletion -- nothing to do here */
+
+            /* update stats */
+            if ( pass <= 1 ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__inc_ref__marked_on_entry), 1ULL);
+
+            } else {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__inc_ref__marked_during_call), 1ULL);
+            }
+
+            HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "can't locate ID");
+        }
+
+        if ( info_k.do_not_disturb ) {
+
+            /* Another thread is in the process of performing an operation on the info kernel
+             * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+             * regular id callback that must be serialized.
+             *
+             * Thus we must wait until that thread is done and then re-start the operation -- which
+             * may be moot by that point.
+             */
+
+            /* update stats */
+            atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+            /* need to do better than this.  Want to call pthread_yield(),
+             * but that call doesn't seem to be supported anymore.
+             */
+            sleep(1);
+
+            continue;
+        }
+
+        /* Set mod_info_k to reflect the ref_count increment */
+        mod_info_k.count             = info_k.count + 1;
+        mod_info_k.app_count         = info_k.app_count;
+        mod_info_k.object            = info_k.object;
+
+        mod_info_k.marked            = info_k.marked;
+        mod_info_k.do_not_disturb    = info_k.do_not_disturb;
+        mod_info_k.is_future         = info_k.is_future;
+        mod_info_k.have_global_mutex = info_k.have_global_mutex;
+
+        if ( app_ref ) {
+
+            mod_info_k.app_count++;
+        }
+
+        if ( atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+
+            /* Update stats and set return value*/
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__inc_ref__incremented), 1ULL);
+
+            if ( app_ref ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__inc_ref__app_incremented), 1ULL);
+
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                ret_value = (int)(mod_info_k.app_count);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+            } else {
+
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                ret_value = (int)(mod_info_k.count);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+            }
+
+            done = TRUE;
+
+        } else {
+
+            /* the atomic compare exchange strong failed -- try again */
+
+            /* done is false, so nothing to do to trigger the retry */
+        }
+    } while ( ! done );
+
+done:
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I_inc_ref((id = 0x%llx, app_ref = %d) returns %d. \n", 
+              (unsigned long long)id, (int)app_ref, (int)ret_value);
+#endif /* H5I_MT_DEBUG */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_inc_ref() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_inc_ref
@@ -1299,6 +5553,55 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_inc_ref() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_get_ref
+ *
+ * Purpose:     Retrieve the reference count for an object.
+ * 
+ *              Updated for multi-thread.
+ *
+ * Return:      Success:    The reference count
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+H5I_get_ref(hid_t id, hbool_t app_ref)
+{
+    H5I_mt_id_info_t           *id_info_ptr      = NULL; /* Pointer to the ID */
+    H5I_mt_id_info_kernel_t  info_k;
+    int                      ret_value = 0;    /* Return value */
+
+    FUNC_ENTER_NOAPI((-1))
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_get_ref() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert(id >= 0);
+
+    /* General lookup of the ID */
+    if (NULL == (id_info_ptr = H5I__find_id(id)))
+        HGOTO_ERROR(H5E_ID, H5E_BADID, (-1), "can't locate ID");
+
+    info_k = atomic_load(&(id_info_ptr->k));
+
+    /* Set return value */
+    ret_value = (int)(app_ref ? info_k.app_count : info_k.count);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_get_ref() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I_get_ref
  *
@@ -1330,6 +5633,55 @@ H5I_get_ref(hid_t id, hbool_t app_ref)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_get_ref() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__inc_type_ref
+ *
+ * Purpose:     Increment the reference count for an ID type.
+ *
+ *              Updated for multi-thread.
+ *
+ * Return:      Success:    The new reference count
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+H5I__inc_type_ref(H5I_type_t type)
+{
+    H5I_mt_type_info_t *type_info_ptr = NULL; /* Pointer to the type */
+    int                 ret_value     = -1;   /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__inc_type_ref() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert( ( type > 0 ) && ( (int)type < atomic_load(&(H5I_mt_g.next_type)) ) );
+
+    /* Check arguments */
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( NULL == type_info_ptr )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, (-1), "invalid type");
+
+    /* Set return value -- atomic_fetch_add() returns the old value, hence the plus 1 */
+    ret_value = 1 + (int)(atomic_fetch_add(&(type_info_ptr->init_count), 1));
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__inc_type_ref() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I__inc_type_ref
@@ -1363,6 +5715,75 @@ H5I__inc_type_ref(H5I_type_t type)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__inc_type_ref() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_dec_type_ref
+ *
+ * Purpose:     Decrements the reference count on an entire type of IDs.
+ *              If the type reference count becomes zero then the type is
+ *              destroyed along with all IDs in that type regardless of
+ *              their reference counts. Destroying IDs involves calling
+ *              the free-func for each ID's object and then adding the ID
+ *              struct to the ID free list.
+ *              Returns the number of references to the type on success; a
+ *              return value of 0 means that the type will have to be
+ *              re-initialized before it can be used again (and should probably
+ *              be set to H5I_UNINIT).
+ *
+ * Return:      Success:    Number of references to type
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+H5I_dec_type_ref(H5I_type_t type)
+{
+    H5I_mt_type_info_t *type_info_ptr = NULL; /* Pointer to the ID type */
+    herr_t              ret_value = 0;    /* Return value */
+
+    FUNC_ENTER_NOAPI((-1))
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_dec_type_ref() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, (-1), "invalid type number");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( ( type_info_ptr == NULL ) || ( atomic_load(&(type_info_ptr->init_count)) <= 0 ) )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, (-1), "invalid type");
+
+    /* Decrement the number of users of the ID type.  If this is the
+     * last user of the type then release all IDs from the type and
+     * free all memory it used.  The free function is invoked for each ID
+     * being freed.
+     */
+    if ( 1 == atomic_load(&(type_info_ptr->init_count)) ) {
+
+        H5I__destroy_type(type);
+        ret_value = 0;
+    
+    } else {
+
+        /* atomic_fetch_sub() returns the original value of the atomic variable -- hence the minus 1 */
+        ret_value = (int)(atomic_fetch_sub(&(type_info_ptr->init_count), 1)) - 1;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_dec_type_ref() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_dec_type_ref
@@ -1416,6 +5837,61 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_dec_type_ref() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__get_type_ref
+ *
+ * Purpose:     Retrieve the reference count for an ID type.
+ *
+ *              Updated for multi-thread
+ *
+ * Return:      Success:    The reference count
+ *
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+int
+H5I__get_type_ref(H5I_type_t type)
+{
+    H5I_mt_type_info_t *type_info_ptr = NULL; /* Pointer to the type  */
+    int                 ret_value = -1;   /* Return value         */
+
+    FUNC_ENTER_PACKAGE
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__get_type_ref() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert(type >= 0);
+
+    /* Check arguments */
+
+    if ( ( type <= H5I_BADID ) || ( (int)type >= atomic_load(&(H5I_mt_g.next_type)) ) )
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, (-1), "invalid type number");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( ! type_info_ptr )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, (-1), "invalid type");
+
+    /* Set return value */
+    ret_value = (int)atomic_load(&(type_info_ptr->init_count));
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__get_type_ref() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__get_type_ref
  *
@@ -1449,6 +5925,309 @@ H5I__get_type_ref(H5I_type_t type)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__get_type_ref() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__iterate_cb
+ *
+ * Purpose:     Callback routine for H5I_iterate, invokes "user" callback
+ *              function, and then sets return value, based on the result of
+ *              that callback.
+ *
+ *              Updated for multi-thread.
+ *
+ * Return:      Success:    H5_ITER_CONT (0) or H5_ITER_STOP (1)
+ *              Failure:    H5_ITER_ERROR (-1)
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
+{
+    hbool_t                  have_global_mutex;
+    H5I_mt_id_info_t        *id_info_ptr       = (H5I_mt_id_info_t *)_item;  /* Pointer to the ID info */
+    H5I_iterate_ud_t        *udata             = (H5I_iterate_ud_t *)_udata; /* User data for callback */
+    H5I_mt_id_info_kernel_t  info_k;
+    herr_t                   result;
+    int                      ret_value         = H5_ITER_CONT;               /* Callback return value */
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__iterate_cb() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_calls), 1ULL);
+
+    have_global_mutex = udata->have_global_mutex;
+
+    if ( have_global_mutex ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_calls__with_global_mutex), 1ULL);
+
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_calls__without_global_mutex), 1ULL);
+    }
+
+    /* read the current value of the id info kernel */
+    info_k = atomic_load(&(id_info_ptr->k));
+
+    /* Only invoke the callback function if this ID has not been marked for deletion, is visible 
+     * externally and its reference count is positive.
+     *
+     * While the user_func (and all the callbacks defined in the type) should be thread safe,
+     * for now, use the do_not_disturb flag to ensure that user_func has exclusive access
+     * to the object -- at least from within H5I.  (Note, however, that the object can still 
+     * be looked up by the user and accessed outside the H5I code.  Similarly, the user 
+     * may have a copy of the pointer, and be able to access its data structure at will 
+     * directly))  
+     *
+     * If the limited protection given to the object associated with the ID is not sufficient, 
+     * the client object will have to be made multi-thread safe.  Indeed, this should be 
+     * the end state -- but unless and until the native VOL is made thread safe, this 
+     * limited protection seems a reasonable middle ground 
+     * 
+     * As per the other uses of the do_not_disturb flag, it is possible for the user_func to 
+     * trigger a deadlock if it attempts to access the current ID via H5I either directly 
+     * or through some sequence of calls.
+     */
+    if ( ( ! info_k.marked ) && ( ( ( ! udata->app_ref ) || ( info_k.app_count > 0 ) ) ) ) {
+
+        hbool_t                  done = FALSE;
+        hbool_t                  bypass_do_not_disturb;
+        hbool_t                  do_not_disturb_set = FALSE;
+        int                      pass                = 0;
+        H5I_type_t               type                = udata->obj_type;
+        H5I_mt_id_info_kernel_t  mod_info_k;
+        void                    *object;
+        herr_t                   cb_ret_val;
+
+        do {
+            bypass_do_not_disturb = FALSE;
+
+            /* increment the pass and log retries */
+            if ( pass++ >= 1 ) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__dec_ref__retries), 1ULL);
+            }
+
+            info_k = atomic_load(&(id_info_ptr->k));
+
+            if ( info_k.marked ) {
+
+                /* the ID has been marked for deletion since we started, update stats 
+                 * and return without calling the user_func()
+                 */
+                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__marked_during_call), 1ULL);
+
+                break;
+            }
+
+            if ( info_k.do_not_disturb ) {
+
+                if ( ( have_global_mutex ) && ( info_k.have_global_mutex ) ) {
+
+                    bypass_do_not_disturb = TRUE;
+
+                } else {
+
+                    /* Another thread is in the process of performing an operation on the info kernel
+                     * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+                     * regular id callback that must be serialized.
+                     *
+                     * Thus we must wait until that thread is done and then re-start the operation -- which
+                     * may be moot by that point.
+                     */
+
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+                    /* need to do better than this.  Want to call pthread_yield(),
+                     * but that call doesn't seem to be supported anymore.
+                     */
+                    sleep(1);
+
+                    continue;
+                }
+            }
+
+            if ( ! bypass_do_not_disturb ) {
+
+                /* attempt to set the do_not_disturb flag */
+                mod_info_k.count             = info_k.count;
+                mod_info_k.app_count         = info_k.app_count;
+                mod_info_k.object            = info_k.object;
+
+                mod_info_k.marked            = info_k.marked;
+                mod_info_k.do_not_disturb    = TRUE;
+                mod_info_k.is_future         = info_k.is_future;
+
+                /* set mod_inf_k.have_global_mutex to TRUE since if we don't have the global
+                 * mutext, we will grab it before calling the user function, and drop it as soon
+                 * as it returns.
+                 */
+                mod_info_k.have_global_mutex = have_global_mutex;
+
+                /* We want to ensure that no other thread inside H5I does anything with 
+                 * the object while we call the user_func on the objec on the object.  
+                 * Note that this is only a partial solution, but it is the best we can 
+                 * do in H5I.
+                 *
+                 * To do this, try to set the do_not_disturb flag in the kernl.   If
+                 * successful, this will prevent any other threads from modifying
+                 * id_info_ptr->k until after it is set back to FALSE.  In particluar,
+                 * no thread in H5I will call any function on the object associated 
+                 * with the ID until it successfully sets the do_not_disturb flag.
+                 */
+                if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k) ) {
+
+                    /* Some other thread changed the value of id_info_ptr->k since we last read
+                     * it.  Thus we must return to the beginning of the do loop and start
+                     * again.  Note that it is possible that by that time, there will be
+                     * nothing left to do.
+                     */
+    
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.num_failed_do_not_disturb_sets), 1ULL);
+    
+                    continue;
+    
+                } else {
+    
+                    do_not_disturb_set = TRUE;
+    
+#if 0 /* JRM */
+                    /* make info_k into a copy of the global kernel */
+                    info_k.do_not_disturb = TRUE;
+#else /* JTM */
+                    /* On the face of it, it would seem that we could just update info_k
+                     * to match mod_info_k, and use it in the next atomic_compare_exchange_strong()
+                     * call.  However, for reason or reasons unknown, this doesn't work.
+                     *
+                     * Instead, we reload info_k after the atomic_compare_exchange_strong(),
+                     * and verify that it contains the expected values.
+                     */
+                    info_k = atomic_load(&(id_info_ptr->k));
+
+                    assert(info_k.count             == mod_info_k.count);
+                    assert(info_k.app_count         == mod_info_k.app_count);
+                    assert(info_k.object            == mod_info_k.object);
+
+                    assert(info_k.marked            == mod_info_k.marked);
+                    assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
+                    assert(info_k.is_future         == mod_info_k.is_future);
+                    assert(info_k.have_global_mutex == mod_info_k.have_global_mutex);
+#endif /* JRM */
+
+                    /* prepare to reset the do_not_disturb flag */
+                    mod_info_k.do_not_disturb    = FALSE;
+                    mod_info_k.have_global_mutex = FALSE;
+
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.num_successful_do_not_disturb_sets), 1ULL);
+
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+                    fprintf(stdout, "H5I__iterate_cb() set do not disturb on id = 0x%llx.\n",
+                            (unsigned long long)(id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+                }
+            } /* if ( ! bypass_do_not_disturb ) */
+
+            assert( ( do_not_disturb_set ) || ( bypass_do_not_disturb ) );
+
+            /* The stored object pointer might be an H5VL_object_t, in which
+             * case we'll need to get the wrapped object struct (H5F_t *, etc.).
+             */
+#if 0 
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            object = H5I__unwrap((void *)info_k.object, type, &object); /* may hit global mutex */
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
+#endif 
+            /* H5I__unwrap() can fail -- for now at least.  Handle this by treating any 
+             * failure as a callback failure.  
+             */
+            H5_GCC_CLANG_DIAG_OFF("cast-qual")
+            result = H5I__unwrap((void *)info_k.object, type, &object);
+            H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+            if ( result < 0 ) {
+
+                cb_ret_val = -1;
+
+            } else {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_calls), 1ULL);
+
+                /* Invoke callback function.  Grab the global mutex if we don't have it already */
+                if ( ! have_global_mutex ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__global_mutex_locks_for_user_func), 1ULL);
+                    H5_API_LOCK
+                    cb_ret_val = (*udata->user_func)((void *)object, id_info_ptr->id, udata->user_udata);
+                    H5_API_UNLOCK
+                    atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__global_mutex_unlocks_for_user_func), 1ULL);
+
+                } else {
+
+                    cb_ret_val = (*udata->user_func)((void *)object, id_info_ptr->id, udata->user_udata);
+                }
+            }
+
+            /* Set the return value based on the callback's return value */
+            if (cb_ret_val > 0) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_iter_stops), 1ULL);
+
+                ret_value = H5_ITER_STOP; /* terminate iteration early */
+
+            } else if (cb_ret_val < 0) {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_fails), 1ULL);
+
+                ret_value = H5_ITER_ERROR; /* indicate failure (which terminates iteration) */
+
+            } else {
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_successes), 1ULL);
+            }
+
+            if ( ! bypass_do_not_disturb ) {
+
+                /* since we have the do_not_disturb flag, the following atomic_compare_exchange_strong()
+                 * must succeed.
+                 */
+                assert(info_k.do_not_disturb);
+
+                assert( ! mod_info_k.do_not_disturb );
+
+                assert(atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k));
+
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+                fprintf(stdout, "H5I__iterate_cb() reset do not disturb on id = 0x%llx.\n",
+                        (unsigned long long)(id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+            }
+
+            /* If execution gets this far, we are done with the do/while loop */
+            done = TRUE;
+
+        } while ( ! done );
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__iterate_cb__num_user_func_skips), 1ULL);
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__iterate_cb() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I__iterate_cb
@@ -1498,6 +6277,114 @@ H5I__iterate_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__iterate_cb() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_iterate
+ *
+ * Purpose:     Apply function FUNC to each member of type TYPE (with
+ *              non-zero application reference count if app_ref is TRUE).
+ *              Stop if FUNC returns a non zero value (i.e. anything
+ *              other than H5_ITER_CONT).
+ *
+ *              If FUNC returns a positive value (i.e. H5_ITER_STOP),
+ *              return SUCCEED.
+ *
+ *              If FUNC returns a negative value (i.e. H5_ITER_ERROR),
+ *              return FAIL.
+ *
+ *              The FUNC should take a pointer to the object and the
+ *              udata as arguments and return non-zero to terminate
+ *              siteration, and zero to continue.
+ *
+ *              Updated for multi-thread.
+ *
+ * Limitation:  Currently there is no way to start the iteration from
+ *              where a previous iteration left off.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_iterate(H5I_type_t type, H5I_search_func_t func, void *udata, hbool_t app_ref)
+{
+    hbool_t                  have_global_mutex = TRUE; /* trivially true in the single thread case */
+    H5I_mt_type_info_t      *type_info_ptr = NULL;    /* Pointer to the type */
+    H5I_mt_id_info_kernel_t  info_k;
+    herr_t                   ret_value     = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_iterate() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+
+    if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 ) {
+        
+        ret_value = H5_ITER_ERROR;
+    
+    } 
+#endif /* defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD) */
+
+
+    /* Check arguments */
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "invalid type number");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    /* Only iterate through ID list if it is initialized and there are IDs in type */
+    if ( ( type_info_ptr )  && ( atomic_load(&(type_info_ptr->init_count)) > 0 ) && 
+         ( atomic_load(&(type_info_ptr->id_count)) > 0 ) ) {
+
+        H5I_iterate_ud_t       iter_udata; /* User data for iteration callback */
+        H5I_mt_id_info_t      *id_info_ptr = NULL;
+        unsigned long long int id;
+        void * value;
+
+        /* Set up iterator user data */
+        iter_udata.user_func         = func;
+        iter_udata.user_udata        = udata;
+        iter_udata.app_ref           = app_ref;
+        iter_udata.obj_type          = type;
+        iter_udata.have_global_mutex = have_global_mutex;
+
+        /* Iterate over IDs */
+        if ( lfht_get_first(&(type_info_ptr->lfht), &id, &value) ) {
+
+            do {
+                id_info_ptr = (H5I_mt_id_info_t *)value;
+
+                info_k = atomic_load(&(id_info_ptr->k));
+
+                if (! info_k.marked) {
+
+                    int ret = H5I__iterate_cb((void *)id_info_ptr, NULL, (void *)&iter_udata);
+
+                    if (H5_ITER_ERROR == ret)
+                        HGOTO_ERROR(H5E_ID, H5E_BADITER, FAIL, "iteration failed");
+
+                    if (H5_ITER_STOP == ret)
+                        break;
+                }
+            } while (lfht_get_next(&(type_info_ptr->lfht), id, &id, &value));
+        }
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_iterate() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_iterate
@@ -1566,6 +6453,690 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_iterate() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_get_first
+ *
+ * Purpose:     Given a type ID, find the first ID in the given type, and 
+ *              return that ID and its associated un-wrapped object pointer
+ *              in *id_ptr and *object_ptr respectively.
+ *
+ *              If the type is empty, *id_ptr is set to zero, and 
+ *              *object_ptr is set to NULL.  Recall that since type 0 is 
+ *              not used, and since the type is encoded in the id, an 
+ *              id of zero cannot occur.
+ *
+ *              Note that the itteration supported by the H5I_get_first()
+ *              and H5I_get_next() is neither id nor insertion order.
+ *
+ *              On failure, *id_ptr and *object_ptr are undefined.
+ *
+ * Return:      Success:    SUCCEED
+ *
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_get_first(H5I_type_t type, hid_t *id_ptr, void ** object_ptr)
+{
+    H5I_mt_type_info_t      *type_info_ptr    = NULL;    /* Pointer to the type */
+    unsigned long long int   id               = 0;
+    void                    *value            = NULL;
+    void                    *object           = NULL;
+    H5I_mt_id_info_t        *id_info_ptr      = NULL;
+    H5I_mt_id_info_kernel_t  info_k;
+    herr_t                   result;
+    herr_t                   ret_value        = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Check arguments */
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "invalid type number");
+
+    if ( ( ! id_ptr ) || ( ! object_ptr ) ) 
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "bad id or object ptr");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    /* Only iterate through ID list if it is initialized and there are IDs in type */
+    if ( ( type_info_ptr )  && ( atomic_load(&(type_info_ptr->init_count)) > 0 ) && 
+         ( atomic_load(&(type_info_ptr->id_count)) > 0 ) ) {
+
+        /* Even though we have just tested to see if the type is non-empty, it is 
+         * possible that it will be emptied during the following do-while loop.
+         * Thus set *id_ptr and *object_ptr to values indicating that the type is
+         * empty before starting our search for the first entry in the type.
+         * Typically, the following assignments will be overwritten.
+         */
+        *id_ptr     = (hid_t)0;
+        *object_ptr = NULL;
+
+        /* Iterate over IDs */
+        if ( lfht_get_first(&(type_info_ptr->lfht), &id, &value) ) {
+
+            do {
+                id_info_ptr = (H5I_mt_id_info_t *)value;
+
+                info_k = atomic_load(&(id_info_ptr->k));
+
+                if ( ! info_k.marked ) {
+
+                    /* The stored object pointer might be an H5VL_object_t, in which
+                     * case we'll need to get the wrapped object struct (H5F_t *, etc.).
+                     */
+#if 0 
+                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                    object = H5I__unwrap((void *)info_k.object, type);
+                    H5_GCC_CLANG_DIAG_ON("cast-qual")
+#endif 
+                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                    result = H5I__unwrap((void *)info_k.object, type, &object);
+                    H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+                    if ( result < 0 )
+
+                        HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "Can't get unwrapped object");
+
+                    *id_ptr     = (hid_t)id;
+                    *object_ptr = object;
+                    break;
+                }
+            } while (lfht_get_next(&(type_info_ptr->lfht), id, &id, &value));
+        }
+    } else {
+
+        *id_ptr     = (hid_t)0;
+        *object_ptr = NULL;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_get_first() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_get_next
+ *
+ * Purpose:     Given a type ID, and the last id visited in an itteration 
+ *              through the specified index, return the next ID in the 
+ *              itteration and its associated un-wrapped object pointer 
+ *              in *next_id_ptr and *object_ptr respectively.
+ *
+ *              If there are no further IDs remaining in the type, 
+ *              *id_ptr is set to zero, and *object_ptr is set to NULL.  
+ *              Recall that since type 0 is not used, and since the type 
+ *              is encoded in the id, an id of zero cannot occur.
+ *
+ *              Note that the itteration supported by the H5I_get_first()
+ *              and H5I_get_next() is neither id nor insertion order.
+ *
+ *              Further, note that the index may be modified during the
+ *              itteration.  Deletions, additions, and modifications to
+ *              the object associated with an ID may or may not be 
+ *              reflected in the itterations.
+ *
+ *              On failure, *id_ptr and *object_ptr are undefined.
+ *
+ * Return:      Success:    SUCCEED
+ *
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_get_next(H5I_type_t type, hid_t last_id, hid_t *next_id_ptr, void ** next_object_ptr)
+{
+    H5I_mt_type_info_t      *type_info_ptr = NULL;    /* Pointer to the type */
+    unsigned long long int   id            = 0;
+    void                    *value         = NULL;
+    void                    *object        = NULL;
+    H5I_mt_id_info_t        *id_info_ptr   = NULL;
+    H5I_mt_id_info_kernel_t  info_k;
+    herr_t                   result;
+    herr_t                   ret_value     = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Check arguments */
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "invalid type number");
+
+    if ( ( last_id == 0 ) || ( type != H5I_TYPE(last_id) ) ) 
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid last_id");
+
+    if ( ( ! next_id_ptr ) || ( ! next_object_ptr ) ) 
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "bad next id or next object ptr");
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    /* Only iterate through ID list if it is initialized and there are IDs in type */
+    if ( ( type_info_ptr )  && ( atomic_load(&(type_info_ptr->init_count)) > 0 ) && 
+         ( atomic_load(&(type_info_ptr->id_count)) > 0 ) ) {
+
+        id = (unsigned long long int)last_id;
+
+        /* While we know that the target index is not empty, it is possible that 
+         * last_id is the last id in the itteration through theindex, or that the 
+         * next id will be deleted before we get to it.  
+         * 
+         * Thus set *next_id_ptr and *next_object_ptr to values indicating that we 
+         * have completed the itteration before we start searcing for the next 
+         * id in the indexxthe type is
+         * 
+         * Usually, the following assignments will be overwritten.
+         */
+        *next_id_ptr     = (hid_t)0;
+        *next_object_ptr = NULL;
+
+        /* Iterate over IDs starting just after last_id */
+        while ( lfht_get_next(&(type_info_ptr->lfht), id, &id, &value) ) {
+
+            id_info_ptr = (H5I_mt_id_info_t *)value;
+
+            info_k = atomic_load(&(id_info_ptr->k));
+
+            if ( ! info_k.marked ) {
+
+                /* The stored object pointer might be an H5VL_object_t, in which
+                 * case we'll need to get the wrapped object struct (H5F_t *, etc.).
+                 */
+#if 0 
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                object = H5I__unwrap((void *)info_k.object, type);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+#endif 
+                H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                result = H5I__unwrap((void *)info_k.object, type, &object);
+                H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+                if ( result < 0 )
+
+                    HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "Can't get unwrapped object");
+
+                *next_id_ptr     = (hid_t)id;
+                *next_object_ptr = object;
+                break;
+            }
+        }
+    } else {
+
+        *next_id_ptr     = (hid_t)0;
+        *next_object_ptr = NULL;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_get_next() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__find_id
+ *
+ * Purpose:     Given an object ID find the info struct that describes the
+ *              object.
+ *
+ * Return:      Success:    A pointer to the object's info struct.
+ *
+ *              Failure:    NULL
+ *
+ *-------------------------------------------------------------------------
+ */
+H5I_mt_id_info_t *
+H5I__find_id(hid_t id)
+{
+    hbool_t                 do_not_disturb_set;
+    hbool_t                 done = FALSE;
+    hbool_t                 have_global_mutex = TRUE; /* trivially true in the serial case */
+    hbool_t                 cls_is_mt_safe;
+    int                     pass = 0;
+    herr_t                  result;
+    H5I_type_t              type;                      /* ID's type */
+    H5I_mt_type_info_t     *type_info_ptr      = NULL; /* Pointer to the type */
+    H5I_mt_id_info_t       *id_info_ptr        = NULL; /* ID's info */
+    H5I_mt_id_info_t       *dup_id_info_ptr;
+    H5I_mt_id_info_t       *last_id_info_ptr   = NULL; /* ID's info */
+    H5I_mt_id_info_kernel_t info_k;
+    H5I_mt_id_info_kernel_t mod_info_k;
+    H5I_mt_id_info_t       *ret_value          = NULL; /* Return value */
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__num_calls), 1ULL);
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I__find_id(0x%llx) called. \n", (unsigned long long)id);
+#endif /* H5I_MT_DEBUG */
+
+#if defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD)
+
+    if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
+
+        HGOTO_DONE(NULL);
+
+#endif /* defined(H5_HAVE_THREADSAFE) || defined(H5_HAVE_MULTITHREAD) */
+
+    if ( have_global_mutex ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__find_id__num_calls_with_global_mutex), 1ULL);
+
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__find_id__num_calls_without_global_mutex), 1ULL);
+    }
+
+    /* Check arguments */
+    type = H5I_TYPE(id);
+    if (type <= H5I_BADID || (int)type >= atomic_load(&(H5I_mt_g.next_type)))
+        HGOTO_DONE(NULL);
+
+    do {
+
+        do_not_disturb_set = FALSE;
+        type_info_ptr = NULL;
+        id_info_ptr = NULL;
+
+        /* increment the pass and log retries */
+        if ( pass++ >= 1 ) {
+
+            atomic_fetch_add(&(H5I_mt_g.H5I__find_id__retries), 1ULL);
+        }
+
+        type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+        if  ( ( ! type_info_ptr ) || ( atomic_load(&(type_info_ptr->init_count)) <= 0) ) {
+
+            /* type doesn't exist, or has been logically deleted.  No point in
+             * in retrying, so just return NULL.
+             */
+            HGOTO_DONE(NULL);
+        }
+
+        cls_is_mt_safe = ((type_info_ptr->cls->flags & H5I_CLASS_IS_MT_SAFE) != 0);
+
+        /* Check for same ID as we have looked up last time */
+        last_id_info_ptr = atomic_load(&(type_info_ptr->last_id_info));
+
+        if ( ( last_id_info_ptr ) && ( last_id_info_ptr->id == id ) ) {
+
+            id_info_ptr = last_id_info_ptr;
+
+        } else {
+
+            if ( ! lfht_find(&(type_info_ptr->lfht), (unsigned long long int)id, (void **)&id_info_ptr) ) {
+
+                assert(NULL == id_info_ptr);
+            }
+
+            /* Remember this ID */
+            atomic_store(&(type_info_ptr->last_id_info), id_info_ptr);
+        }
+
+        if ( id_info_ptr ) {
+
+            info_k = atomic_load(&(id_info_ptr->k));
+
+            if ( info_k.marked ) {
+
+                /* the ID is marked for deletion -- nothing to do here.  Set
+                 * id_info_ptr to NULL and break out of the loop
+                 */
+                id_info_ptr = NULL;
+
+                break;
+            }
+
+            /* As long as we don't modify it, we can read an id whose do not disturb flag is set.
+             * Thus we only need to do a thread yield and continue if the is_future flag is set.
+             */
+            if ( ( info_k.is_future ) && ( info_k.do_not_disturb ) ) {
+
+                /* Another thread is in the process of performing an operation on the info kernel
+                 * that can't be rolled back -- either a future id realize_cb or discard_cb, or a
+                 * regular id callback that must be serialized.
+                 *
+                 * Thus we must wait until that thread is done and then re-start the operation -- which
+                 * may be moot by that point.
+                 */
+
+                /* update stats */
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_yields), 1ULL);
+
+                /* need to do better than this.  Want to call pthread_yield(),
+                 * but that call doesn't seem to be supported anymore.
+                 */
+                sleep(1);
+
+                continue;
+            }
+
+            if ( info_k.is_future ) {
+
+                /* we must try to resolve the future ID.  This requires 
+                 * the following three operations:
+                 *
+                 * 1) Call the realize callback on id_info_ptr->k.object
+                 *    This will return the actual ID and the actual object
+                 *
+                 * 2) Remove the actual ID from the index.
+                 *
+                 * 3) Discard id_info_ptr->k.object via a call to the
+                 *    discard callback
+                 *
+                 * This done, we must set id_info_ptr->k.is_future to FALSE,
+                 * and set id_info_ptr->k.object to point to the actual 
+                 * object.
+                 *
+                 * All this must be done as a single operation, with no 
+                 * other thread allowed into this critical region until 
+                 * we are done.
+                 *
+                 * The obvious way of doing this is with a mutex -- however,
+                 * the is_future flag only set when the async VOL is in use.
+                 * Thus in the overwelming majority of cases, this would 
+                 * impose significant overhead to no purpose.
+                 *
+                 * Instead, use the do_not_disturb flag in the kernel.
+                 *
+                 * If this flag is set, no other thread will begin an attempt
+                 * modify id_info_ptr->k until it is reset, and once it is set, 
+                 * any attempt to modify the kernel by a thread that is already
+                 * in progress will fail -- prompting a retry and a wait on 
+                 * the do_not_disturb flag.
+                 *
+                 * This has the advantage of adding only the cost of testing 
+                 * a flag in the kernel and then proceeding in the typical 
+                 * case -- acceptable overhead I hope.
+                 *
+                 * Note however, that in effect, I am using atomics to 
+                 * construct my own lock, and thus I am creating the 
+                 * possibility of a deadlock if either the realize_cb
+                 * or the discard_cb attempts to access this ID and 
+                 * modify its kernel.  Since I have no control over the
+                 * the async VOL, this is possible, and will have to be
+                 * dealt with if the situation arrises.
+                 *
+                 * Note also that the do_not_disturb flag is also used 
+                 * to serialize calls to ID callbacks in the HDF5 library --
+                 * creating the same potential for deadlocks.  However, these
+                 * calls are in the library, and thus any such misbehaviour 
+                 * can be addressed directly.
+                 */
+
+                if ( pass == 1 ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__future_id_conversions_attempted), 1ULL);
+                }
+
+                /* attempt to set the do_not_disturb flag.  If we fail, return 
+                 * to the beginning of the do/while loop and retry.  Note that 
+                 * circumstances may have changed -- in particular, some other 
+                 * thread may have realized the ID.
+                 */
+
+                mod_info_k.count             = info_k.count;
+                mod_info_k.app_count         = info_k.app_count;
+                mod_info_k.object            = info_k.object;
+
+                mod_info_k.marked            = info_k.marked;
+                mod_info_k.do_not_disturb    = TRUE;
+                mod_info_k.is_future         = info_k.is_future;
+
+                /* set mod_info_k.have_global_mutex to TRUE if either this thread has the 
+                 * global mutex or the class is not multi-thread safe.  Set mod_info_k.have_global_mutex
+                 * to TRUE in the latter case since we must grab the global mutex before calling
+                 * the realize callback and drop it when it returns.
+                 */
+                mod_info_k.have_global_mutex = ((have_global_mutex) || (! cls_is_mt_safe));
+
+                if ( ! atomic_compare_exchange_strong(&(id_info_ptr->k), &info_k, mod_info_k ) ) {
+
+                    /* Some other thread changed the value of id_info_ptr->k since we last read
+                     * it.  Thus we must return to the beginning of the do loop and start
+                     * again.  Note that it is possible that by that time, there will be
+                     * nothing left to do.
+                     */
+
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.num_failed_do_not_disturb_sets), 1ULL);
+
+                    continue;
+
+                } else {
+
+                    do_not_disturb_set = TRUE;
+
+#if 0 /* JRM */
+                    /* make info_k into a copy of the global kernel */
+                    info_k.do_not_disturb = TRUE;
+#else /* JTM */
+                    /* On the face of it, it would seem that we could just update info_k
+                     * to match mod_info_k, and use it in the next atomic_compare_exchange_strong()
+                     * call.  However, for reason or reasons unknown, this doesn't work.
+                     *
+                     * Instead, we reload info_k after the atomic_compare_exchange_strong(),
+                     * and verify that it contains the expected values.
+                     */
+                    info_k = atomic_load(&(id_info_ptr->k));
+
+                    assert(info_k.count             == mod_info_k.count);
+                    assert(info_k.app_count         == mod_info_k.app_count);
+                    assert(info_k.object            == mod_info_k.object);
+
+                    assert(info_k.marked            == mod_info_k.marked);
+                    assert(info_k.do_not_disturb    == mod_info_k.do_not_disturb);
+                    assert(info_k.is_future         == mod_info_k.is_future);
+                    assert(info_k.have_global_mutex == mod_info_k.have_global_mutex);
+#endif /* JRM */
+
+                    /* setup mod_info_k to reset the do_not_disturb flag.  If we are successful
+                     * at realizing the future ID, we will make further changes to mod_info_k
+                     * before we use it to overwrite id_info_ptr->k.
+                     */
+                    mod_info_k.do_not_disturb    = FALSE;
+                    mod_info_k.have_global_mutex = FALSE;
+
+                    /* update stats */
+                    atomic_fetch_add(&(H5I_mt_g.num_successful_do_not_disturb_sets), 1ULL);
+
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+                    fprintf(stdout, "H5I__find_id() set do not disturb on id = 0x%llx.\n",
+                              (unsigned long long)(id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+                }
+            }
+
+            assert( ( ! info_k.is_future ) || ( do_not_disturb_set ) );
+
+            /* save a copy of id_info_ptr for use when we reset the do_not_disturb flag. */
+            dup_id_info_ptr = id_info_ptr;
+
+            if ( info_k.is_future ) {
+
+                hid_t actual_id;
+                const void * actual_object;
+                const void * future_object;
+
+                atomic_fetch_add(&(H5I_mt_g.H5I__find_id__num_calls_to_realize_cb), 1ULL);
+                    
+                /* Invoke the realize callback, to get the actual object.  If this
+                 * call fails, we must reset the do_not_disturb flag and return NULL
+                 *
+                 * If we don't have the global mutex, and the class is not multi-thread
+                 * safe, grab the global mutex before the call and drop it immediately 
+                 * afterwards.
+                 */
+                if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb), 1ULL);
+                    H5_API_LOCK
+                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                    result = (id_info_ptr->realize_cb)((void *)info_k.object, &actual_id);
+                    H5_GCC_CLANG_DIAG_ON("cast-qual")
+                    H5_API_UNLOCK
+                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_realize_cb), 1ULL);
+
+                } else {
+
+                    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                    result = (id_info_ptr->realize_cb)((void *)info_k.object, &actual_id);
+                    H5_GCC_CLANG_DIAG_ON("cast-qual")
+                }
+
+                if ( result < 0 ) {
+
+                    id_info_ptr = NULL;
+                    done = TRUE;
+
+                } else if ( ( H5I_INVALID_HID == actual_id ) || ( H5I_TYPE(id) != H5I_TYPE(actual_id) ) ) {
+
+                    /* either we received an invalid ID from the realize_cb(), or that ID 
+                     * is not of the same type as the id passed into this function.  In either 
+                     * case, we must reset the do_not_disturb flag and return NULL.
+                     */
+
+                    id_info_ptr = NULL;
+                    done = TRUE;
+
+                } else {
+
+                    /* Swap the actual object in for the future object */
+
+                    future_object = info_k.object;
+
+                    /* The call to H5I__remove_common() simply marks the actual 
+                     * id as deleted, and if H5I_mt_g.marking is FALSE, deletes
+                     * it from the lock free hash table.
+                     *
+                     * Thus there shouldn't be any potential for dead lock here.
+                     */
+                    actual_object = H5I__remove_common(type_info_ptr, actual_id);
+
+                    assert(actual_object);
+
+                    atomic_fetch_add(&(H5I_mt_g.H5I__find_id__num_calls_to_discard_cb), 1ULL);
+
+                    /* Discard the future object.  If we don't hold the global mutex and 
+                     * the class is not multi-thread safe, grab the global mutex before 
+                     * the call to the discard_cb, and drop it immediately on return.
+                     */
+                    if ( ( ! have_global_mutex ) && ( ! cls_is_mt_safe ) ) {
+
+                        atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_locks_for_discard_cb), 1ULL);
+                        H5_API_LOCK
+                        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                        result = (id_info_ptr->discard_cb)((void *)future_object);
+                        H5_GCC_CLANG_DIAG_ON("cast-qual")
+                        H5_API_UNLOCK
+                        atomic_fetch_add(&(H5I_mt_g.H5I__find_id__global_mutex_unlocks_for_discard_cb), 1ULL);
+
+                    } else {
+
+                        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+                        result = (id_info_ptr->discard_cb)((void *)future_object);
+                        H5_GCC_CLANG_DIAG_ON("cast-qual")
+                    }
+
+                    if ( result < 0 ) {
+
+                        /* The discard callback has failed.  We must reset the do_not_disturb flag
+                         * and return NULL.
+                         */
+                        id_info_ptr = NULL;
+                        done = TRUE;
+
+                    } else {
+
+                        /* we have successfully realized the future ID.  Set up mod_info_k
+                         * to reflect this.
+                         *
+                         * Note that unlike the serial version of H5I, we do not set the 
+                         * realize_cb and discard_cb fields to NULL.  They are not accessed 
+                         * unless is_future is TRUE, and by not modifying them after the 
+                         * the instance of H5I_mt_id_info_t is allocated, there is no need
+                         * to make them atomic -- at least until compiliers start optimizing 
+                         * across function boundaries.
+                         */
+                        mod_info_k.is_future = FALSE;
+                        mod_info_k.object = actual_object;
+
+                        /* update stats */
+                        atomic_fetch_add(&(H5I_mt_g.H5I__find_id__future_id_conversions_completed), 1ULL);
+
+                        done = TRUE;
+                    }
+
+                    future_object = NULL;
+                }
+            }
+
+            if ( do_not_disturb_set ) {
+
+                /* we must reset the do_not_disturb flag, and possibly make other changes to the 
+                 * id info kernel as well.  Do this with a call to atomic_compare_exchange_strong().
+                 * This call must succeed, so simply assert that it does.
+                 *
+                 * In the event of failure in realizing the future id, id_info_ptr will have 
+                 * been set to NULL -- hence the use of dup_id_info_ptr below.
+                 */
+
+                assert( ! mod_info_k.do_not_disturb );
+
+                assert(atomic_compare_exchange_strong(&(dup_id_info_ptr->k), &info_k, mod_info_k));
+
+                atomic_fetch_add(&(H5I_mt_g.num_do_not_disturb_resets), 1ULL);
+
+#if H5I_MT_DEBUG_DO_NOT_DISTURB
+                fprintf(stdout, "H5I__find_id() reset do not disturb on id = 0x%llx.\n",
+                          (unsigned long long)(dup_id_info_ptr->id));
+#endif /* H5I_MT_DEBUG_DO_NOT_DISTURB */
+            }
+
+            done = TRUE;
+
+        } else {
+
+            /* target ID doesn't appear to exist */
+            done = TRUE;
+        }
+    } while ( ! done );
+
+    if ( id_info_ptr ) {
+
+        atomic_fetch_add(&(H5I_mt_g.H5I__find_id__ids_found), 1ULL);
+    }
+
+    /* Set return value */
+    ret_value = id_info_ptr;
+
+done:
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "   H5I__find_id(0x%llx) returns 0x%llx. \n", 
+              (unsigned long long)id, (unsigned long long) ret_value);
+#endif /* H5I_MT_DEBUG */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__find_id() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__find_id
  *
@@ -1595,6 +7166,7 @@ H5I__find_id(hid_t id)
     type_info = H5I_type_info_array_g[type];
     if (!type_info || type_info->init_count <= 0)
         HGOTO_DONE(NULL);
+
 
     /* Check for same ID as we have looked up last time */
     if (type_info->last_id_info && type_info->last_id_info->id == id)
@@ -1648,6 +7220,79 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__find_id() */
 
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I__find_id_cb
+ *
+ * Purpose:     Callback for searching for an ID with a specific pointer
+ *
+ *              Updated for multi-thread.
+ *
+ * Return:      Success:    H5_ITER_CONT (0) or H5_ITER_STOP (1)
+ *              Failure:    H5_ITER_ERROR (-1)
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+H5I__find_id_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
+{
+    H5I_mt_id_info_t        *id_info_ptr      = (H5I_mt_id_info_t *)_item; /* Pointer to the ID info */
+    H5I_mt_id_info_kernel_t  info_k;
+    H5I_get_id_ud_t         *udata            = (H5I_get_id_ud_t *)_udata; /* Pointer to user data */
+    H5I_type_t               type             = udata->obj_type;
+    void                    *object           = NULL;
+    herr_t                   result;
+    int                      ret_value        = H5_ITER_CONT; /* Return value */
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I__find_id_cb() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    /* Sanity check */
+    assert(id_info_ptr);
+    assert(udata);
+
+    info_k = atomic_load(&(id_info_ptr->k));
+
+    /* ignore entries that are marked for deletion */
+    if ( ! info_k.marked ) {
+
+        /* Get a pointer to the VOL connector's data */
+#if 0 
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        object = H5I__unwrap((void *)info_k.object, type); /* will hit global mutex */
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+#endif
+        H5_GCC_CLANG_DIAG_OFF("cast-qual")
+        result = H5I__unwrap((void *)info_k.object, type, &object);
+        H5_GCC_CLANG_DIAG_ON("cast-qual")
+
+        if ( result < 0 ) {
+
+            ret_value = H5_ITER_ERROR;
+
+        } else {
+
+            /* Check for a match */
+            if (object == udata->object) {
+
+                udata->ret_id = id_info_ptr->id;
+                ret_value     = H5_ITER_STOP;
+            }
+        }
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I__find_id_cb() */
+
+#else /* H5_HAVE_MULTITHREAD */
+
 /*-------------------------------------------------------------------------
  * Function:    H5I__find_id_cb
  *
@@ -1686,6 +7331,90 @@ H5I__find_id_cb(void *_item, void H5_ATTR_UNUSED *_key, void *_udata)
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I__find_id_cb() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/*-------------------------------------------------------------------------
+ * Function:    H5I_find_id
+ *
+ * Purpose:     Return the ID of an object by searching through the ID list
+ *              for the type.
+ *
+ *              Updated for multi-thread.
+ *
+ * Return:      SUCCEED/FAIL
+ *              (id will be set to H5I_INVALID_HID on errors or not found)
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5I_find_id(const void *object, H5I_type_t type, hid_t *id)
+{
+    H5I_mt_type_info_t *type_info_ptr = NULL;    /* Pointer to the type */
+    herr_t              ret_value = SUCCEED;     /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+#if H5I_MT_DEBUG
+    fprintf(stdout, "\n\n   H5I_find_id() called. \n\n\n");
+#endif /* H5I_MT_DEBUG */
+
+    assert(id);
+
+    *id = H5I_INVALID_HID;
+
+    type_info_ptr = atomic_load(&(H5I_mt_g.type_info_array[type]));
+
+    if ( ( ! type_info_ptr ) || ( atomic_load(&(type_info_ptr->init_count)) <= 0 ) )
+
+        HGOTO_ERROR(H5E_ID, H5E_BADGROUP, FAIL, "invalid type");
+
+    /* Only iterate through ID list if it is initialized and there are IDs in type */
+    if ( ( atomic_load(&(type_info_ptr->init_count)) > 0 ) && ( atomic_load(&(type_info_ptr->id_count)) > 0 ) ) {
+
+        H5I_get_id_ud_t         udata; /* User data */
+        H5I_mt_id_info_t       *id_info_ptr = NULL;
+        unsigned long long int  scan_id;
+        void                   *value;
+
+        /* Set up iterator user data */
+        udata.object   = object;
+        udata.obj_type = type;
+        udata.ret_id   = H5I_INVALID_HID;
+
+        /* Iterate over IDs for the ID type */
+        if ( lfht_get_first(&(type_info_ptr->lfht), &scan_id, &value) ) {
+
+            int ret;
+
+            do {
+                id_info_ptr = (H5I_mt_id_info_t *)value;
+
+                ret = H5I__find_id_cb((void *)id_info_ptr, NULL, (void *)&udata);
+
+                if (H5_ITER_ERROR == ret)
+
+                    HGOTO_ERROR(H5E_ID, H5E_BADITER, FAIL, "iteration failed");
+
+                if (H5_ITER_STOP == ret)
+
+                    break;
+
+            } while (lfht_get_next(&(type_info_ptr->lfht), scan_id, &scan_id, &value));
+        }
+
+        *id = udata.ret_id;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5I_find_id() */
+
+#else /* H5_HAVE_MULTITHREAD */
 
 /*-------------------------------------------------------------------------
  * Function:    H5I_find_id
@@ -1741,3 +7470,861 @@ H5I_find_id(const void *object, H5I_type_t type, hid_t *id)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5I_find_id() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+
+#if H5_HAVE_MULTITHREAD
+
+/************************************************************************
+ *
+ * H5I__clear_mt_id_info_free_list
+ *
+ *     Discard all entries on the id info free list in preparation for 
+ *     shutdown.  
+ *
+ *     Note that this function assumes that no other threads are active 
+ *     in H5I, and that it is therefore safe to ignore the re_allocable 
+ *     field in the instances of H5I_mt_id_info_t in the free list.
+ *
+ *                                          JRM -- 10/24/23
+ *
+ ************************************************************************/
+
+static herr_t
+H5I__clear_mt_id_info_free_list(void)
+{
+    H5I_mt_id_info_sptr_t fl_head;
+    H5I_mt_id_info_sptr_t null_snext = {NULL, 0ULL};
+    H5I_mt_id_info_t    * fl_head_ptr;
+    H5I_mt_id_info_t    * id_info_ptr;;
+    herr_t                ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    fl_head = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+    fl_head_ptr = fl_head.ptr;
+
+    if ( ( ! fl_head_ptr ) ||  ( 0ULL == atomic_load(&(H5I_mt_g.id_info_fl_len)) ) )
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5I_mt_g.id_info_fl_shead.ptr == NULL -- H5I_mt_g not initialized?");
+
+
+    while ( fl_head_ptr ) {
+
+        id_info_ptr = fl_head_ptr;
+
+        assert(H5I__ID_INFO == id_info_ptr->tag);
+        assert(id_info_ptr->on_fl);
+
+        fl_head = atomic_load(&(id_info_ptr->fl_snext));
+        fl_head_ptr = fl_head.ptr;
+
+        /* prepare *if_info_ptr for discard */
+        id_info_ptr->tag = H5I__ID_INFO_INVALID;
+        id_info_ptr->id  = (hid_t)0;
+        atomic_store(&(id_info_ptr->fl_snext), null_snext);
+
+        free(id_info_ptr);
+
+        atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_freed), 1ULL);
+        assert(atomic_fetch_sub(&(H5I_mt_g.id_info_fl_len), 1ULL) > 0ULL);
+    }
+    atomic_store(&(H5I_mt_g.id_info_fl_shead), null_snext);
+    atomic_store(&(H5I_mt_g.id_info_fl_stail), null_snext);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I__clear_mt_id_info_free_list() */
+
+/************************************************************************
+ *
+ * H5I__discard_mt_id_info
+ *
+ *     Append the supplied instance of H5I_mt_id_info_t on the id info
+ *     free list and increment H5I_mt_t.id_info_fl_len.
+ *
+ *     If the free list length exceeds 
+ *     H5I_mt_t.max_desired_id_info_fl_len, attempt the remove the node 
+ *     at the head of the id info free list from the free list, and 
+ *     discard it and decrement lfht_ptr->fl_len if successful.
+ *     ---- skip for now ---
+ *
+ *                                          JRM -- 9/1/23
+ *
+ ************************************************************************/
+
+static herr_t 
+H5I__discard_mt_id_info(H5I_mt_id_info_t * id_info_ptr)
+{
+    hbool_t done = FALSE;
+    hbool_t on_fl = FALSE;
+    uint64_t fl_len;
+    uint64_t max_fl_len;
+    H5I_mt_id_info_sptr_t snext = {NULL, 0ULL};
+    H5I_mt_id_info_sptr_t new_snext;
+    H5I_mt_id_info_sptr_t fl_stail;
+    H5I_mt_id_info_sptr_t fl_snext;
+    H5I_mt_id_info_sptr_t new_fl_snext;
+    H5I_mt_id_info_sptr_t new_fl_stail;
+    H5I_mt_id_info_sptr_t test_fl_stail;
+    H5I_mt_id_info_kernel_t info_k;
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI_NOERR
+
+    assert(id_info_ptr);
+    assert(H5I__ID_INFO == id_info_ptr->tag);
+
+    info_k = atomic_load(&(id_info_ptr->k));
+
+    assert(0 == info_k.count);
+    assert(0 == info_k.app_count);
+    assert(NULL == info_k.object);
+    assert(TRUE == info_k.marked);
+    assert(FALSE == info_k.do_not_disturb);
+    assert(FALSE == info_k.is_future);
+    assert(FALSE == info_k.have_global_mutex);
+
+    assert(!atomic_load(&(id_info_ptr->on_fl)));
+    assert(!atomic_load(&(id_info_ptr->re_allocable)));
+
+    snext = atomic_load(&(id_info_ptr->fl_snext));
+    new_snext.ptr = NULL;
+    new_snext.sn = snext.sn + 1;
+
+    atomic_store(&(id_info_ptr->fl_snext), new_snext);
+
+    assert( atomic_compare_exchange_strong(&(id_info_ptr->on_fl), &on_fl, TRUE) );
+#if 1 /* JRM */
+    assert( atomic_compare_exchange_strong(&(id_info_ptr->re_allocable), &on_fl, TRUE) );
+#endif /* JRM */
+
+    while ( ! done ) {
+
+        fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
+
+        assert(fl_stail.ptr);
+
+        /* it is possible that *fl_tail.ptr has passed through the free list
+         * and been re-allocated between the time we loaded it, and now.
+         * If so, fl_stail_ptr->on_fl will no longer be TRUE.
+         * This isn't a problem, but if so, the following if statement will fail.
+         */
+        // assert(atomic_load(&(fl_stail.ptr->on_fl)));
+
+        fl_snext = atomic_load(&(fl_stail.ptr->fl_snext));
+
+        test_fl_stail = atomic_load(&(H5I_mt_g.id_info_fl_stail));
+
+        if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
+
+            if ( NULL == fl_snext.ptr ) {
+
+                /* attempt to append id_info_ptr by setting fl_tail->fl_snext.ptr to id_info_ptr.
+                 * If this succeeds, update stats and attempt to set H5I_mt_g.id_info_fl_stail.ptr
+                 * to id_info_ptr as well.  This may or may not succeed, but in either
+                 * case we are done.
+                 */
+                new_fl_snext.ptr = id_info_ptr;
+                new_fl_snext.sn  = fl_snext.sn + 1;
+                if ( atomic_compare_exchange_strong(&(fl_stail.ptr->fl_snext), &fl_snext, new_fl_snext) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.id_info_fl_len), 1);
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_added_to_fl), 1);
+
+                    new_fl_stail.ptr = id_info_ptr;
+                    new_fl_stail.sn  = fl_stail.sn + 1;
+                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), 
+                                                          &fl_stail, new_fl_stail) ) {
+
+                        atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_update_cols), 1);
+                    }
+
+                    /* if appropriate, attempt to update H5I_mt_g.max_id_info_fl_len.  In the
+                     * event of a collision, just ignore it and go on, as I don't see any
+                     * reasonable way to recover.
+                     */
+                    if ( (fl_len = atomic_load(&(H5I_mt_g.id_info_fl_len))) >
+                         (max_fl_len = atomic_load(&(H5I_mt_g.max_id_info_fl_len))) ) {
+
+                        atomic_compare_exchange_strong(&(H5I_mt_g.max_id_info_fl_len), &max_fl_len, fl_len);
+                    }
+
+                    done = true;
+
+                } else {
+
+                    /* append failed -- update stats and try again */
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_append_cols), 1);
+
+                }
+            } else {
+
+                // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_next->tag)));
+
+                /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't
+                 * matter whether we succeed or fail, as if we fail, it
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                new_fl_stail.ptr = fl_snext.ptr;
+                new_fl_stail.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &fl_stail, new_fl_stail) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 1);
+                }
+            }
+        }
+    }
+
+    /* don't implement frees for now -- may deal with this in H5I_mt_enter/exit() */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I__discard_mt_id_info() */
+
+
+/************************************************************************
+ *
+ * H5I__new_mt_id_info
+ *
+ *     Test to see if an instance of H5I_mt_id_info_t is available on the
+ *     id info free list.  If there is, remove it from the free list, 
+ *     re-initialize it, and return a pointer to it.
+ *
+ *     Otherwise, allocate and initialize an instance of struct
+ *     lfht_fl_node_t and return a pointer to the included instance of
+ *     lfht_node_t to the caller.
+ *
+ *     Return a pointer to the new instance on success, and NULL on
+ *     failure.
+ *
+ *                                          JRM -- 8/30/23
+ *
+ ************************************************************************/
+
+static H5I_mt_id_info_t * 
+H5I__new_mt_id_info(hid_t id, unsigned count, unsigned app_count, const void * object, hbool_t is_future, 
+                    H5I_future_realize_func_t realize_cb, H5I_future_discard_func_t discard_cb)
+{
+    hbool_t fl_search_done = FALSE;;
+    H5I_mt_id_info_t * id_info_ptr = NULL;
+    H5I_mt_id_info_sptr_t sfirst;
+    H5I_mt_id_info_sptr_t new_sfirst;
+    H5I_mt_id_info_sptr_t test_sfirst;
+    H5I_mt_id_info_sptr_t slast;
+    H5I_mt_id_info_sptr_t new_slast;
+    H5I_mt_id_info_sptr_t snext;
+    H5I_mt_id_info_sptr_t new_snext;
+    H5I_mt_id_info_kernel_t new_k = {count, app_count, object, FALSE, FALSE, is_future, FALSE};
+    H5I_mt_id_info_kernel_t old_k;
+    H5I_mt_id_info_t * ret_value = NULL; /* Return value */
+
+    FUNC_ENTER_NOAPI(NULL)
+
+    sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+
+    if ( NULL == sfirst.ptr ) {
+
+        /* free list is not yet initialized */
+        fl_search_done = TRUE;
+    }
+
+    while ( ! fl_search_done ) {
+
+        sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+        slast = atomic_load(&(H5I_mt_g.id_info_fl_stail));
+
+        assert(sfirst.ptr);
+        assert(slast.ptr);
+
+        snext = atomic_load(&(sfirst.ptr->fl_snext));
+
+        test_sfirst = atomic_load(&(H5I_mt_g.id_info_fl_shead));
+
+        if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
+
+            if ( sfirst.ptr == slast.ptr ) {
+
+                if ( NULL == snext.ptr ) {
+
+                    /* the free list is empty */
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_empty), 1);
+                    fl_search_done = TRUE;
+                    break;
+                }
+
+                /* attempt to set H5I_mt_g.id_info_fl_stail to snext.  It doesn't
+                 * matter whether we succeed or fail, as if we fail, it
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                new_slast.ptr = snext.ptr;
+                new_slast.sn  = slast.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_stail), &slast, new_slast) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_tail_update_cols), 1ULL);
+                }
+            } else {
+
+                /* set up new_sfirst now in case we need it later.  */
+                assert(snext.ptr);
+                new_sfirst.ptr = snext.ptr;
+                new_sfirst.sn  = sfirst.sn + 1;
+
+                if ( ! atomic_load(&(sfirst.ptr->re_allocable)) ) {
+
+                    /* The entry at the head of the free list is not re allocable,
+                     * which means that there may be a pointer to it somewhere.  
+                     * Rather than take the risk, let it sit on the free list until 
+                     * is is marked as re allocable.
+                     */
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable), 1ULL);
+                    fl_search_done = true;
+
+                } else if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.id_info_fl_shead), &sfirst, new_sfirst) ) {
+
+                    /* the attempt to remove the first item from the free list
+                     * failed.  Update stats and try again.
+                     */
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_fl_head_update_cols), 1ULL);
+
+                } else {
+
+                    /* first has been removed from the free list.  Set fl_node_ptr to first,
+                     * update stats, and exit the loop by setting fl_search_done to true.
+                     */
+                    id_info_ptr = sfirst.ptr;
+
+                    assert(H5I__ID_INFO == id_info_ptr->tag);
+
+                    id_info_ptr->id = id;
+
+                    assert(atomic_load(&(id_info_ptr->on_fl)));
+                    atomic_store(&(id_info_ptr->on_fl), FALSE);
+
+                    assert(atomic_load(&(id_info_ptr->re_allocable)));
+                    atomic_store(&(id_info_ptr->re_allocable), FALSE);
+
+                    new_snext.ptr = NULL;
+                    new_snext.sn  = snext.sn + 1;
+
+                    assert(atomic_compare_exchange_strong(&(id_info_ptr->fl_snext), &snext, new_snext));
+
+                    old_k = atomic_load(&(id_info_ptr->k));
+
+                    assert(0 == old_k.count);
+                    assert(0 == old_k.app_count);
+                    assert(NULL == old_k.object);
+
+                    atomic_store(&(id_info_ptr->k), new_k);
+
+                    id_info_ptr->realize_cb = realize_cb;
+                    id_info_ptr->discard_cb = discard_cb;
+
+                    atomic_fetch_sub(&(H5I_mt_g.id_info_fl_len), 1ULL);
+                    atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_alloced_from_fl), 1ULL);
+
+                    fl_search_done = true;
+                }
+            }
+        }
+    } /* while ( ! fl_search_done ) */
+
+    if ( NULL == id_info_ptr ) {
+
+        id_info_ptr = (H5I_mt_id_info_t *)malloc(sizeof(H5I_mt_id_info_t));
+
+        if ( NULL == id_info_ptr )
+            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, NULL, "ID info allocation failed");
+
+        atomic_fetch_add(&(H5I_mt_g.num_id_info_structs_alloced_from_heap), 1ULL);
+
+        id_info_ptr->tag = H5I__ID_INFO;
+        id_info_ptr->id = id;
+        atomic_init(&(id_info_ptr->k), new_k);
+        id_info_ptr->realize_cb = realize_cb;
+        id_info_ptr->discard_cb = discard_cb;
+        atomic_init(&(id_info_ptr->on_fl), FALSE);
+        atomic_init(&(id_info_ptr->re_allocable), FALSE);
+        snext.ptr = NULL;
+        snext.sn = 0ULL;
+        atomic_init(&(id_info_ptr->fl_snext), snext);
+    }
+
+    assert(id_info_ptr);
+
+    /* Set return value */
+    ret_value = id_info_ptr;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I__new_mt_id_info() */
+
+
+/************************************************************************
+ *
+ * H5I__clear_mt_type_info_free_list
+ *
+ *     Discard all entries on the type info free list in preparation for 
+ *     shutdown.  
+ *
+ *     Note that this function assumes that no other threads are active 
+ *     in H5I, and that it is therefore safe to ignore the re_allocable 
+ *     field in the instances of H5I_mt_type_info_t in the free list.
+ *
+ *                                          JRM -- 10/24/23
+ *
+ ************************************************************************/
+
+static herr_t
+H5I__clear_mt_type_info_free_list(void)
+{
+    H5I_mt_type_info_sptr_t fl_head;
+    H5I_mt_type_info_sptr_t null_snext = {NULL, 0ULL};
+    H5I_mt_type_info_t    * fl_head_ptr;
+    H5I_mt_type_info_t    * type_info_ptr;;
+    herr_t                  ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    fl_head = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+    fl_head_ptr = fl_head.ptr;
+
+    if ( ! fl_head_ptr )
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5I_mt_g.type_info_fl_shead.ptr == NULL -- H5I_mt_g not initialized?");
+
+
+    while ( fl_head_ptr ) {
+
+        type_info_ptr = fl_head_ptr;
+
+        assert(H5I__TYPE_INFO == type_info_ptr->tag);
+        assert(0 == atomic_load(&(type_info_ptr->init_count)));
+        assert(0 == atomic_load(&(type_info_ptr->id_count)));
+        assert(atomic_load(&(type_info_ptr->lfht_cleared)));
+        assert(atomic_load(&(type_info_ptr->on_fl)));
+
+        fl_head = atomic_load(&(type_info_ptr->fl_snext));
+        fl_head_ptr = fl_head.ptr;
+
+        /* prepare *if_info_ptr for discard */
+        type_info_ptr->tag = H5I__TYPE_INFO_INVALID;
+        type_info_ptr->cls = NULL;
+        atomic_store(&(type_info_ptr->fl_snext), null_snext);
+
+        free(type_info_ptr);
+
+        atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_freed), 1ULL);
+        assert(atomic_fetch_sub(&(H5I_mt_g.type_info_fl_len), 1ULL) > 0ULL);
+    }
+    atomic_store(&(H5I_mt_g.type_info_fl_shead), null_snext);
+    atomic_store(&(H5I_mt_g.type_info_fl_stail), null_snext);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I__clear_mt_type_info_free_list() */
+
+/************************************************************************
+ *
+ * H5I__discard_mt_type_info
+ *
+ *     Append the supplied instance of H5I_mt_type_info_t on the type info
+ *     free list and increment H5I_mt_t.type_info_fl_len.
+ *
+ *     If the free list length exceeds 
+ *     H5I_mt_t.max_desired_type_info_fl_len, attempt the remove the node 
+ *     at the head of the type info free list from the free list, and 
+ *     discard it and decrement lfht_ptr->fl_len if successful.
+ *     ---- skip for now ---
+ *
+ *                                          JRM -- 9/1/23
+ *
+ ************************************************************************/
+
+static herr_t 
+H5I__discard_mt_type_info(H5I_mt_type_info_t * type_info_ptr)
+{
+    hbool_t done = FALSE;
+    hbool_t on_fl = FALSE;
+    uint64_t fl_len;
+    uint64_t max_fl_len;
+    H5I_mt_type_info_sptr_t snext = {NULL, 0ULL};
+    H5I_mt_type_info_sptr_t new_snext;
+    H5I_mt_type_info_sptr_t fl_stail;
+    H5I_mt_type_info_sptr_t fl_snext;
+    H5I_mt_type_info_sptr_t new_fl_snext;
+    H5I_mt_type_info_sptr_t new_fl_stail;
+    H5I_mt_type_info_sptr_t test_fl_stail;
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI_NOERR
+
+    assert(type_info_ptr);
+    assert(H5I__TYPE_INFO == type_info_ptr->tag);
+
+    assert(0 == atomic_load(&(type_info_ptr->init_count)));
+    assert(0 == atomic_load(&(type_info_ptr->id_count)));
+
+    assert(atomic_load(&(type_info_ptr->lfht_cleared)));
+
+    assert(!atomic_load(&(type_info_ptr->on_fl)));
+    assert(!atomic_load(&(type_info_ptr->re_allocable)));
+
+    snext = atomic_load(&(type_info_ptr->fl_snext));
+
+    new_snext.ptr = NULL;
+    new_snext.sn = snext.sn + 1;
+
+    atomic_store(&(type_info_ptr->fl_snext), new_snext);
+
+    assert( atomic_compare_exchange_strong(&(type_info_ptr->on_fl), &on_fl, TRUE) );
+
+#if 1 /* JRM */
+    assert( atomic_compare_exchange_strong(&(type_info_ptr->re_allocable), &on_fl, TRUE) );
+#endif /* JRM */
+
+    while ( ! done ) {
+
+        fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
+
+        assert(fl_stail.ptr);
+
+        /* it is possible that *fl_tail.ptr has passed through the free list
+         * and been re-allocated between the time we loaded it, and now.
+         * If so, fl_stail_ptr->on_fl will no longer be TRUE.
+         * This isn't a problem, but if so, the following if statement will fail.
+         */
+        // assert(atomic_load(&(fl_stail.ptr->on_fl)));
+
+        fl_snext = atomic_load(&(fl_stail.ptr->fl_snext));
+
+        test_fl_stail = atomic_load(&(H5I_mt_g.type_info_fl_stail));
+
+        if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
+
+            if ( NULL == fl_snext.ptr ) {
+
+                /* attempt to append type_info_ptr by setting fl_tail->fl_snext.ptr to type_info_ptr.
+                 * If this succeeds, update stats and attempt to set H5I_mt_g.type_info_fl_stail.ptr
+                 * to type_info_ptr as well.  This may or may not succeed, but in either
+                 * case we are done.
+                 */
+                new_fl_snext.ptr = type_info_ptr;
+                new_fl_snext.sn  = fl_snext.sn + 1;
+                if ( atomic_compare_exchange_strong(&(fl_stail.ptr->fl_snext), &fl_snext, new_fl_snext) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.type_info_fl_len), 1);
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_added_to_fl), 1);
+
+                    new_fl_stail.ptr = type_info_ptr;
+                    new_fl_stail.sn  = fl_stail.sn + 1;
+                    if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), 
+                                                          &fl_stail, new_fl_stail) ) {
+
+                        atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_head_update_cols), 1);
+                    }
+
+                    /* if appropriate, attempt to update H5I_mt_g.max_type_info_fl_len.  In the
+                     * event of a collision, just ignore it and go on, as I don't see any
+                     * reasonable way to recover.
+                     */
+                    if ( (fl_len = atomic_load(&(H5I_mt_g.type_info_fl_len))) >
+                         (max_fl_len = atomic_load(&(H5I_mt_g.max_type_info_fl_len))) ) {
+
+                        atomic_compare_exchange_strong(&(H5I_mt_g.max_type_info_fl_len), &max_fl_len, fl_len);
+                    }
+
+                    done = true;
+
+                } else {
+
+                    /* append failed -- update stats and try again */
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_append_cols), 1);
+
+                }
+            } else {
+
+                // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_next->tag)));
+
+                /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't
+                 * matter whether we succeed or fail, as if we fail, it
+                 * just means that some other thread beat us to it.
+                 *
+                 * that satype, it doesn't hurt to collect stats
+                 */
+                new_fl_stail.ptr = fl_snext.ptr;
+                new_fl_stail.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &fl_stail, new_fl_stail) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 1);
+                }
+            }
+        }
+    }
+
+    /* don't implement frees for now -- may deal with this in H5I_mt_enter/exit() */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I__discard_mt_type_info() */
+
+
+/************************************************************************
+ *
+ * H5I__new_mt_type_info
+ *
+ *     Test to see if an instance of H5I_mt_type_info_t is available on the
+ *     type info free list.  If there is, remove it from the free list, 
+ *     re-initialize it, and return a pointer to it.
+ *
+ *     Otherwise, allocate and initialize an instance of struct
+ *     lfht_fl_node_t and return a pointer to the included instance of
+ *     lfht_node_t to the caller.
+ *
+ *     Return a pointer to the new instance on success, and NULL on
+ *     failure.
+ *
+ *                                          JRM -- 8/30/23
+ *
+ ************************************************************************/
+
+static H5I_mt_type_info_t * 
+H5I__new_mt_type_info(const H5I_class_t *cls, unsigned reserved)
+{
+    hbool_t fl_search_done = FALSE;;
+    H5I_mt_type_info_t * type_info_ptr = NULL;
+    H5I_mt_type_info_sptr_t sfirst;
+    H5I_mt_type_info_sptr_t new_sfirst;
+    H5I_mt_type_info_sptr_t test_sfirst;
+    H5I_mt_type_info_sptr_t slast;
+    H5I_mt_type_info_sptr_t new_slast;
+    H5I_mt_type_info_sptr_t snext;
+    H5I_mt_type_info_sptr_t new_snext;
+    H5I_mt_type_info_t * ret_value = NULL; /* Return value */
+
+    FUNC_ENTER_NOAPI(NULL)
+
+    sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+
+    if ( NULL == sfirst.ptr ) {
+
+        /* free list is not yet initialized */
+        fl_search_done = TRUE;
+    }
+
+    while ( ! fl_search_done ) {
+
+        sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+        slast = atomic_load(&(H5I_mt_g.type_info_fl_stail));
+
+        assert(sfirst.ptr);
+        assert(slast.ptr);
+
+        snext = atomic_load(&(sfirst.ptr->fl_snext));
+
+        test_sfirst = atomic_load(&(H5I_mt_g.type_info_fl_shead));
+
+        if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
+
+            if ( sfirst.ptr == slast.ptr ) {
+
+                if ( NULL == snext.ptr ) {
+
+                    /* the free list is empty */
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_empty), 1);
+                    fl_search_done = TRUE;
+                    break;
+                }
+
+                /* attempt to set H5I_mt_g.type_info_fl_stail to snext.  It doesn't
+                 * matter whether we succeed or fail, as if we fail, it
+                 * just means that some other thread beat us to it.
+                 *
+                 * that satype, it doesn't hurt to collect stats
+                 */
+                new_slast.ptr = snext.ptr;
+                new_slast.sn  = slast.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_stail), &slast, new_slast) ) {
+
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_tail_update_cols), 1ULL);
+                }
+            } else {
+
+                /* set up new_sfirst now in case we need it later.  */
+                assert(snext.ptr);
+                new_sfirst.ptr = snext.ptr;
+                new_sfirst.sn  = sfirst.sn + 1;
+
+                if ( ! atomic_load(&(sfirst.ptr->re_allocable)) ) {
+
+                    /* The entry at the head of the free list is not re allocable,
+                     * which means that there may be a pointer to it somewhere.  
+                     * Rather than take the risk, let it sit on the free list until 
+                     * is is marked as re allocable.
+                     */
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable), 1ULL);
+                    fl_search_done = TRUE;
+
+                } else if ( ! atomic_compare_exchange_strong(&(H5I_mt_g.type_info_fl_shead), &sfirst, new_sfirst) ) {
+
+                    /* the attempt to remove the first item from the free list
+                     * failed.  Update stats and try again.
+                     */
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_fl_head_update_cols), 1ULL);
+
+                } else {
+
+                    /* first has been removed from the free list.  Set fl_node_ptr to first,
+                     * update stats, and exit the loop by setting fl_search_done to true.
+                     */
+                    type_info_ptr = sfirst.ptr;
+
+                    assert(H5I__TYPE_INFO == type_info_ptr->tag);
+
+                    type_info_ptr->cls = cls;
+
+                    atomic_store(&(type_info_ptr->init_count), 0);
+                    atomic_store(&(type_info_ptr->id_count), reserved);
+                    atomic_store(&(type_info_ptr->last_id_info), NULL);
+                    atomic_store(&(type_info_ptr->lfht_cleared), FALSE);
+
+                    lfht_init(&(type_info_ptr->lfht));
+
+                    assert(atomic_load(&(type_info_ptr->on_fl)));
+                    atomic_store(&(type_info_ptr->on_fl), FALSE);
+
+                    assert(atomic_load(&(type_info_ptr->re_allocable)));
+                    atomic_store(&(type_info_ptr->on_fl), FALSE);
+
+                    assert(atomic_load(&(type_info_ptr->re_allocable)));
+                    atomic_store(&(type_info_ptr->re_allocable), FALSE);
+
+                    new_snext.ptr = NULL;
+                    new_snext.sn  = snext.sn + 1;
+
+                    assert(atomic_compare_exchange_strong(&(type_info_ptr->fl_snext), &snext, new_snext));
+
+                    atomic_fetch_sub(&(H5I_mt_g.type_info_fl_len), 1ULL);
+                    atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_alloced_from_fl), 1ULL);
+
+                    fl_search_done = true;
+                }
+            }
+        }
+    } /* while ( ! fl_search_done ) */
+
+    if ( NULL == type_info_ptr ) {
+
+        type_info_ptr = (H5I_mt_type_info_t *)malloc(sizeof(H5I_mt_type_info_t));
+
+        if ( NULL == type_info_ptr )
+            HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, NULL, "ID info allocation failed");
+
+        atomic_fetch_add(&(H5I_mt_g.num_type_info_structs_alloced_from_heap), 1ULL);
+
+        type_info_ptr->tag = H5I__TYPE_INFO;
+        type_info_ptr->cls = cls;
+        atomic_init(&(type_info_ptr->init_count), 0);
+        atomic_init(&(type_info_ptr->id_count), 0ULL);
+        atomic_init(&(type_info_ptr->nextid), reserved);
+        atomic_init(&(type_info_ptr->last_id_info), NULL);
+        atomic_init(&(type_info_ptr->lfht_cleared), FALSE);
+        lfht_init(&(type_info_ptr->lfht));
+        atomic_init(&(type_info_ptr->on_fl), FALSE);
+        atomic_init(&(type_info_ptr->re_allocable), FALSE);
+        snext.ptr = NULL;
+        snext.sn = 0ULL;
+        atomic_init(&(type_info_ptr->fl_snext), snext);
+    }
+
+    assert(type_info_ptr);
+
+    /* Set return value */
+    ret_value = type_info_ptr;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5I__new_mt_type_info() */
+
+
+/************************************************************************
+ *
+ * H5I__enter()
+ *
+ *     Perform required book keeping on entry to the H5I package.  At 
+ *     present this consists of incrementing H5I_mt_g.threads_active, 
+ *     updating statistics, and updating free lists if appropriate.
+ *
+ *     Note that this function should eventually be converted to a 
+ *     macro to reduce overhead.
+ *
+ *                                            JRM -- 12/14/23
+ *
+ * Changes: None.
+ *
+ ************************************************************************/
+
+void
+H5I__enter(hbool_t public_api)
+{
+    if ( public_api ) {
+
+        atomic_fetch_add(&(H5I_mt_g.num_H5I_entries_via_public_API), 1ULL);
+
+    } else {
+
+        atomic_fetch_add(&(H5I_mt_g.num_H5I_entries_via_internal_API), 1ULL);
+    }
+
+    if ( atomic_fetch_add(&(H5I_mt_g.active_threads), 1ULL) >
+         atomic_load(&(H5I_mt_g.max_active_threads)) ) {
+ 
+        atomic_fetch_add(&(H5I_mt_g.max_active_threads), 1ULL);
+    }
+
+    return;
+
+} /* H5I__enter() */
+
+
+/************************************************************************
+ *
+ * H5I__exit()
+ *
+ *     Perform required book keeping on exit from the H5I package.  At 
+ *     present this consists of updating statistics, and updating free 
+ *     lists if appropriate.
+ *
+ *                                            JRM -- 12/14/23
+ *
+ * Changes: None.
+ *
+ ************************************************************************/
+
+void
+H5I__exit(void)
+{
+
+    if ( 1ULL == atomic_fetch_sub(&(H5I_mt_g.active_threads), 1ULL) ) {
+
+        atomic_fetch_add(&(H5I_mt_g.times_active_threads_is_zero), 1ULL);
+    }
+
+    return;
+
+} /* H5I__exit() */
+
+#endif /* H5_HAVE_MULTITHREAD */
+

--- a/hdf5/src/H5Ipkg.h
+++ b/hdf5/src/H5Ipkg.h
@@ -50,9 +50,1297 @@
 /* Map an ID to an ID type number */
 #define H5I_TYPE(a) ((H5I_type_t)(((hid_t)(a) >> ID_BITS) & TYPE_MASK))
 
+#if H5_HAVE_MULTITHREAD
+#include "lfht.h"
+#endif /* H5_HAVE_MULTITHREAD */
+
 /****************************/
 /* Package Private Typedefs */
 /****************************/
+#if H5_HAVE_MULTITHREAD /****************************************************************************************/
+
+/****************************************************************************************
+ *
+ * struct H5I_mt_id_info_sptr_t
+ *
+ * H5I_mt_id_info_sptr_t combines a pointer to H5I_mt_id_info_t with a serial number
+ * that must be incremented each time the value of the pointer is changed.
+ *
+ * When it appears in either H5I_mt_id_info_t or H5I_mt_t, it should do so
+ * as an atomic object.  Its purpose is to avoid ABA bugs.
+ *
+ * ptr: pointer to an instance of H5I_mt_id_info_t, or NULL if undefined.
+ *
+ * sn:  uint64_t that is initialized to 0, and must be incremented by 1 each time the
+ *      ptr field is modified.
+ *
+ ****************************************************************************************/
+
+typedef struct H5I_mt_id_info_t H5I_mt_id_info_t; /* forward declaration */
+
+typedef struct H5I_mt_id_info_sptr_t {
+
+    H5I_mt_id_info_t * ptr;
+    uint64_t           sn;
+
+} H5I_mt_id_info_sptr_t;
+
+
+/****************************************************************************************
+ *
+ * struct H5I_mt_type_info_sptr_t
+ *
+ * H5I_mt_vol_info_sptr_t combines a pointer to H5I_mt_vol_info_t with a serial number
+ * that must be incremented each time the value of the pointer is changed.
+ *
+ * When it appears in either H5I_mt_type_info_t or H5I_mt_t, it should do so
+ * as an atomic object.  Its purpose is to avoid ABA bugs.
+ *
+ * ptr: pointer to an instance of H5I_mt_type_info_t, or NULL if undefined.
+ *
+ * sn:  uint64_t that is initialized to 0, and must be incremented by 1 each time the
+ *      ptr field is modified.
+ *
+ ****************************************************************************************/
+
+typedef struct H5I_mt_type_info_t H5I_mt_type_info_t; /* forward declaration */
+
+typedef struct H5I_mt_type_info_sptr_t {
+
+    H5I_mt_type_info_t * ptr;
+    uint64_t             sn;
+
+} H5I_mt_type_info_sptr_t;
+
+
+/****************************************************************************************
+ *
+ * struct H5I_mt_t
+ *
+ * A single, global instance of H5I_mt_t is used to collect all global variables that
+ *
+ * 1) are existing globals that must be made into atomic variables in the MT context, or
+ *
+ * 2) are new globals needed for the MT case, or 
+ *
+ * 3) are needed to maintain statistics on the multi-thread version of H5I.
+ *
+ * The single instance is declared as a global, and initialized in H5I_init().
+ *
+ * Fields are discussed individually below.
+ *
+ *
+ * Pre-existing Globals:
+ *
+ * type_info_array: Array of atomic pointers to H5I_mt_type_info_t of length
+ *      H5I_MAX_NUM_TYPES used to map type IDs to the associated instances of 
+ *      H5I_mt_type_info_t,
+ *
+ *      All elements of the type_info_array are initialized to NULL, and are 
+ *      set back to NULL when an instance of H5I_mt_type_info_t is discarded.
+ *
+ * type_info_allocation_table:  Array of atomic booleans used to track which 
+ *      entries in the type_info_array are allocated.
+ *
+ *      In the single thread version of H5I, type IDs can be re-used.  I had 
+ *      originally planed to simplify the H5I code by dis-allowing this in the 
+ *      multi-thread H5I code, however this breaks the serial tests.  While it 
+ *      is doubtful that this has any practical significance, this is not 
+ *      something to be changed lightly -- particularly in the initial prototype.
+ *
+ *      To make things more complicated, type IDs are allocated in two different
+ *      ways.  Index types used by the HDF5 library proper are allocated statically
+ *      in the header files, while index types created by users are allocated 
+ *      dynamically in H5Iregister_type().  In the single thread code, this is 
+ *      done via one of two methods:
+ *
+ *      First, type IDs are allocated sequentially using the H5I_next_type_g
+ *      to maintain the next ID to be allocated.  This method is used until 
+ *      the value of H5I_next_type_g is equal to H5I_MAX_NUM_TYPES.  When this
+ *      method is exhausted, the sequential code does a linear scan on the 
+ *      H5I_type_info_array_g, and uses the index of the first NULL entry 
+ *      encountered as the next type ID to allocate.
+ *
+ *      This proceedure of scanning the type_info_array is not directly applicable
+ *      to the multi-thread case as the ID is allocated well before the associated
+ *      entry in the type_info_array is set to point to the new instance of 
+ *      H5I_mt_type_info_t.  While this could be finessed with a special value 
+ *      indicating that the entry in the type_info_array was allocated but invalid,
+ *      an allocation table seemed to offer a cleaner solution.
+ *
+ *      Thus the booleans in the type_info_allocation_table are set to TRUE when
+ *      a type ID is allocated, and back to FALSE when it is de-allocated.  In 
+ *      contrast, the pointers in the type_info_array are NULL if the associated
+ *      ID is undefined, and point to the associated instance of H5I_mt_type_info_t
+ *      if the ID is defined.  This lets us treat type ID allocation and definition
+ *      as two, separate atomic operations.
+ *
+ *      Note that for now at least, I am retaining the two methods of allocating 
+ *      type IDs.  While this is redundant, I hesitate to change the behaviour of 
+ *      the H5I code any more than is necessary -- at least for the initial 
+ *      multi-thread implementation.  
+ *
+ * next_type: Integer variable to keep track of the number of types allocated.  
+ *      Its value is the next type ID to be handed out, so it is always one greater 
+ *      than the number of types.
+ *
+ *      Starts at 1 instead of 0 because it makes trace output look nicer.  If more
+ *      types (or IDs within a type) are needed, adjust TYPE_BITS in H5Ipkg.h
+ *      and/or increase size of hid_t
+ *
+ *      Note that to simplify the MT implementation, type IDs are not recycled,
+ *      unlike the current single thread implementation.
+ *
+ * marking: Functionally, the marking field replaces the H5I_marking_g boolean 
+ *      in the single thread version of H5I.  It is an integer instead of a 
+ *      boolean to allow for multiple threads setting and re-setting it.
+ *
+ *      In the serial version, when H5I_marking_g is set, when entries are deleted,
+ *      they are first marked (i.e. info_ptr->k.marked is set to TRUE), an then
+ *      deleted from the index at a later point.
+ *
+ *      The argument for this is that callbacks may delete entries on the index
+ *      and thus cause data structure corruption.  
+ *
+ *      However, in the multi-thread case, entries can be deleted whenever, so 
+ *      the point seems moot -- we simply need to adjust to that fact.
+ *
+ *      However, for now I am keeping the marking field, and will use as per the 
+ *      single thread version.  That said, it will probably be removed later.
+ *
+ *
+ * New Globals:
+ *
+ * active_threads: Atomic integer used to track the number of threads currently
+ *      active in H5I.
+ *
+ *
+ * id_info_fl_shead: Atomic instance of struct H5I_mt_id_info_sptr_t, which contains 
+ *      a pointer (ptr) to the head of the id info free list, and a serial number (sn) 
+ *      which must be incremented each time a new value is assigned to id_info_fl_shead.
+ *
+ *      The objective here is to prevent ABA bugs, which would otherwise occasionally 
+ *      allow re-allocation of instances of H5I_mt_id_info_t before all threads that
+ *      might have pointers to them have left H5I.
+ *
+ *      Note that once initialized, the id info free list will always contain at least
+ *      one entry, and is logically empty if id_info_fl_shead.ptr == id_info_fl_stail.ptr 
+ *      != NULL.
+ *
+ * id_info_fl_stail: Atomic instance of struct H5I_mt_id_info_sptr_t, which contains
+ *      a pointer (ptr) to the tail of the id info free list, and a serial number (sn)
+ *      which must be incremented each time a new value is assigned to id_info_fl_stail.
+ *
+ *      The objective here is to prevent ABA bugs, which would otherwise occasionally
+ *      allow re-allocation of instances of H5I_mt_id_info_t before all threads that
+ *      might have pointers to them have left H5I.
+ *
+ * id_info_fl_len: Atomic unsigned integer used to maintain a count of the number of 
+ *      nodes on the id info free list.  Note that due to the delay between free list
+ *      insertions and deletins, and the update of this field, this count may be off 
+ *      for brief periods of time.
+ *
+ *      Recall that the free list must always contain at least one entry.  Thus, when 
+ *      correct, fl_len will be one greater than the number of entries on the free list.
+ *
+ * max_desired_id_info_fl_len: Unsigned integer field containing the desired maximum 
+ *      id info free list length.  This is of necessity a soft limit as entries cannot
+ *      be removed from the head of the free list unless their re-allocable fields are 
+ *      TRUE.  
+ *
+ *
+ * type_info_fl_shead: Atomic instance of struct H5I_mt_type_info_sptr_t, which contains 
+ *      a pointer (ptr) to the head of the type info free list, and a serial number (sn) 
+ *      which must be incremented each time a new value is assigned to type_info_fl_shead.
+ *
+ *      The objective here is to prevent ABA bugs, which would otherwise occasionally 
+ *      allow re-allocation of instances of H5I_mt_type_info_t before all threads that
+ *      might have pointers to them have left H5I.
+ *
+ *      Note that once initialized, the type info free list will always contain at least
+ *      one entry, and is logically empty if type_info_fl_shead.ptr == type_info_fl_stail.ptr 
+ *      != NULL.
+ *
+ * type_info_fl_stail: Atomic instance of struct H5I_mt_type_info_sptr_t, which contains
+ *      a pointer (ptr) to the tail of the type info free list, and a serial number (sn)
+ *      which must be incremented each time a new value is assigned to type_info_fl_stail.
+ *
+ *      The objective here is to prevent ABA bugs, which would otherwise occasionally
+ *      allow re-allocation of instances of H5I_mt_type_info_t before all threads that
+ *      might have pointers to them have left H5I.
+ *
+ * type_info_fl_len: Atomic unsigned integer used to maintain a count of the number of 
+ *      nodes on the type info free list.  Note that due to the delay between free list
+ *      insertions and deletins, and the update of this field, this count may be off 
+ *      for brief periods of time.
+ *
+ *      Recall that the free list must always contain at least one entry.  Thus, when 
+ *      correct, type_info_fl_len will be one greater than the number of entries on the 
+ *      free list.
+ *
+ * max_desired_type_info_fl_len: Unsigned integer field containing the desired maximum 
+ *      type info free list length.  This is of necessity a soft limit as entries cannot
+ *      be removed from the head of the free list unless their re-allocable fields are 
+ *      TRUE.  
+ *
+ * Statistics:
+ *
+ * dump_stats_on_shutdown: Boolean flag that controls display of statistics in 
+ *      H5I_term_package().  When set to TRUE, stats are displayed when shutdown is
+ *      complete, and just before stats are reset.
+ *
+ * init_type_registrations: Number of initial type registrations.
+ *
+ * duplicate_type_registrations: Number of duplicate type registrations.
+ *
+ * type_registration_collisions: Number of type registration collisions.  Collisions 
+ *      occur when two or more threads simultaneously create new instances of 
+ *      H5I_type_info_t, but only one can be inserted into H5I_type_info_array_g[] for 
+ *      the target type.
+ *
+ *
+ * ID Info Free List Statistics:
+ *
+ * max_id_info_fl_len: Maximum number of entries that have resided on the id info free 
+ *      list at any point during the current run.  In the multi-thread case, this number 
+ *      should be viewed as aproximate.
+ *
+ * num_id_info_structs_alloced_from_heap: Number of instances of H5I_mt_id_info_t 
+ *      allocated from the heap.
+ *
+ * num_id_info_structs_alloced_from_fl:  Number of times an instance of H5I_mt_id_info_t
+ *      has been allocated from the id info free list.
+ *
+ * num_id_info_structs_freed: Number of instances of H5I_mt_id_info_t that have been 
+ *      freed -- that is returned to the heap.
+ *
+ * num_id_info_structs_added_to_fl: Number of times an instance of H5I_mt_id_info_t
+ *      has been added to the id info free list.
+ *
+ * num_id_info_fl_head_update_cols: Number of id info free list head update collisions.
+ *
+ * num_id_info_fl_tail_update_cols: Number of id info free list tail update collisions.
+ *
+ * num_id_info_fl_append_cols: Number of collisions when appending an instance of 
+ *     H5I_mt_id_info_t to the id info free list.
+ *
+ * num_id_info_structs_marked_reallocatable: Each instance of H5I_mt_id_info_t has its 
+ *      reallocatable field set to FALSE when it is allocated, or it is inserted
+ *      on the id info free list. This field is set to TRUE when it is known that all
+ *      threads that might have a pointer to the instance of H5I_mt_id_info_t have left
+ *      H5I.  num_id_info_structs_marked_reallocatable is incremented each time the 
+ *      reallocatable field of an instance of H5I_mt_id_info_t is set to TRUE.  Note
+ *      that this should only happen when an instance is on the id info free list.
+ *
+ * num_id_info_fl_alloc_req_denied_due_to_empty:  Number of times an alloc request
+ *      for an instance of H5I_mt_id_info_t has had to be satisfied from the heap
+ *      instead of the free list because the id info free list is empty.  Recall 
+ *      that the id info free list is logically empty when it contains only a single
+ *      entry.
+ *
+ * num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable:  Number of times an 
+ *      alloc request for an instance of H5I_mt_id_info_t has had to be satisfied 
+ *      from the heap instead of the free list because the reallocatable field of the
+ *      instance of H5I_mt_id_info_t at the head of the id info free list is set to
+ *      FALSE.
+ *
+ * num_id_info_fl_frees_skipped_due_to_empty: Number of times that an instance of 
+ *      H5I_mt_id_info_t on the id info free list is not released to the heap because
+ *      the free list is empty (or more correctly, has fewer than 
+ *      max_desired_id_info_fl_len entries).
+ *
+ * num_id_info_fl_frees_skipped_due_to_head_not_reallocable: Number of times that an 
+ *      instance of H5I_mt_id_info_t on the id info free list is not released to the heap 
+ *      because the reallocatable field of the instance of H5I_mt_id_info_t at the head 
+ *      of the id info free list is set to FALSE.
+ *
+ *
+ * Type Info Free List Statistics:
+ *
+ * max_type_info_fl_len: Maximum number of entries that have resided on the type info free 
+ *      list at any point during the current run.  In the multi-thread case, this number 
+ *      should be viewed as aproximate.
+ *
+ * num_type_info_structs_alloced_from_heap: Number of instances of H5I_mt_type_info_t 
+ *      allocated from the heap.
+ *
+ * num_type_info_structs_alloced_from_fl:  Number of times an instance of 
+ *      H5I_mt_type_info_t has been allocated from the type info free list.
+ *
+ * num_type_info_structs_freed: Number of instances of H5I_mt_type_info_t that have been 
+ *      freed -- that is returned to the heap.
+ *
+ * num_type_info_structs_added_to_fl: Number of times an instance of H5I_mt_type_info_t
+ *      has been added to the type info free list.
+ *
+ * num_type_info_fl_head_update_cols: Number of type info free list head update collisions.
+ *
+ * num_type_info_fl_tail_update_cols: Number of type info free list tail update collisions.
+ *
+ * num_type_info_fl_append_cols: Number of collisions when appending an instance of 
+ *     H5I_mt_type_info_t to the type info free list.
+ *
+ * num_type_info_structs_marked_reallocatable: Each instance of H5I_mt_type_info_t has its 
+ *      reallocatable field set to FALSE when it is allocated, or it is inserted
+ *      on the type info free list. This field is set to TRUE when it is known that all
+ *      threads that might have a pointer to the instance of H5I_mt_type_info_t have left
+ *      H5I.  num_type_info_structs_marked_reallocatable is incremented each time the 
+ *      reallocatable field of an instance of H5I_mt_type_info_t is set to TRUE.  Note
+ *      that this should only happen when an instance is on the type info free list.
+ *
+ * num_type_info_fl_alloc_req_denied_due_to_empty:  Number of times an alloc request
+ *      for an instance of H5I_mt_type_info_t has had to be satisfied from the heap
+ *      instead of the free list because the type info free list is empty.  Recall 
+ *      that the type info free list is logically empty when it contains only a single
+ *      entry.
+ *
+ * num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable:  Number of times an 
+ *      alloc request for an instance of H5I_mt_type_info_t has had to be satisfied 
+ *      from the heap instead of the free list because the reallocatable field of the
+ *      instance of H5I_mt_type_info_t at the head of the type info free list is set to
+ *      FALSE.
+ * 
+ *
+ * Statistics on the behaviour of the H5I__mark_node() function:
+ *
+ * H5I__mark_node__num_calls: Number of times that H5I__mark_node() is called.
+ *
+ * H5I__mark_node__num_calls_with_global_mutex: Number of times that H5I__mark_node() 
+ *      is called by a thread that has the global mutex.
+ *
+ * H5I__mark_node__num_calls_without_global_mutex: Number of times that H5I__mark_node() 
+ *      is called by a thread that doesn't have the global mutex.
+ *
+
+ *
+ * H5I__mark_node__already_marked: Number of times that H5I__mark_node() is called on an 
+ *      instance of H5I_mt_id_info_t that is alread marked for deletion.
+ *
+ * H5I__mark_node__marked: Number of times that H5I__mark_node() marks the supplied 
+ *      instance of H5I_mt_id_info_t for deletion.
+ *
+ * H5I__mark_node__marked_by_another_thread: Number of times that H5I__mark_node() is 
+ *      called on an un-marked instance of H5I_mt_id_info_t which is marked for 
+ *      deletion by another thread before H5I__mark_node() can do so.
+ *
+ * H5I__mark_node__no_ops: Number of times that H5I__mark_node() examines the supplied 
+ *      instance of H5I_mt_id_info_t and does nothing.  Note that this count does not 
+ *      include either instances of H5I_mt_id_info_t that are already marked, or cases
+ *      in which the discard_cb or free_func fails and force is not set.
+ *
+ * H5I__mark_node__global_mutex_locks_for_discard_cb: Number of times that H5I__mark_node()
+ *      obtains the global mutex prior to a call to the discard_cb.
+ *
+ * H5I__mark_node__global_mutex_unlocks_for_discard_cb; Number of times that 
+ *      H5I__mark_node() drops the global mutex immediately after a call to the 
+ *      discard_cb
+ *
+ * H5I__mark_node__discard_cb_failures_marked: Number of times that H5I__mark_node() 
+ *      calls the discard_cb associated with the supplied instance of H5I_mt_id_info_t,
+ *      that call fails, and marks the supplied instance of H5I_mt_id_info_t
+ *      reguardless.
+ *
+ * H5I__mark_node__discard_cb_failures_unmarked: Number of times that H5I__mark_node()
+ *      calls the discard_cb associated with the supplied instance of H5I_mt_id_info_t,
+ *      that call fails, and does not mark the supplied instance of H5I_mt_id_info_t.
+ *
+ * H5I__mark_node__discard_cb_successes: Number of times that H5I__mark_node()
+ *      successfully calls the discard_cb associated with the supplied instance of 
+ *      H5I_mt_id_info_t.
+ *
+ * H5I__mark_node__global_mutex_locks_for_free_func: Number of times that 
+ *      H5I__mark_node() obtains the global mutex prior to a call to the free_func.
+ *
+ * H5I__mark_node__global_mutex_unlocks_for_free_func: Number of times that 
+ *      H5I__mark_node() drops the global mutex just after a call to the free_func.
+ *
+ * H5I__mark_node__free_func_failures_marked: Number of times that H5I__mark_node()
+ *      calls the free_func associated with the supplied instance of H5I_mt_id_info_t,
+ *      that call fails, and H5I__mark_node() marks the supplied instance of 
+ *      H5I_mt_id_info_t reguardless.
+ *
+ * H5I__mark_node__free_func_failures_unmarked: Number of times that H5I__mark_node()
+ *      calls the free_func associated with the supplied instance of H5I_mt_id_info_t,
+ *      that call fails, and H5I__mark_node() does not mark the supplied instance of 
+ *      H5I_mt_id_info_t.
+ *
+ * H5I__mark_node__free_func_successes: Number of times that H5I__mark_node()
+ *      successfully calls the free_func associated with the supplied instance of 
+ *      H5I_mt_id_info_t.
+ *
+ * H5I__mark_node__retries: Number of times that H5I__mark_node() has to retry the 
+ *      the operation.  This happens when an attempt to overwrite the kernel of the 
+ *      supplied instance of H5I_mt_id_info_t fails -- presumably due to some other 
+ *      thread modifying the kernel between the time that H5I__mark_node() reads it
+ *      and attempts to overwrite it with a modified version.
+ *
+ * 
+ * Statistics on the behaviour of the H5I__remove_common() function.
+ *
+ * H5I__remove_common__num_calls: Number of times that H5I__remove_common() is called.
+ *
+ * H5I__remove_common__already_marked: Number of times that H5I__remove_common() is 
+ *      called on an ID whose instance of H5I_mt_id_info_t that is alread marked for 
+ *      deletion.
+ *
+ * H5I__remove_common__marked_by_another_thread:  Number of times that 
+ *      H5I__remove_common() is called on an ID whose associaetd instance of 
+ *      H5I_mt_id_info_t is un-marked for deletion on entry, but is marked for
+ *      deletion by another thread before H5I__remove_common() can do so.
+ *
+ * H5I__remove_common__marked: Number of times that H5I__remove_common() is called
+ *      on an ID and marks the associated instance of H5I_mt_id_info_t for deletion.
+ *
+ * H5I__remove_common__target_not_in_lfht:  Number of times that H5I__remove_common() is called
+ *      on an ID that doesn't appear in the lock free hash table.
+ *
+ * H5I__remove_common__retries; Number of time that H5I__remove_common() has to retry
+ *      the operation.  This happens when an attempt to overwrite the kernel of the
+ *      instance of H5I_mt_id_info_t associated with the supplied ID fails -- presumably 
+ *      due to some other thread modifying the kernel between the time that 
+ *      H5I__remove_common() reads it and attempts to overwrite it with a modified version.
+ *
+ *
+ * Statistics on the behaviour of the H5I__find_id() function.
+ *
+ * H5I__find_id__num_calls: Number of times that H5I__find_id() is called.
+ *
+ * H5I__find_id__num_calls_with_global_mutex: Number of times that H5I__find_id() is called
+ *      by a thread that holds the global mutex.
+ *
+ * H5I__find_id__num_calls_without_global_mutex: Number of times that H5I__find_id() is 
+ *      called by a thread that doesn't hold the global mutex.
+ *
+ * H5I__find_id__ids_found: Number of times that H6I__find_id() succeeds and returns
+ *      a pointer to the object associated with the supplied ID.
+ *
+ * H5I__find_id__num_calls_to_realize_cb: Number of times that H5I__find_id() calls 
+ *      the realize_cb.
+ *
+ * H5I__find_id__global_mutex_locks_for_realize_cb: Number of times that H5I__find_id()
+ *      obtains the global mutex before calling the realize_cb.
+ *
+ * H5I__find_id__global_mutex_unlocks_for_realize_cb: Number of times that H5I__find_id()
+ *      drops the global mutex immediately after calling the realize_cb.
+ *
+ * H5I__find_id__num_calls_to_discard_cb: Number of times that H5I__find_id() calls
+ *      the discard_cb.
+ *
+ * H5I__find_id__global_mutex_locks_for_discard_cb: Number of times that H5I__find_id()
+ *      obtains the global mutex before calling the discard_cb.
+ *
+ * H5I__find_id__global_mutex_unlocks_for_discard_cb: Number of times that H5I__find_id()
+ *      drops the global mutex immediately after calling the discard_cb.
+ *
+ * H5I__find_id__future_id_conversions_attempted: Number of times that H5I__find_id()
+ *      is called on a future ID, and attempts to convert it to a real ID.
+ *
+ * H5I__find_id__future_id_conversions_completed: Number of times that H5I__find_id()
+ *      successfully converts a future ID to a real ID.
+ *
+ * H5I__find_id__retries: Number of times that H5I__find_id() has to re-try the 
+ *      operation.  This is caused by either another thread modifying the kernel of
+ *      instance of H5I_mt_id_info_t associated with the ID in the period between 
+ *      the time that H5I__find_id() reads it, and then tries to overwrite it with 
+ *      a modified version, or the function encounters a set do_not_disturb flag.
+ *
+ *
+ * Statistics on the behaviour of the H5I_register_using_existing_id() function.
+ *
+ * H5I_register_using_existing_id__num_calls: Number of times that 
+ *      H5I_register_using_existing_id() is called.
+ *
+ * H5I_register_using_existing_id__num_marked_only: Number of times that the supplied
+ *      existing ID refers to an ID that has been marked for deletion, but not yet 
+ *      removed from the index.
+ *
+ * H5I_register_using_existing_id__num_id_already_in_use: Number of times that the supplied
+ *      existing ID refers to an ID that is already back in use.
+ *
+ * H5I_register_using_existing_id__num_failures: Number of times that 
+ *      H5I_register_using_existing_id() reports failure.
+ *
+ *
+ * Statistics on the behaviour of the H5I_subst() function.
+ *
+ * H5I_subst__num_calls: Number of times that H5I_subst() is called.
+ *
+ * H5I_subst__marked_on_entry; Number of times that the supplied ID is marked for 
+ *      deletion on entry.
+ *
+ *  H5I_subst__marked_during_call: Number of times that the supplied ID is marked for
+ *      deletion by another thread after entry.
+ *
+ * H5I_subst__retries: Number of times that H5I_subst() has to retry its modifications
+ *      to the kernel of the id info associated with the ID.
+ *
+ * H5I_subst__failures: Number of times that H5I_subst() fails to perform the 
+ *      requested operation.
+ *
+ *
+ * Statistics on the behaviour of the H5I__dec_ref() function.
+ *
+ * H5I__dec_ref__num_calls: Number of times that H5I__dec_ref() is called.
+ *
+ * H5I__dec_ref__num_app_calls: Number of times that H5I__dec_ref() is called with 
+ *      the app flag set to TRUE.  
+ *
+ * H5I__dec_ref__num_calls_with_global_mutex: Number of times that H5I__dec_ref() is 
+ *      called by a thread that holds the global mutex.
+ *
+ * H5I__dec_ref__num_calls_without_global_mutex: Number of times that H5I__dec_ref() is 
+ *      called by a thread that does not hold the global mutex.
+ *
+ * H5I__dec_ref__marked_on_entry: Number of times that the supplied ID is marked for
+ *      deletion on entry.  Note that this should be almost impossible, as the 
+ *      ID will have to be marked for deletion between the call to H5I__find_id() 
+ *      and the check for the deleted flag early in the do/while loop.
+ *
+ * H5I__dec_ref__marked_during_call: Number of times that the supplied ID is marked for
+ *      deletion by another thread after entry.
+ *
+ * H5I__dec_ref__marked: Number of times that H5I__dec_ref() successfully marks an 
+ *      ID for deletion after reducing its ref count to zero.
+ *
+ * H5I__dec_ref__decremented: Number of times that H5I__dec_ref() successfully 
+ *      decrements the ref count of an ID, but the resulting ref count is still 
+ *      greater that zero.
+ *
+ * H5I__dec_ref__app_decremented: Number of times that H5I__dec_ref() successfully 
+ *      decrements the application ref count of an ID, while also decrementing 
+ *      the regular reference count.
+ *
+ * H5I__dec_ref__calls_to_free_func: Number of times that H5I__dec_ref() 
+ *      calls the free_func()
+ *
+ * H5I__dec_ref__global_mutex_locks_for_free_func: Number of times that H5I__dec_ref()
+ *      obtains the global mutext just prior to calling the free_func.
+ *
+ * H5I__dec_ref__global_mutex_unlocks_for_free_func:  Number of times that 
+ *      H5I__dec_ref() drops the global mutext just after calling the free_func.
+ *
+ * H5I__dec_ref__free_func_failed; Number of times that H5I__dec_ref() calls the 
+ *      free function on an ID, and that free function fails.
+ *
+ * H5I__dec_ref__retries: Number of times that H5I__dec_ref() has to retry the 
+ *      operation.  Retries are caused by changes to the kernel between read 
+ *      and attempt to overwrite with a modified version, and by encountering 
+ *      a set do_not_disturb flag.
+ *
+ *
+ * Statistics on the behavious of the H5I__inc_ref() function.
+ *
+ * H5I__inc_ref__num_calls: Number of times that H5I__inc_ref() is called
+ *
+ * H5I__inc_ref__num_app_calls: Number of times that H5I__inc_ref() is called
+ *      with the app_ref parameter set.
+ *
+ * H5I__inc_ref__marked_on_entry:  Number of times that the supplied ID is marked for
+ *      deletion on entry.  Note that this should be almost impossible, as the
+ *      ID will have to be marked for deletion between the call to H5I__find_id() and 
+ *      the check for the marked flag early in the do/while loop.
+ *
+ * H5I__inc_ref__marked_during_call: Number of times that the supplied ID is marked for
+ *      deletion by another thread after entry.
+ *
+ * H5I__inc_ref__incremented: Number of times that H5I__inc_ref() successfully 
+ *      increments the ref count on an ID.
+ *
+ * H5I__inc_ref__app_incremented: Number of times that H5I__inc_ref() successfully 
+ *      increments the application ref count on an ID.
+ *
+ * H5I__inc_ref__retries: Number of times that H5I__inc_ref() has to retry the
+ *      operation.  Retries are caused by changes to the kernel between read
+ *      and attempt to overwrite with a modified version, and by encountering
+ *      a set do_not_disturb flag.
+ *
+ *
+ * Statistics on the behaviour of the H5I__iterate_cb() function.
+ *
+ * H5I__iterate_cb__num_calls: Number of times that H5I__iterate_cb() is called.
+ *
+ * H5I__iterate_cb__num_calls__with_global_mutex: Number of times that 
+ *      H5I__iterate_cb() is called by a thread that holds the global mutex.
+ *
+ * H5I__iterate_cb__num_calls__without_global_mutex: Number of times that 
+ *      H5I__iterate_cb() is called by a thread that doesn't hold the global mutex.
+ *
+ * H5I__iterate_cb__marked_during_call: Number of times that the ID supplied to
+ *      H5I__iterate_cb() is marked for deletion by another thread during the 
+ *      execution of the function.
+ *
+ * H5I__iterate_cb__num_user_func_calls: Number of times that H5I__iterate_cb() 
+ *      calls the user_func.
+ *
+ * H5I__iterate_cb__global_mutex_locks_for_user_func: Number of times that 
+ *      H5I__iterate_cb() obtains the global mutex before calling the 
+ *      user func.
+ *
+ * H5I__iterate_cb__global_mutex_unlocks_for_user_func: Number of times that 
+ *      H5I__iterate_cb() drops the global mutex immedaitely after calling the
+ *      user func.
+ *
+ * H5I__iterate_cb__num_user_func_successes: Number of times that the supplied 
+ *      user function is called and returns success.
+ *
+ * H5I__iterate_cb__num_user_func_iter_stops: Number of times that the supplied
+ *      user function is called and halts the itteration.
+ *
+ * H5I__iterate_cb__num_user_func_fails: Number of times that the supplied
+ *      user function is called and returns failure -- also halting the 
+ *      itteration.
+ *
+ * H5I__iterate_cb__num_user_func_skips: Number of times that H5I__iterate_cb()
+ *      skips any attempt to call the user function.
+ *
+ * H5I__iterate_cb__num_retries: Number of times that H5I__iterate_cb() has to
+ *      retry the operation.
+ *
+ *
+ * Statistics on the behaviour of the H5I__unwrap() function.
+ *
+ * H5I__unwrap__num_calls: Number of times that H5I__unwrap() is called.
+ *
+ * H5I__unwrap__num_calls_with_global_mutex:  Number of times that H5I__unwrap() 
+ *      is called by a thread that holds the global mutex.
+ *
+ * H5I__unwrap__num_calls_without_global_mutex:  Number of times that H5I__unwrap() 
+ *      is called by a thread that does not hold the global mutex.
+ *
+ * H5I__unwrap__times_global_mutex_locked_for_H5VL:  Number of times that 
+ *      H5I__unwrap() has locked the global mutex prior to a call to 
+ *      H5VL_object_data().
+ *
+ * H5I__unwrap__times_global_mutex_unlocked_for_H5VL:  Number of times that 
+ *      H5I__unwrap() has unlocked the global mutex after a call to 
+ *      H5VL_object_data().
+ *
+ * H5I__unwrap__times_global_mutex_locked_for_H5T:  Number of times that 
+ *      H5I__unwrap() has locked the global mutex prior to a call to 
+ *      H5T_get_actual_type().
+ *
+ * H5I__unwrap__times_global_mutex_unlocked_for_H5T:  Number of times that 
+ *      H5I__unwrap() has unlocked the global mutex after a call to 
+ *      H5T_get_actual_type().
+ *
+ * 
+ * Statistics on the behaviour of the H5I_is_file_object() function.
+ *
+ * H5I_is_file_object__num_calls: Number of times that H5I_is_file_object() is 
+ *      called.
+ *
+ * H5I_is_file_object__num_calls_to_H5T_is_named: Number of times that 
+ *      H5I_is_file_object() calls H5T_is_named().
+ *
+ * H5I_is_file_object__global_mutex_locks_for_H5T_is_named:  Number of times that
+ *      H5I_is_file_object() obtains the global must just prior to a call to 
+ *      H5T_is_named().
+ *
+ * H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named:i Number of times that
+ *      H5I_is_file_object() drops the global must just after to a call to
+ *      H5T_is_named().
+ *
+ *
+ * Statistics on operations on the do not disturb flag.  See the discussion of 
+ * the this fields and the kernel in the comments on H5I_mt_id_info_t for further 
+ * details.
+ *
+ * num_do_not_disturb_yields: Number of times a thread encounters a H5I_mt_id_info_t
+ *      kernel with the do_not_disturb flag set, and retries as a result.
+ *
+ * num_successful_do_not_disturb_sets: Number of times that a thread successfully
+ *      attempts to set the do_not_disturb flag on the kernel of an instance of 
+ *      H5I_mt_id_info_t.
+ *
+ * num_failed_do_not_disturb_sets: Number of times that a thread unsuccessfully
+ *      attempts to set the do_not_disturb flag on the kernel of an instance of 
+ *      H5I_mt_id_info_t.
+ *
+ * num_do_not_disturb_resets: Number of time that a thread resets the do_not_disturb
+ *      flag on the kernel of an instance of H5I_mt_id_info_t.  Note that in theory,
+ *      this operation will always succeed.  If it doesn't, it should trigger an 
+ *      assertion failure.
+ *
+ *
+ * Statistics on H5I entries and numbers of threads active in H5I.
+ *
+ * num_H5I_entries_via_public_API: Number of times that H5I has been entered via 
+ *      public API calls.
+ *
+ * num_H5I_entries_via_internal_API: Number of times that H5I has been entered via
+ *      private API calls.  Note that H5I public API functions call private H5I APIs,
+ *      and that some private API calls are called from within H5I.  Thus this 
+ *      number is typically overstated.
+ *
+ * max_active_threads: Maximum number of threads active in H5I at any point in time.
+ *      Note that due to the number of internal and external API entry points, this 
+ *      value will likely be overstated.
+ *
+ * times_active_threads_is_zero:  Number of times that the number of threads active 
+ *      in H5I drops to zero.
+ *
+ ****************************************************************************************/
+
+#define H5I__MAX_DESIRED_ID_INFO_FL_LEN    256ULL
+#define H5I__MAX_DESIRED_TYPE_INFO_FL_LEN   16ULL
+
+typedef struct H5I_mt_type_info_t H5I_mt_type_info_t;  /* forward declaration */
+
+typedef struct H5I_mt_t {
+
+    /* Pre-existing Globals: */
+    _Atomic (H5I_mt_type_info_t *) type_info_array[H5I_MAX_NUM_TYPES];
+    _Atomic hbool_t type_info_allocation_table[H5I_MAX_NUM_TYPES];
+    _Atomic int next_type;
+    _Atomic int marking;
+
+    /* New Globals: */
+    _Atomic uint32_t active_threads;
+
+    _Atomic H5I_mt_id_info_sptr_t   id_info_fl_shead;
+    _Atomic H5I_mt_id_info_sptr_t   id_info_fl_stail;
+    _Atomic uint64_t                id_info_fl_len;
+    _Atomic uint64_t                max_desired_id_info_fl_len; /* Ray changed it to atomic */
+
+    _Atomic H5I_mt_type_info_sptr_t type_info_fl_shead;
+    _Atomic H5I_mt_type_info_sptr_t type_info_fl_stail;
+    _Atomic uint64_t                type_info_fl_len;
+    _Atomic uint64_t                max_desired_type_info_fl_len; /* Ray changed it to atomic */
+
+    /* Statistics: */
+
+    _Atomic hbool_t dump_stats_on_shutdown;
+    
+    /* type registration stats */
+    _Atomic uint64_t init_type_registrations;
+    _Atomic uint64_t duplicate_type_registrations;
+    _Atomic uint64_t type_registration_collisions;
+
+    /* id info free list stats */
+    _Atomic uint64_t max_id_info_fl_len;
+    _Atomic uint64_t num_id_info_structs_alloced_from_heap;
+    _Atomic uint64_t num_id_info_structs_alloced_from_fl;
+    _Atomic uint64_t num_id_info_structs_freed;
+    _Atomic uint64_t num_id_info_structs_added_to_fl;
+    _Atomic uint64_t num_id_info_fl_head_update_cols;
+    _Atomic uint64_t num_id_info_fl_tail_update_cols;
+    _Atomic uint64_t num_id_info_fl_append_cols;
+    _Atomic uint64_t num_id_info_structs_marked_reallocatable;
+    _Atomic uint64_t num_id_info_fl_alloc_req_denied_due_to_empty;
+    _Atomic uint64_t num_id_info_fl_alloc_req_denied_due_to_head_not_reallocable;
+    _Atomic uint64_t num_id_info_fl_frees_skipped_due_to_empty;
+    _Atomic uint64_t num_id_info_fl_frees_skipped_due_to_head_not_reallocable;
+
+    /* type info free list stats */
+    _Atomic uint64_t max_type_info_fl_len;
+    _Atomic uint64_t num_type_info_structs_alloced_from_heap;
+    _Atomic uint64_t num_type_info_structs_alloced_from_fl;
+    _Atomic uint64_t num_type_info_structs_freed;
+    _Atomic uint64_t num_type_info_structs_added_to_fl;
+    _Atomic uint64_t num_type_info_fl_head_update_cols;
+    _Atomic uint64_t num_type_info_fl_tail_update_cols;
+    _Atomic uint64_t num_type_info_fl_append_cols;
+    _Atomic uint64_t num_type_info_structs_marked_reallocatable;
+    _Atomic uint64_t num_type_info_fl_alloc_req_denied_due_to_empty;
+    _Atomic uint64_t num_type_info_fl_alloc_req_denied_due_to_head_not_reallocable;
+    _Atomic uint64_t num_type_info_fl_frees_skipped_due_to_empty;
+    _Atomic uint64_t num_type_info_fl_frees_skipped_due_to_head_not_reallocable;
+
+    /* H5I__mark_node() stats */
+    _Atomic uint64_t H5I__mark_node__num_calls;
+    _Atomic uint64_t H5I__mark_node__num_calls_with_global_mutex;
+    _Atomic uint64_t H5I__mark_node__num_calls_without_global_mutex;
+    _Atomic uint64_t H5I__mark_node__already_marked;
+    _Atomic uint64_t H5I__mark_node__marked;
+    _Atomic uint64_t H5I__mark_node__marked_by_another_thread;
+    _Atomic uint64_t H5I__mark_node__no_ops;
+    _Atomic uint64_t H5I__mark_node__global_mutex_locks_for_discard_cb;
+    _Atomic uint64_t H5I__mark_node__global_mutex_unlocks_for_discard_cb;
+    _Atomic uint64_t H5I__mark_node__discard_cb_failures_marked;
+    _Atomic uint64_t H5I__mark_node__discard_cb_failures_unmarked;
+    _Atomic uint64_t H5I__mark_node__discard_cb_successes;
+    _Atomic uint64_t H5I__mark_node__global_mutex_locks_for_free_func;
+    _Atomic uint64_t H5I__mark_node__global_mutex_unlocks_for_free_func;
+    _Atomic uint64_t H5I__mark_node__free_func_failures_marked;
+    _Atomic uint64_t H5I__mark_node__free_func_failures_unmarked;
+    _Atomic uint64_t H5I__mark_node__free_func_successes;
+    _Atomic uint64_t H5I__mark_node__retries;
+
+    /* H5I__remove_common() stats */
+    _Atomic uint64_t H5I__remove_common__num_calls;
+    _Atomic uint64_t H5I__remove_common__already_marked;
+    _Atomic uint64_t H5I__remove_common__marked_by_another_thread;
+    _Atomic uint64_t H5I__remove_common__marked;
+    _Atomic uint64_t H5I__remove_common__target_not_in_lfht;
+    _Atomic uint64_t H5I__remove_common__retries;
+
+    /* H5I__find_id() stats */
+    _Atomic uint64_t H5I__find_id__num_calls;
+
+    _Atomic uint64_t H5I__find_id__num_calls_with_global_mutex;
+    _Atomic uint64_t H5I__find_id__num_calls_without_global_mutex;
+
+    _Atomic uint64_t H5I__find_id__ids_found;
+
+    _Atomic uint64_t H5I__find_id__num_calls_to_realize_cb;
+    _Atomic uint64_t H5I__find_id__global_mutex_locks_for_realize_cb;
+    _Atomic uint64_t H5I__find_id__global_mutex_unlocks_for_realize_cb;
+    _Atomic uint64_t H5I__find_id__num_calls_to_discard_cb;
+    _Atomic uint64_t H5I__find_id__global_mutex_locks_for_discard_cb;
+    _Atomic uint64_t H5I__find_id__global_mutex_unlocks_for_discard_cb;
+
+    _Atomic uint64_t H5I__find_id__future_id_conversions_attempted;
+    _Atomic uint64_t H5I__find_id__future_id_conversions_completed;
+    _Atomic uint64_t H5I__find_id__retries;
+
+    /* H5I_register_using_existing_id() stats */
+    _Atomic uint64_t H5I_register_using_existing_id__num_calls;
+    _Atomic uint64_t H5I_register_using_existing_id__num_marked_only;
+    _Atomic uint64_t H5I_register_using_existing_id__num_id_already_in_use;
+    _Atomic uint64_t H5I_register_using_existing_id__num_failures;
+
+    /* H5I_subst() stats */
+    _Atomic uint64_t H5I_subst__num_calls;
+    _Atomic uint64_t H5I_subst__marked_on_entry;
+    _Atomic uint64_t H5I_subst__marked_during_call;
+    _Atomic uint64_t H5I_subst__retries;
+    _Atomic uint64_t H5I_subst__failures;
+
+    /* H5I__dec_ref() stats */
+    _Atomic uint64_t H5I__dec_ref__num_calls;
+    _Atomic uint64_t H5I__dec_ref__num_app_calls;
+    _Atomic uint64_t H5I__dec_ref__num_calls_with_global_mutex;
+    _Atomic uint64_t H5I__dec_ref__num_calls_without_global_mutex;
+    _Atomic uint64_t H5I__dec_ref__marked_on_entry;
+    _Atomic uint64_t H5I__dec_ref__marked_during_call;
+    _Atomic uint64_t H5I__dec_ref__marked;
+    _Atomic uint64_t H5I__dec_ref__decremented;
+    _Atomic uint64_t H5I__dec_ref__app_decremented;
+    _Atomic uint64_t H5I__dec_ref__calls_to_free_func;
+    _Atomic uint64_t H5I__dec_ref__global_mutex_locks_for_free_func;
+    _Atomic uint64_t H5I__dec_ref__global_mutex_unlocks_for_free_func;
+    _Atomic uint64_t H5I__dec_ref__free_func_failed;
+    _Atomic uint64_t H5I__dec_ref__retries;
+
+    /* H5I__inc_ref() stats */
+    _Atomic uint64_t H5I__inc_ref__num_calls;
+    _Atomic uint64_t H5I__inc_ref__num_app_calls;
+    _Atomic uint64_t H5I__inc_ref__marked_on_entry;
+    _Atomic uint64_t H5I__inc_ref__marked_during_call;
+    _Atomic uint64_t H5I__inc_ref__incremented;
+    _Atomic uint64_t H5I__inc_ref__app_incremented;
+    _Atomic uint64_t H5I__inc_ref__retries;
+
+    /* H5I__iterate_cb() stats */
+    _Atomic uint64_t H5I__iterate_cb__num_calls;
+    _Atomic uint64_t H5I__iterate_cb__num_calls__with_global_mutex;
+    _Atomic uint64_t H5I__iterate_cb__num_calls__without_global_mutex;
+    _Atomic uint64_t H5I__iterate_cb__marked_during_call;
+    _Atomic uint64_t H5I__iterate_cb__num_user_func_calls;
+    _Atomic uint64_t H5I__iterate_cb__global_mutex_locks_for_user_func;
+    _Atomic uint64_t H5I__iterate_cb__global_mutex_unlocks_for_user_func;
+    _Atomic uint64_t H5I__iterate_cb__num_user_func_successes;
+    _Atomic uint64_t H5I__iterate_cb__num_user_func_iter_stops;
+    _Atomic uint64_t H5I__iterate_cb__num_user_func_fails;
+    _Atomic uint64_t H5I__iterate_cb__num_user_func_skips;
+    _Atomic uint64_t H5I__iterate_cb__num_retries;
+ 
+    /* H5I__unwrap() stats */
+    _Atomic uint64_t H5I__unwrap__num_calls;
+    _Atomic uint64_t H5I__unwrap__num_calls_with_global_mutex;
+    _Atomic uint64_t H5I__unwrap__num_calls_without_global_mutex;
+    _Atomic uint64_t H5I__unwrap__times_global_mutex_locked_for_H5VL;
+    _Atomic uint64_t H5I__unwrap__times_global_mutex_unlocked_for_H5VL;
+    _Atomic uint64_t H5I__unwrap__times_global_mutex_locked_for_H5T;
+    _Atomic uint64_t H5I__unwrap__times_global_mutex_unlocked_for_H5T;
+ 
+    /* H5I_is_file_object() stats */
+    _Atomic uint64_t H5I_is_file_object__num_calls;
+    _Atomic uint64_t H5I_is_file_object__num_calls_to_H5T_is_named;
+    _Atomic uint64_t H5I_is_file_object__global_mutex_locks_for_H5T_is_named;
+    _Atomic uint64_t H5I_is_file_object__global_mutex_unlocks_for_H5T_is_named;
+
+    /* do not disturb flag stats */
+    _Atomic uint64_t num_do_not_disturb_yields;
+    _Atomic uint64_t num_successful_do_not_disturb_sets;
+    _Atomic uint64_t num_failed_do_not_disturb_sets;
+    _Atomic uint64_t num_do_not_disturb_resets;
+
+    /* active_threads stats */
+    _Atomic uint64_t num_H5I_entries_via_public_API;
+    _Atomic uint64_t num_H5I_entries_via_internal_API;
+    _Atomic uint64_t max_active_threads;
+    _Atomic uint64_t times_active_threads_is_zero;
+
+} H5I_mt_t; 
+
+/************************************************************************************ 
+ * 
+ * struct H5I_mt_id_info_t 
+ * 
+ * H5I_mt_id_info_t is a re-write of H5_id_info_t with modifications to facilitate 
+ * the multi-thread version of H5I. 
+ * 
+ * As such, most of the fields will be familiar from H5_id_info_t. 
+ * 
+ * Note that most of these are gathered together into a single, atomic sub-structure, 
+ * to allow atomic operations on the the id info. 
+ * 
+ * The remaining fields are either constant during the life of an instance of 
+ * H5I_mt_id_info_t, or exist to support the free list that a deleted instance of 
+ * H5I_mt_id_info_t must reside on until we are sure that no thread retains a pointer 
+ * to it. 
+ *
+ * The fields of H5I_mt_id_info_t are discussed individually below.  
+ * 
+ * tag: unsigned int 32 set to H5I__ID_INFO when allocated, and to 
+ *      H5I__id_INFO_INVALID just before the instance of H5I_mt_id_info_t 
+ *      is deallocated. 
+ * 
+ * id:  ID associated with this instance of H5I_mt_id_info_t.  This is the id used to 
+ *      locate the instance in the lock free hash table. 
+ * 
+ * 
+ * k:   The non-MT version of H5I_mt_id_info_t has a number of variables that must be
+ *      kept in synchronization.  The obvious way of doing this would be to protect
+ *      them with a mutex.  However, it seems best to avoid locking to the extent
+ *      possible so as to avoid lock ordering considerations. 
+ * 
+ *      This leads to the option of encapsulating the variables in a single atomic
+ *      structure, the kernel for short.  In this case, the kernel must be read
+ *      atomically, modified,  and written back atomically with a
+ *      compare_exchange_strong().  In the event of failure in the
+ *      compare_exchange_strong(), the procedure must be repeated
+ *      until it is successful, or the point becomes moot – for example if the id info
+ *      is marked as being deleted. 
+ * 
+ *      The hidden assumption here is that operations on the encapsulated variables
+ *      can be rolled back if the compare_exchange_strong() fails.  This is clearly
+ *      true with ref counts, and with overwrites of the pointer to the object
+ *      associated with the id info.  If we further view an id as being functionally
+ *      deleted once is it marked as deleted, in principle, this should be true of
+ *      deletions as well, as we should be able to do the remainder of the cleanup
+ *      at leisure. 
+ *
+ *      By similar logic, this should include the discard of un-realized future IDs, 
+ *      as once the marked flag is set, no other will modify the kernel (see step 2 in
+ *      the protocols below). 
+ * 
+ *      Unfortunately, the serial version of H5I doesn't work this way.  In 
+ *      particular, in H5I__mark_node(), if either the discard_cb (in the case of a 
+ *      future ID) or the free_func (in the case of a regular ID) fails, and the 
+ *      force flag is not set, the target ID is not marked for deletion, and the 
+ *      (possibly corrupt) buffer pointed to by the object field is left in the 
+ *      index.  This seems a questionable design choice, but until we have a working
+ *      prototype, going with it seems to be the best option.  Obviously, it should
+ *      be revisited once that point is reached. 
+ * 
+ *      Conversions from future to real IDs present a similar problem, as the 
+ *      conversion may fail, and cannot be rolled back.  Further, this operation may 
+ *      be attempted repeatedly until it succeeds. 
+ * 
+ *      To square this circle, we need a mechanism for serializing callbacks, and for 
+ *      ensuring that operations that can't be rolled back can't be interrupted.
+ * 
+ *      We do this by adding two flags to the kernel -- the already defined 
+ *      marked flag, and the new do_not_disturb flag, and then proceeding by the 
+ *      appropriate protocol as given below. 
+ * 
+ *      In the cases where roll backs are possible, proceed as follows: 
+ * 
+ *       1) Load the kernel. 
+ * 
+ *       2) Check to see if the marked flag is set.  If so, issue an ID doesn’t exist 
+ *          error and return. 
+ * 
+ *       3) Check to see if the do_not_disturb flag is set.  If so, do a thread yield 
+ *          or sleep, and return to 1) above. 
+ *  
+ *       4) Perform the desired operations (i.e ref count increment or decrement, or 
+ *          object pointer overwite on the local copy of the kernel.  If the ref 
+ *          count drops to zero, set the marked flag on the local copy of the kernel. 
+ * 
+ *       5) Attempt to overwrite the global copy of the kernel with the local copy 
+ *          via a compare_exchange_strong().  If this succeeds, we are done.  
+ *          Otherwise roll back the operation, and return to 1. 
+ * 
+ *          Note no thread yield or sleep in this case, as this will typically be 
+ *          another thread that jumped in and modified the kernel.  If the 
+ *          do_not_disturb flag is set, we will hit it on the next pass. 
+ * 
+ *      Note that this thread yield or sleep and then re-try approach is also 
+ *      used in the lock free hash table to handle a very unlikely collisions without 
+ *      the use of locks in the lock free hash table. 
+ * 
+ *      For operations that can't be rolled back (i.e. realization or discard of 
+ *      future IDs, ID frees, etc), the above procedure is modified as follows:
+ * 
+ *       1) Load the kernel. 
+ * 
+ *       2) Check to see if the marked flag is set.  If so, issue an ID doesn’t exist 
+ *          error and return. 
+ * 
+ *       3) Check to see if the do_not_disturb flag is set.  If so, do a thread yield 
+ *          or sleep, and return to 1) above. 
+ * 
+ *       4) Check to see if the desired operation is still pending (i.e. if the 
+ *          operation is converting a future ID to a real ID, is the is_future flag 
+ *          still TRUE?). If it isn't, some other thread has already performed the 
+ *          operation so we can exit with success. 
+ * 
+ *          Otherwise: 
+ * 
+ *       5) Set the do_not_disturb flag in the local copy of the kernel, and attempt 
+ *          to overwrite the global copy of the kernel with the local copy via a 
+ *          compare_exchange_strong(). 
+ * 
+ *          If this fails, do a thread yield or sleep, and return to 1. 
+ * 
+ *          If it succeeds, we know that we have exclusive access to the kernel until 
+ *          we reset the do_not_disturb flag on the global copy, as no new thread 
+ *          looking at the kernel will proceed beyond reading the flag, and the 
+ *          compare_exchange_strong() of any existing thread attempting to modify the 
+ *          kernel will fail -- sending it back to step 1. 
+ * 
+ *       6) Attempt to perform the desired operation. 
+ * 
+ *          If this fails, reset the do_not_disturb flag in the local copy of the 
+ *          kernel, overwrite the global copy of the kernel with the local copy via a 
+ *          compare_exchange_strong(), and report the failure of the operation if
+ *          appropriate.
+ * 
+ *          Observe that the call to compare_exchange_strong() must succeed, per the 
+ *          argument given in the final paragraph in 5 above.  Note that we use 
+ *          compare_exchange_strong() in this case only as a sanity check.  Assuming  
+ *          my analysis is correct, we could simply use atomic_store() on  
+ *          architectures where compare_exchange_strong() is not available.   
+ *          Unfortunately, the rest of the algorithm does depend on 
+ *          compare_exchange_strong(), so it will have to be re-worked for those
+ *          architectures. 
+ * 
+ *          If the operation succeeds, update the kernel accordingly, reset the 
+ *          do_not_disturb flag in the local copy of the kernel, and overwrite the 
+ *          global copy of the  kernel with the local copy via a 
+ *          compare_exchange_strong().  As before this operation must succeed, and we
+ *          are done. 
+ * 
+ *      An atomic instance of H5I_mt_id_info_kernel_t is used to instantiate the 
+ *      kernel mentioned above.  It maintains its fields as a single atomic object. 
+ *      As the size of this structure is too large for true atomic operations, C11 
+ *      maintains atomicity via mutexes.  This hurts performance, but since the 
+ *      objective is to avoid explicit locking (and thus lock ordering concerns) this 
+ *      is fine -- for now at least. 
+ *
+ *      Note that if we combined all the booleans in a flags field, 
+ *      and reduced the size of the count and app_count integers, we could fit the 
+ *      H5I_mt_id_info_kernel_t into 128 bytes, allowing true atomic operation on 
+ *      many (most) more modern CPUs.  However, that is an optimization for another 
+ *      day, as is re-working the future ID feature into something more multi-thread
+ *      friendly.
+ * 
+ *      Since H5I_mt_id_info_kernel_t is only used either in H5I_mt_id_info_t, or to 
+ *      stage reads and writes of the kernal in that structure, its fields are 
+ *      discussed here. 
+ * 
+ *      k.count: Reference count on this ID.  This is typically the number of 
+ *           references to the ID elsewhere in the HDF5 library.  This ref count is 
+ *           used to prevent deletion of the id (and the associated instance of 
+ *           H5I_mt_id_info_t until all references have been dropped. 
+ * 
+ *      k.app_count: Application reference count on this ID.  This allows the 
+ *           application to prevent deletion of this ID (under most circumstances) 
+ *           until all its references to the ID have been dropped. 
+ * 
+ *      k.object: Pointer to void.  Points to the data (if any) associated with
+ *           this ID. 
+ * 
+ *      k.marked: Boolean flag indicating whether this instance of H5I_mt_id_info_t 
+ *           has been marked for deletion.  Once set, this flag is never re-set, and 
+ *           any ID for which this flag is set must be viewed as logically deleted, 
+ *           even though the actual removal from the lock free has table and deletion 
+ *           may occur later. 
+ * 
+ *      k.do_not_disturb: Boolean flag.  When set, a thread that needs to perform 
+ *           an operation on the ID that can't be rolled back is in progress.  All 
+ *           other threads must wait until this operation completes (see discussion
+ *           above). 
+ * 
+ *      k.is_future: Boolean flag indicating whether this ID represents a future ID. 
+ * 
+ *      k.have_global_mutex: Boolean flag that should be set to TRUE when 
+ *           k.do_not_disturb is set to TRUE, and the setting thread has the HDF5
+ *           global mutex at the time.
+ * 
+ *           This field is a temporary hack designed allow HDF5 callbacks to access 
+ *           the index without deadlocking.  Thus, when the do_not_disturb flag is 
+ *           detected, it can be ignored if the have_global_mutex flag is set and the 
+ *           current thread has the global mutext.
+ *
+ *           It will almost certainly be replace with a thread ID stored in
+ *           H5I_mt_id_info_t proper, and set whenever k.do_not_disturb is set.  While
+ *           this will make k.do_not_disturb into a recursive lock, it will also 
+ *           require additional logic to allow for the possibility that the kernel 
+ *           has been modified while the k.do_not_disturb flag is set.
+ * 
+ *      If we followed the single thread version of H5I exactly, the realize_cb and 
+ *      discard_cb would have to be atomic since they are set to NULL when is_future 
+ *      is set to FALSE.  However, that doesn't seem necessary, so the are non-atomic 
+ *      fields in H5I_mt_id_info_t.  This should be OK, as the only time they are
+ *      modified is when the instance of H5I_mt_id_info_t is being initialized prior 
+ *      to insertion into the index.  Since only one thread has access at that point, 
+ *      leaving them as regular fields should work.  However, if compilers start 
+ *      optimizing across function boundaries, this will have to be re-visited. 
+ *
+ *      More generally, note that the above is a bit of a kluge to accommodate the 
+ *      current implementation of future IDs, and more generally, to accommodate call
+ *      backs that can fail and/or can’t be rolled back.
+ *
+ *      While we are probably stuck with the current callbacks for the native VOL
+ *      for the foreseeable future, new, more multi-thread friendly versions of the
+ *      H5I callbacks should be developed.
+ *
+ *      Finally, note that while we have technically managed to avoid locks, the
+ *      do_not_disturb flag is effectively a lock which will have to be made
+ *      recursive.  Its main virtue is its near total lack of overhead in cases
+ *      where locking is not required.  Hopefully, this will make up for its other
+ *      sins.
+ * 
+ * realize_cb: 'realize' callback for future object.  
+ * 
+ * discard_cb: 'discard' callback for future object. 
+ * 
+ * 
+ * Fields supporting the H5I_mt_id_info_t free list: 
+ * 
+ * on_fl: Atomic boolean flag that is set to TRUE when the instance of  
+ *      H5I_mt_id_info_t is place on the id info free list, and to FALSE on initial  
+ *      allocation from the heap, or when the instance is allocated from the free
+ *      list. 
+ * 
+ * re_allocable:  Atomic boolean flag that is set to FALSE on allocation from the   
+ *      heap or from the free list.  It is set to TRUE if the entry is on the free    
+ *      list and it is known that it is no longer on the lock free hash table, and  
+ *      no thread currently in H5I has a pointer to it. 
+ * 
+ * fl_snext: Atomic instance of H5I_mt_id_info_sptr_t used in the maintenance of the 
+ *      id info free list.  The structure contains both a pointer and a serial   
+ *      number, which facilitates the avoidance of ABA bugs when managing the free
+ *      list. 
+ * 
+ ************************************************************************************/
+
+#define H5I__ID_INFO            0x1010 /* 4112 */
+#define H5I__ID_INFO_INVALID    0x2020 /* 8224 */
+
+typedef struct H5I_mt_id_info_kernel_t {
+
+    unsigned                  count;      /* Ref. count for this ID */
+    unsigned                  app_count;  /* Ref. count of application visible IDs */
+    const void              * object;     /* Pointer associated with the ID */
+
+    hbool_t                   marked;     /* Marked for deletion */
+    hbool_t                   do_not_disturb;  
+    hbool_t                   is_future;  /* Whether this ID represents a future object */
+    hbool_t                   have_global_mutex; 
+
+} H5I_mt_id_info_kernel_t;
+
+typedef struct H5I_mt_id_info_t {
+
+    uint32_t tag;
+
+    hid_t id;
+
+    _Atomic H5I_mt_id_info_kernel_t k;
+
+    /* Future ID callbacks */
+    H5I_future_realize_func_t realize_cb; /* 'realize' callback for future object */
+    H5I_future_discard_func_t discard_cb; /* 'discard' callback for future object */
+
+    _Atomic hbool_t on_fl;
+
+    _Atomic hbool_t re_allocable;
+
+    _Atomic H5I_mt_id_info_sptr_t fl_snext;
+
+} H5I_mt_id_info_t;
+
+
+/****************************************************************************************
+ *
+ * struct H5I_mt_type_info_t
+ *
+ * H5I_mt_type_info_t is a re-write of H5_type_info_t with modifications to facilitate the  
+ * multi-thread version of H5I. 
+ *
+ * As such, most of the fields will be familiar from H5_type_info_t.  
+ *
+ * tag: unsigned int 32 set to H5I__TYPE_INFO when allocated, and to H5I__TYPE_INFO_INVALID
+ *      just before the instance of H5I_mt_id_info_t is deallocated.
+ *
+ * cls: Pointer to the ID class.
+ *
+ * init_count: Number of times this type has been initialized less the number of times
+ *      its reference count has been decremented.
+ *
+ * id_count: Current number of IDs in the type.
+ *
+ * next_id: ID to be allocated to the next object inserted into the index.
+ *
+ * last_id_info: Pointer to the instance of H5I_mt_id_info_t associated with the last 
+ *      ID accessed in the index.  Note that it is possible for this pointer to be NULL,
+ *      or for it to point (briefly) to and instance of H5I_mt_id_info_t that has been 
+ *      marked for deletion.
+ *
+ * lfht_cleared: Boolean flag that is set to TRUE when the lock free hash table associated
+ *      with the index is cleared in preparation for deletion.
+ *
+ * lfht: The instance of lfht_t that forms the root of the lock free hash table in which 
+ *      all objects in the index are stored, and which supports the look up of the 
+ *      instance of H5I_mt_id_info_t associated with any given ID.
+ *
+ *      Note that the lock free hash table may contain pointers to instances of 
+ *      H5I_mt_id_info_t that have been marked for deletion.  Such entries and their
+ *      associated IDs have been logically deleted from the index, even their associated
+ *      instances of H5I_mt_id_info_t remain in the lock free hash table.
+ *
+ *
+ * Fields supporting the H5I_mt_type_info_t free list:
+ *
+ * on_fl: Atomic boolean flag that is set to TRUE when the instance of H5I_mt_type_info_t
+ *      is place on the type info free list, and to FALSE on initial allocation from the 
+ *      heap, or when the instance is allocated from the free list.
+ *
+ * re_allocable:  Atomic boolean flag that is set to FALSE on allocation from the heap
+ *      or from the free list.  It is set to TRUE if the entry is on the free list and 
+ *      it is known that it is no longer on the lock free hash table, and no thread
+ *      currently in H5I has a pointer to it.
+ *
+ * fl_snext: Atomic instance of H5I_mt_type_info_sptr_t used in the maintenance of the 
+ *      type info free list.  The structure contains both a pointer and a serial number,
+ *      which facilitates the avoidance of ABA bugs when managing the free list.
+ * 
+ ****************************************************************************************/
+
+#define H5I__TYPE_INFO            0x1011 /* 4113 */
+#define H5I__TYPE_INFO_INVALID    0x2021 /* 8225 */
+
+typedef struct H5I_mt_type_info_t {
+    uint32_t                        tag;
+    const H5I_class_t             * cls;          /* Pointer to ID class */
+    _Atomic unsigned                init_count;   /* # of times this type has been initialized */
+    _Atomic uint64_t                id_count;     /* Current number of IDs held */
+    _Atomic uint64_t                nextid;       /* ID to use for the next object */
+    H5I_mt_id_info_t * _Atomic      last_id_info; /* Info for most recent ID looked up */
+    _Atomic hbool_t                 lfht_cleared; /* TRUE iff the lock free hash table has been cleared 
+                                                   * in prep for deletion */
+    lfht_t                          lfht;         /* lock free hash table for this ID type */
+    _Atomic hbool_t                 on_fl;
+    _Atomic hbool_t                 re_allocable;
+    _Atomic H5I_mt_type_info_sptr_t fl_snext;
+} H5I_type_info_t;
+
+#else /* H5_HAVE_MULTITHREAD */ /********************************************************************************/
 
 /* ID information structure used */
 typedef struct H5I_id_info_t {
@@ -81,11 +1369,22 @@ typedef struct H5I_type_info_t {
     H5I_id_info_t     *hash_table;   /* Hash table pointer for this ID type */
 } H5I_type_info_t;
 
+#endif /* H5_HAVE_MULTITHREAD */ /*******************************************************************************/
+
 /*****************************/
 /* Package Private Variables */
 /*****************************/
 
 /* Array of pointers to ID types */
+#if H5_HAVE_MULTITHREAD 
+
+/* This structure contains cognates of H5I_type_info_array_g and H5I_next_type_g globals, 
+ * additional global variables need for the multi-thread version of H5I, and statistics.
+ */
+H5_DLLVAR H5I_mt_t H5I_mt_g;
+
+#else /* H5_HAVE_MULTITHREAD */
+
 H5_DLLVAR H5I_type_info_t *H5I_type_info_array_g[H5I_MAX_NUM_TYPES];
 
 /* Variable to keep track of the number of types allocated.  Its value is the
@@ -96,6 +1395,7 @@ H5_DLLVAR H5I_type_info_t *H5I_type_info_array_g[H5I_MAX_NUM_TYPES];
  * and/or increase size of hid_t
  */
 H5_DLLVAR int H5I_next_type_g;
+#endif /* H5_HAVE_MULTITHREAD */
 
 /******************************/
 /* Package Private Prototypes */
@@ -107,7 +1407,13 @@ H5_DLL int            H5I__destroy_type(H5I_type_t type);
 H5_DLL void          *H5I__remove_verify(hid_t id, H5I_type_t type);
 H5_DLL int            H5I__inc_type_ref(H5I_type_t type);
 H5_DLL int            H5I__get_type_ref(H5I_type_t type);
+#if H5_HAVE_MULTITHREAD
+H5_DLL H5I_mt_id_info_t *H5I__find_id(hid_t id);
+H5_DLL void H5I__enter(hbool_t public_api);
+H5_DLL void H5I__exit(void);
+#else /* H5_HAVE_MULTITHREAD */
 H5_DLL H5I_id_info_t *H5I__find_id(hid_t id);
+#endif /* H5_HAVE_MULTITHREAD */
 
 /* Testing functions */
 #ifdef H5I_TESTING

--- a/hdf5/src/H5Iprivate.h
+++ b/hdf5/src/H5Iprivate.h
@@ -36,6 +36,9 @@
 
 /* Flags for ID class */
 #define H5I_CLASS_IS_APPLICATION 0x01
+#define H5I_CLASS_IS_MT_SAFE     0x02 /* set only if all callbacks associated with the class can
+                                       * be executed safely by multiple threads simultaneeously.
+                                       */
 
 /****************************/
 /* Library Private Typedefs */
@@ -61,6 +64,7 @@ typedef struct H5I_class_t {
 /***************************************/
 /* Library-private Function Prototypes */
 /***************************************/
+H5_DLL herr_t     H5I_init(void);
 H5_DLL herr_t     H5I_register_type(const H5I_class_t *cls);
 H5_DLL int64_t    H5I_nmembers(H5I_type_t type);
 H5_DLL herr_t     H5I_clear_type(H5I_type_t type, hbool_t force, hbool_t app_ref);
@@ -75,6 +79,12 @@ H5_DLL int        H5I_dec_app_ref_always_close(hid_t id);
 H5_DLL int        H5I_dec_app_ref_always_close_async(hid_t id, void **token);
 H5_DLL int        H5I_dec_type_ref(H5I_type_t type);
 H5_DLL herr_t     H5I_find_id(const void *object, H5I_type_t type, hid_t *id /*out*/);
+
+#if H5_HAVE_MULTITHREAD
+/* External iterator for use in the multi-thread case */
+H5_DLL herr_t H5I_get_first(H5I_type_t type, hid_t *id_ptr, void ** object_ptr);
+H5_DLL herr_t H5I_get_next(H5I_type_t type, hid_t last_id, hid_t *next_id_ptr, void ** next_object_ptr);
+#endif /* H5_HAVE_MULTITHREAD */
 
 /* NOTE:    The object and ID functions below deal in non-VOL objects (i.e.;
  *          H5S_t, etc.). Similar VOL calls exist in H5VLprivate.h. Use
@@ -99,6 +109,9 @@ H5_DLL herr_t H5I_register_using_existing_id(H5I_type_t type, void *object, hboo
                                              hid_t existing_id);
 
 /* Debugging functions */
+H5_DLL void   H5I_dump_stats(FILE * file_ptr);
+H5_DLL void   H5I_dump_nz_stats(FILE * file_ptr, const char * tag);
+H5_DLL void   H5I_clear_stats(void);
 H5_DLL herr_t H5I_dump_ids_for_type(H5I_type_t type);
 
 #endif /* H5Iprivate_H */

--- a/hdf5/src/H5TSprivate.h
+++ b/hdf5/src/H5TSprivate.h
@@ -124,6 +124,8 @@ H5_DLL herr_t H5TS_mutex_lock(H5TS_mutex_t *mutex);
 H5_DLL herr_t H5TS_mutex_unlock(H5TS_mutex_t *mutex);
 H5_DLL herr_t H5TS_cancel_count_inc(void);
 H5_DLL herr_t H5TS_cancel_count_dec(void);
+/* (Only used in the multi-thread build) */
+H5_DLL herr_t H5TS_have_mutex(H5TS_mutex_t *mutex, bool *have_mutex_ptr);
 
 /* Testing routines */
 H5_DLL H5TS_thread_t H5TS_create_thread(void *(*func)(void *), H5TS_attr_t *attr, void *udata);

--- a/hdf5/src/H5config.h.in
+++ b/hdf5/src/H5config.h.in
@@ -170,6 +170,9 @@
    */
 #undef HAVE_IOC_VFD
 
+/* Define to 1 if you have the `atomic' library (-latomic). */
+#undef HAVE_LIBATOMIC
+
 /* Define to 1 if you have the `crypto' library (-lcrypto). */
 #undef HAVE_LIBCRYPTO
 
@@ -218,7 +221,7 @@
 /* Define if MPI_Info_c2f and MPI_Info_f2c exist */
 #undef HAVE_MPI_MULTI_LANG_Info
 
-/* Define if we have multithread support */
+/* Define if we have multithread support (pthread and atomic header) */
 #undef HAVE_MULTITHREAD
 
 /* Define to 1 if you have the <netdb.h> header file. */

--- a/hdf5/src/lfht.c
+++ b/hdf5/src/lfht.c
@@ -1,0 +1,3420 @@
+#include <assert.h>
+#include <stddef.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+/************************************************************************
+ *
+ * lfht_add
+ *
+ * Insert a node with the supplied id and value into the indicated lock 
+ * free hash table.  Fail and return false if the hash table already 
+ * contains already contains a node with the supplied id. Observe that
+ * this implies that the hash generated from the id is unique within
+ * the range of valid ids.  
+ * 
+ * Return true on success.
+ *
+ *                                           JRM -- 6/30/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+bool lfht_add(struct lfht_t * lfht_ptr, unsigned long long int id, void * value)
+{
+    bool success;
+    int index_bits;
+    unsigned long long curr_buckets_defined;
+    unsigned long long new_buckets_defined;
+    unsigned long long int hash;
+    struct lfht_node_t * bucket_head_ptr;
+    struct lfht_fl_node_t * fl_node_ptr = NULL;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+#ifdef H5_HAVE_MULTITHREAD
+    assert((id & ID_MASK) <= LFHT__MAX_ID);
+#else /* H5_HAVE_MULTITHREAD */
+    assert(id <= LFHT__MAX_ID);
+#endif /* H5_HAVE_MULTITHREAD */
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+#ifdef H5_HAVE_MULTITHREAD
+    hash = lfht_id_to_hash((id & ID_MASK), false);
+#else /* H5_HAVE_MULTITHREAD */
+    hash = lfht_id_to_hash(id, false);
+#endif /* H5_HAVE_MULTITHREAD */
+
+    bucket_head_ptr = lfht_get_hash_bucket_sentinel(lfht_ptr, hash);
+
+    success = lfht_add_internal(lfht_ptr, bucket_head_ptr, id, hash, false, value, NULL);
+
+    /* test to see if the logical length of the LFSLL has increased to 
+     * the point that we should double the (logical) size of the bucket
+     * index.  If so, increment the index_bits and buckets_defined 
+     * fields accordingly.
+     */
+
+    index_bits = atomic_load(&(lfht_ptr->index_bits));
+    curr_buckets_defined = 0x01ULL << index_bits;
+
+    if ( index_bits < lfht_ptr->max_index_bits ) {
+
+        if ( (atomic_load(&(lfht_ptr->lfsll_log_len)) / curr_buckets_defined) >= 8 ) {
+
+            /* attempt to increment lfht_ptr->index_bits and lfht_buckets_defined.  Must do 
+             * this with a compare and exchange, as it is likely that other threads will be 
+             * attempting to do the same thing at more or less the same time.
+             *
+             * Do nothing if the compare and exchange fails, as that only means that 
+             * another thread beat us to it.
+             *
+             * However, do collect stats.
+             */
+
+            if ( atomic_compare_exchange_strong(&(lfht_ptr->index_bits), &index_bits, index_bits + 1) ) {
+
+                /* set of lfht_ptr->index_bits succeeded -- must update lfht_ptr->buckets_defined
+                 * as well.  As it is possible that this update could be interleaved with another 
+                 * index_bits increment, this can get somewhat involved.  
+                 *
+                 * For the first pass, use the computed current and new value for buckets defined
+                 * in the call to atomic_compare_exchange_strong(). If this succeeds, we are done.
+                 *
+                 * Otherwise, load the current values of lfht_ptr->index_bits and 
+                 * lfht_ptr->buckets_defined, and compute what lfht_ptr->buckets_defined should 
+                 * be given the current value of lfht_ptr->index_bits.  If the two values 
+                 * match, or if the actual value is greater than the computed value, we are 
+                 * done.
+                 *
+                 * If not, call atomic_compare_exchange_strong() again to correct the value 
+                 * of lfht_ptr->buckets_defined, and repeat as necessary.
+                 */
+
+                bool first = true;
+                bool done = false;
+
+                new_buckets_defined = curr_buckets_defined << 1;
+
+                do {
+
+                    if ( atomic_compare_exchange_strong(&(lfht_ptr->buckets_defined), &curr_buckets_defined,
+                                                        new_buckets_defined) ) {
+
+                        done = true;
+
+                    } else {
+
+                        if ( first ) {
+
+                            first = false;
+                            atomic_fetch_add(&(lfht_ptr->buckets_defined_update_cols), 1);
+                        }
+
+                        index_bits = atomic_load(&(lfht_ptr->index_bits));
+
+                        assert(index_bits <= lfht_ptr->max_index_bits);
+
+                        new_buckets_defined = 0x01ULL << index_bits;
+
+                        curr_buckets_defined = atomic_load(&(lfht_ptr->buckets_defined));
+
+                        if ( curr_buckets_defined >= new_buckets_defined ) {
+
+                            done = true;
+
+                        } else {
+
+                            atomic_fetch_add(&(lfht_ptr->buckets_defined_update_retries), 1);
+                        }
+                    }
+                } while ( ! done );
+            } else {
+
+                atomic_fetch_add(&(lfht_ptr->index_bits_incr_cols), 1);
+            }
+        }
+    }
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_add() */
+
+
+/************************************************************************
+ *
+ * lfsll_add_internal
+ *
+ * **** INTERNAL USE ONLY - DO NOT CALL FROM OUTSIDE THE LFHT ****
+ *
+ * Intenal function to insert a node with the supplied value into the 
+ * lock free singly linked list of the indicated lock free hash table.
+ *
+ * New entries are inserted into the LFSLL in increasing value order, 
+ * using the sentinel node supplied in bucket_head_ptr as the starting 
+ * point of the search for the target insertion point.  
+ *
+ * The function will fail and return false if the LFSLL already contains 
+ * a node with the supplied hash value.  
+ *
+ * On success, the function will return true.  If the new_node_ptr_ptr 
+ * parameter is not NULL, it will also set *new_node_ptr_ptr to point 
+ * to the newly inserted node prior to returning.  This later function
+ * exists to support insertion of new bucket sentinel nodes.
+ *
+ * In passing, the function will complete the deletion of nodes already 
+ * marked for deletion when encountered and update stats accordingly.  
+ * Similarly, update stats for restarts caused by collisions, 
+ * successful or failed insrtions, etc.
+ *
+ *                                           JRM -- 6/30/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+bool lfht_add_internal(struct lfht_t * lfht_ptr, 
+                       struct lfht_node_t * bucket_head_ptr,
+                       unsigned long long int id, 
+                       unsigned long long int hash, bool sentinel, void * value, 
+                       struct lfht_node_t ** new_node_ptr_ptr)
+{
+    bool done = false;
+    bool success = false;
+    int del_completions = 0;
+    int del_completion_cols = 0;
+    int insertion_cols = 0;
+    int nodes_visited = 0;
+    unsigned long long int lfsll_log_len;
+    unsigned long long int max_lfsll_log_len;
+    unsigned long long int lfsll_phys_len;
+    unsigned long long int max_lfsll_phys_len;
+    struct lfht_node_t * new_node_ptr = NULL;
+    struct lfht_node_t * first_node_ptr;
+    struct lfht_node_t * second_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(bucket_head_ptr);
+    assert(LFHT_VALID_NODE == bucket_head_ptr->tag);
+    assert(bucket_head_ptr->sentinel);
+    assert(bucket_head_ptr->hash < hash);
+    assert(sentinel || (0x01ULL == (hash & 0x01ULL)));
+
+    /* Allocate the new node now.  The objective is to
+     * minimize the window between when lfmt_find_mod_point()
+     * returns, and we actually perform the insertion.
+     *
+     * This has a cost -- as the new value may already exist,
+     * in which case we must discard the node and return 
+     * failure.
+     */
+    new_node_ptr = lfht_create_node(lfht_ptr, id, hash, sentinel, value);
+    assert(new_node_ptr);
+    assert(LFHT_VALID_NODE == new_node_ptr->tag);
+
+    /* now do the insertion.  We repeat until we are successful,
+     * or we discover that the sll already contains a node with 
+     * the specified hash.
+     */
+    do {
+        first_node_ptr = NULL;
+        second_node_ptr = NULL;
+
+        /* in its current implementation, lfsll_find_mod_point() will
+         * either succeed or trigger an assertion -- thus no need to
+         * check return value at present.
+         */
+        lfht_find_mod_point(lfht_ptr,
+                            bucket_head_ptr,
+                            &first_node_ptr,
+                            &second_node_ptr,
+                            &del_completion_cols,
+                            &del_completions,
+                            &nodes_visited,
+                            hash);
+
+        assert(first_node_ptr);
+
+        if ( hash == first_node_ptr->hash ) { 
+
+            /* value already exists in the SLL.  Discard the new node,
+             * and report failure.  Note that we must mark new_node_ptr->next
+             * to keet lfsll_discard_node() happy.
+             */
+            atomic_store(&(new_node_ptr->next), (struct lfht_node_t *)0x01ULL);
+            lfht_discard_node(lfht_ptr, new_node_ptr, 0);
+            new_node_ptr = NULL;
+            done = true;
+            success = false;
+
+        } else {
+
+            assert(second_node_ptr);
+
+            /* load the new node next ptr with second_ptr */
+            atomic_store(&(new_node_ptr->next), second_node_ptr);
+
+            /* attempt to insert *new_node_ptr into the hash table's SLL */
+            if ( atomic_compare_exchange_strong(&(first_node_ptr->next), &second_node_ptr, new_node_ptr) ) {
+
+                /* insertion succeeded */
+
+                /* increment the logical and physical length of the lfsll */
+                if ( ! sentinel ) {
+
+                    atomic_fetch_add(&(lfht_ptr->lfsll_log_len), 1);
+                }
+                atomic_fetch_add(&(lfht_ptr->lfsll_phys_len), 1);
+
+                done = true;
+                success = true;
+
+            } else {
+
+                insertion_cols++;
+            }
+        }
+    } while ( ! done );
+
+    if ( ( success ) && ( new_node_ptr_ptr ) ) {
+
+        *new_node_ptr_ptr = new_node_ptr;
+    }
+
+    /* update statistics */
+
+    if ( success ) {
+
+        if ( ! sentinel ) {
+
+            atomic_fetch_add(&(lfht_ptr->insertions), 1);
+
+        }
+        /* collect stats on successful sentinel insertions? */ /* JRM */
+
+    } else {
+
+        if ( ! sentinel ) {
+
+            atomic_fetch_add(&(lfht_ptr->insertion_failures), 1);
+
+         }
+         /* collect stats on failed sentinel insertions? */ /* JRM */
+    }
+
+    /* if appropriate, attempt to update lfht_ptr->max_lfsll_log_len and lfht_ptr->max_lfsll_phys_len.  
+     * In the event of a collision, just ignore it and go on, as I don't see any reasonable way to 
+     * recover.
+     */
+    if ( (lfsll_log_len = atomic_load(&(lfht_ptr->lfsll_log_len))) > 
+         (max_lfsll_log_len = atomic_load(&(lfht_ptr->max_lfsll_log_len))) ) {
+
+        atomic_compare_exchange_strong(&(lfht_ptr->max_lfsll_log_len), &max_lfsll_log_len, lfsll_log_len);
+    }
+
+    if ( (lfsll_phys_len = atomic_load(&(lfht_ptr->lfsll_phys_len))) > 
+         (max_lfsll_phys_len = atomic_load(&(lfht_ptr->max_lfsll_phys_len))) ) {
+
+        atomic_compare_exchange_strong(&(lfht_ptr->max_lfsll_phys_len), &max_lfsll_phys_len, lfsll_phys_len);
+    }
+
+    assert(insertion_cols >= 0);
+    assert(del_completion_cols >= 0);
+    assert(del_completions >= 0);
+    assert(nodes_visited >= 0);
+    
+    atomic_fetch_add(&(lfht_ptr->ins_restarts_due_to_ins_col), insertion_cols);
+    atomic_fetch_add(&(lfht_ptr->ins_restarts_due_to_del_col), del_completion_cols);
+    atomic_fetch_add(&(lfht_ptr->ins_deletion_completions),    del_completions);
+    atomic_fetch_add(&(lfht_ptr->nodes_visited_during_ins),    nodes_visited);
+
+    return(success);
+
+} /* lfht_add_internal() */
+
+
+/************************************************************************
+ *
+ * lfht_clear
+ *
+ *     Clear the supplied instance of lfht_t in preparation for deletion.
+ *
+ *                                           JRM -- 5/30/23
+ *
+ ************************************************************************/
+
+void lfht_clear(struct lfht_t * lfht_ptr)
+{
+    unsigned long long marked_nodes_discarded = 0;
+    unsigned long long unmarked_nodes_discarded = 0;
+    unsigned long long sentinel_nodes_discarded = 0;
+    struct lfht_node_t * discard_ptr = NULL;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_discard_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr = NULL;
+#if LFHT__USE_SPTR
+    struct lfht_flsptr_t init_flsptr = {NULL, 0x0ULL};
+    struct lfht_flsptr_t fl_shead;
+    struct lfht_flsptr_t snext;
+#endif /* LFHT__USE_SPTR */
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+
+    /* Delete the elements of the LFSLL -- note that this moves 
+     * all elements from the LFHT to the free list.
+     */
+
+    node_ptr = atomic_load(&(lfht_ptr->lfsll_root));
+
+    atomic_store(&(lfht_ptr->lfsll_root), NULL);
+
+    while ( node_ptr ) {
+
+        assert(LFHT_VALID_NODE == node_ptr->tag);
+
+        discard_ptr = node_ptr;
+        node_ptr = atomic_load(&(discard_ptr->next));
+
+        /* first test to see if the node is a sentinel node -- if it is, it must not 
+         * be marked.
+         */
+        if ( discard_ptr->sentinel ) {
+
+            /* sentinel nodes can't be marked for deletion -- verify this */
+            assert(0x0ULL == (((unsigned long long)(discard_ptr->next)) & 0x01ULL));
+
+            /* mark discard_ptr->next to keep lfht_discard_node() happy */
+            atomic_store(&(discard_ptr->next), 
+                         (struct lfht_node_t *)(((unsigned long long)(node_ptr)) | 0x01ULL));
+
+            sentinel_nodes_discarded++;
+
+        } else {
+
+            /* test to see if node_ptr is marked.  If it, remove the
+             * mark so we can use it.
+             */
+            if ( ((unsigned long long)(node_ptr)) & 0x01ULL ) {
+
+                /* node_ptr is marked -- remove the mark and increment marked nodes visited */
+                node_ptr = (struct lfht_node_t *)(((unsigned long long)(node_ptr)) & (~0x01ULL));
+
+                marked_nodes_discarded++;
+
+            } else {
+
+                /* mark discard_ptr->next to keep lfht_discard_node() happy */
+                atomic_store(&(discard_ptr->next), 
+                             (struct lfht_node_t *)(((unsigned long long)(node_ptr)) | 0x01ULL));
+
+                unmarked_nodes_discarded++;
+            }
+        }
+
+        lfht_discard_node(lfht_ptr, discard_ptr, 0);
+    }
+
+    assert(atomic_load(&(lfht_ptr->buckets_initialized)) + 1 == sentinel_nodes_discarded);
+
+    assert(atomic_load(&(lfht_ptr->lfsll_phys_len)) == 
+           sentinel_nodes_discarded + marked_nodes_discarded + unmarked_nodes_discarded);
+
+    assert(atomic_load(&(lfht_ptr->lfsll_log_len)) == unmarked_nodes_discarded);
+
+    /* Now delete and free all items in the free list.  Do 
+     * this directly, as lfht_discard_node() will try to 
+     * put them back on the free list.
+     */
+#if LFHT__USE_SPTR
+    fl_shead = atomic_load(&(lfht_ptr->fl_shead));
+    fl_node_ptr = fl_shead.ptr;
+
+    atomic_store(&(lfht_ptr->fl_shead), init_flsptr);
+    atomic_store(&(lfht_ptr->fl_stail), init_flsptr);
+#else /* LFHT__USE_SPTR */
+    fl_node_ptr = atomic_load(&(lfht_ptr->fl_head));
+
+    atomic_store(&(lfht_ptr->fl_head), NULL);
+    atomic_store(&(lfht_ptr->fl_tail), NULL);
+#endif /* LFHT__USE_SPTR */
+
+    atomic_store(&(lfht_ptr->next_sn), 0ULL);
+
+    while ( fl_node_ptr ) {
+
+        assert(LFHT_FL_NODE_ON_FL == fl_node_ptr->tag);
+
+        fl_discard_ptr = fl_node_ptr;
+#if LFHT__USE_SPTR
+        snext = atomic_load(&(fl_discard_ptr->snext));
+        fl_node_ptr = snext.ptr;
+
+        discard_ptr->tag = LFHT_FL_NODE_INVALID;
+
+        snext.ptr = NULL;
+        snext.sn  = 0ULL;
+        atomic_store(&(fl_discard_ptr->snext), snext);
+#else /* LFHT__USE_SPTR */
+        fl_node_ptr = atomic_load(&(fl_discard_ptr->next));
+
+        discard_ptr->tag = LFHT_FL_NODE_INVALID;
+        atomic_store(&(fl_discard_ptr->next), NULL);
+#endif /* LFHT__USE_SPTR */
+
+        free((void *)fl_discard_ptr);
+    }
+
+    return;
+
+} /* lfht_clear() */
+
+
+/************************************************************************
+ *
+ * lfht_clear_stats()
+ *
+ *     Set all the stats fields in the supplied instance of lfht_t
+ *     to zero..
+ *
+ *                           JRM -- 5/30/23
+ *
+ ************************************************************************/
+
+void lfht_clear_stats(struct lfht_t * lfht_ptr)
+{
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+
+    atomic_store(&(lfht_ptr->max_lfsll_log_len), 0LL);
+    atomic_store(&(lfht_ptr->max_lfsll_phys_len), 0LL);
+
+    atomic_store(&(lfht_ptr->max_fl_len), 0LL);
+    atomic_store(&(lfht_ptr->num_nodes_allocated), 0LL);
+    atomic_store(&(lfht_ptr->num_nodes_freed), 0LL);
+    atomic_store(&(lfht_ptr->num_node_free_candidate_selection_restarts), 0LL);
+    atomic_store(&(lfht_ptr->num_nodes_added_to_fl), 0LL);
+    atomic_store(&(lfht_ptr->num_nodes_drawn_from_fl), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_head_update_cols), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_tail_update_cols), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_append_cols), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_req_denied_due_to_empty), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_req_denied_due_to_ref_count), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_node_ref_cnt_incs), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_node_ref_cnt_inc_retrys), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_node_ref_cnt_decs), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_frees_skiped_due_to_empty), 0LL);
+    atomic_store(&(lfht_ptr->num_fl_frees_skiped_due_to_ref_count), 0LL);
+
+    atomic_store(&(lfht_ptr->index_bits_incr_cols), 0LL);
+    atomic_store(&(lfht_ptr->buckets_defined_update_cols), 0LL);
+    atomic_store(&(lfht_ptr->buckets_defined_update_retries), 0LL);
+    atomic_store(&(lfht_ptr->bucket_init_cols), 0LL);
+    atomic_store(&(lfht_ptr->bucket_init_col_sleeps), 0LL);
+    atomic_store(&(lfht_ptr->recursive_bucket_inits), 0LL);
+    atomic_store(&(lfht_ptr->sentinels_traversed), 0LL);
+
+    atomic_store(&(lfht_ptr->insertions), 0LL);
+    atomic_store(&(lfht_ptr->insertion_failures), 0LL);
+    atomic_store(&(lfht_ptr->ins_restarts_due_to_ins_col), 0LL);
+    atomic_store(&(lfht_ptr->ins_restarts_due_to_del_col), 0LL);
+    atomic_store(&(lfht_ptr->ins_deletion_completions), 0LL);
+    atomic_store(&(lfht_ptr->nodes_visited_during_ins), 0LL);
+
+    atomic_store(&(lfht_ptr->deletion_attempts), 0LL);
+    atomic_store(&(lfht_ptr->deletion_starts), 0LL);
+    atomic_store(&(lfht_ptr->deletion_start_cols), 0LL);
+    atomic_store(&(lfht_ptr->deletion_failures), 0LL);
+    atomic_store(&(lfht_ptr->del_restarts_due_to_del_col), 0LL);
+    atomic_store(&(lfht_ptr->del_retries), 0LL);
+    atomic_store(&(lfht_ptr->del_deletion_completions), 0LL);
+    atomic_store(&(lfht_ptr->nodes_visited_during_dels), 0LL);
+
+    atomic_store(&(lfht_ptr->searches), 0LL);
+    atomic_store(&(lfht_ptr->successful_searches), 0LL);
+    atomic_store(&(lfht_ptr->failed_searches), 0LL);
+    atomic_store(&(lfht_ptr->marked_nodes_visited_in_succ_searches), 0LL);
+    atomic_store(&(lfht_ptr->unmarked_nodes_visited_in_succ_searches), 0LL);
+    atomic_store(&(lfht_ptr->marked_nodes_visited_in_failed_searches), 0LL);
+    atomic_store(&(lfht_ptr->unmarked_nodes_visited_in_failed_searches), 0LL);
+
+    atomic_store(&(lfht_ptr->value_swaps), 0LL);
+    atomic_store(&(lfht_ptr->successful_val_swaps), 0LL);
+    atomic_store(&(lfht_ptr->failed_val_swaps), 0LL);
+    atomic_store(&(lfht_ptr->marked_nodes_visited_in_succ_val_swaps), 0LL);
+    atomic_store(&(lfht_ptr->unmarked_nodes_visited_in_succ_val_swaps), 0LL);
+    atomic_store(&(lfht_ptr->marked_nodes_visited_in_failed_val_swaps), 0LL);
+    atomic_store(&(lfht_ptr->unmarked_nodes_visited_in_failed_val_swaps), 0LL);
+
+    atomic_store(&(lfht_ptr->value_searches), 0LL);
+    atomic_store(&(lfht_ptr->successful_val_searches), 0LL);
+    atomic_store(&(lfht_ptr->failed_val_searches), 0LL);
+    atomic_store(&(lfht_ptr->marked_nodes_visited_in_val_searches), 0LL);
+    atomic_store(&(lfht_ptr->unmarked_nodes_visited_in_val_searches), 0LL);
+    atomic_store(&(lfht_ptr->sentinels_traversed_in_val_searches), 0LL);
+
+    atomic_store(&(lfht_ptr->itter_inits), 0LL);
+    atomic_store(&(lfht_ptr->itter_nexts), 0LL);
+    atomic_store(&(lfht_ptr->itter_ends), 0LL);
+    atomic_store(&(lfht_ptr->marked_nodes_visited_in_itters), 0LL);
+    atomic_store(&(lfht_ptr->unmarked_nodes_visited_in_itters), 0LL);
+    atomic_store(&(lfht_ptr->sentinels_traversed_in_itters), 0LL);
+
+    return;
+
+} /* lfht_clear_stats() */
+
+
+/************************************************************************
+ *
+ * lfht_create_hash_bucket() 
+ *
+ *     Create a hash bucket for the supplied hash and number of hash 
+ *     bucket table index bits.  
+ *
+ *     To do this, find the hash bucket for the same hash but with 
+ *     index_bits minus 1, and use that hash bucket to find the insertion 
+ *     point for the new bucket in the LFSLL.  
+ *
+ *     Note that it is possible that the index bucket for the supplied
+ *     hash but with index_bits minus 1 may not exist -- in which case
+ *     a recursive call is made.  Further, it may be that hash buckets
+ *     for the given hash and both index_bits and index_bits minus 1
+ *     are the same -- in which case there will be nothing to do when 
+ *     the recursive call returns.
+ *
+ *                                          JRM -- 6/30/23
+ *
+ ************************************************************************/
+
+void lfht_create_hash_bucket(struct lfht_t * lfht_ptr, unsigned long long int hash, int index_bits)
+{
+    unsigned long long int target_index;
+    unsigned long long int target_hash;
+    unsigned long long int parent_index;
+    struct lfht_node_t * bucket_head_ptr;
+    struct lfht_node_t * sentinel_ptr = NULL;
+    struct lfht_node_t * null_ptr = NULL;
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(index_bits > 0);
+    
+    target_index = lfht_hash_to_idx(hash, index_bits);
+    parent_index = lfht_hash_to_idx(hash, index_bits - 1);
+
+    if ( NULL == atomic_load(&(lfht_ptr->bucket_idx[target_index])) ) {
+
+        if ( NULL == atomic_load(&(lfht_ptr->bucket_idx[parent_index])) ) {
+
+            /* parent bucket doesn't exist either -- make a recursive call */
+
+            lfht_create_hash_bucket(lfht_ptr, hash, index_bits - 1);
+
+            atomic_fetch_add(&(lfht_ptr->recursive_bucket_inits), 1);
+        }
+
+        assert(NULL != (bucket_head_ptr = atomic_load(&(lfht_ptr->bucket_idx[parent_index]))));
+
+        /* it is possible that parent_index == target_index -- hence the following check */
+
+        if ( NULL == atomic_load(&(lfht_ptr->bucket_idx[target_index])) ) {
+
+            target_hash = lfht_id_to_hash(target_index, true);
+
+            assert(target_index == (lfht_id_to_hash(target_hash >> 1, true) >> 1));
+
+            if ( lfht_add_internal(lfht_ptr, bucket_head_ptr, 0ULL, 
+                                   target_hash, true, NULL, &sentinel_ptr) ) {
+
+                /* creation of the sentinel node for the hash bucket succeeded.
+                 * now store a pointer to the new node in the bucket index.
+                 */
+                assert(sentinel_ptr);
+                assert(LFHT_VALID_NODE == sentinel_ptr->tag);
+                assert(0x0ULL == sentinel_ptr->id);
+                assert(target_hash == sentinel_ptr->hash);
+                assert(sentinel_ptr->sentinel);
+                assert(NULL == atomic_load(&(sentinel_ptr->value)));
+
+                /* set lfht_ptr->bucket_idx[target_index].  Do this via atomic_compare_exchange_strong(). */
+                /* assert that this succeeds, as it should be impossible for it to fail */
+                assert(atomic_compare_exchange_strong(&(lfht_ptr->bucket_idx[target_index]), 
+                                                      &null_ptr, sentinel_ptr) );
+
+                atomic_fetch_add(&(lfht_ptr->buckets_initialized), 1);
+
+            } else {
+
+                /* the attempt to insert the new sentinel node failed -- which means that 
+                 * that the node already exists.  Thus if it hasn't been set already, 
+                 * lfht_ptr->bucket_idx[target_index] will be set to point to the new 
+                 * sentinel shortly.
+                 */
+
+                atomic_fetch_add(&(lfht_ptr->bucket_init_cols), 1);
+            
+                while ( NULL == atomic_load(&(lfht_ptr->bucket_idx[target_index])) ) {
+
+                    /* need to do better than this.  Want to call pthread_yield(),
+                     * but that call doesn't seem to be supported anymore.
+                     */
+                    sleep(1);
+               
+                    atomic_fetch_add(&(lfht_ptr->bucket_init_col_sleeps), 1);
+                }
+            }
+        }
+    } else {
+
+        /* Another thread beat us to defining the new bucket.  
+         *
+         * As there is nothing to back out of, I don't think this qualifies as a 
+         * a collision -- hence no stats for this case.
+         */
+    }
+
+    return;
+
+} /* lfht_create_hash_bucket() */
+
+
+/************************************************************************
+ *
+ * lfht_create_node
+ *
+ *     Test to see if an instance of lfht_fl_node_t is available on the 
+ *     free list.  If there is remove it from the free list, re-initialize 
+ *     it, and return a pointer to the include instance of lfht_node_t
+ *     the the caller.
+ *
+ *     Otherwise, allocate and initialize an instance of struct 
+ *     lfht_fl_node_t and return a pointer to the included instance of 
+ *     lfht_node_t to the caller.  
+ *
+ *     Return a pointer to the new instance on success, and NULL on 
+ *     failure.
+ *
+ *                                          JRM -- 6/30/23
+ *
+ ************************************************************************/
+
+struct lfht_node_t * lfht_create_node(struct lfht_t * lfht_ptr, unsigned long long int id, 
+                                      unsigned long long int hash, bool sentinel, void * value)
+{
+    bool fl_search_done = false;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr = NULL;
+#if LFHT__USE_SPTR
+    struct lfht_flsptr_t sfirst;
+    struct lfht_flsptr_t new_sfirst;
+    struct lfht_flsptr_t test_sfirst;
+    struct lfht_flsptr_t slast;
+    struct lfht_flsptr_t new_slast;
+    struct lfht_flsptr_t snext;
+    struct lfht_flsptr_t new_snext;
+#else /* LFHT__USE_SPTR */
+    bool new_node = false;
+    struct lfht_fl_node_t * first = NULL;
+    struct lfht_fl_node_t * last = NULL;
+    struct lfht_fl_node_t * next = NULL;
+#endif /* LFHT__USE_SPTR */
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+
+    if ( hash > LFHT__MAX_HASH ) {
+
+        fprintf(stderr, "hash = 0x%llx, LFHT__MAX_HASH = 0x%llx\n", hash, LFHT__MAX_HASH);
+    }
+    assert(hash <= LFHT__MAX_HASH);
+
+#if LFHT__USE_SPTR
+    sfirst = atomic_load(&(lfht_ptr->fl_shead));
+    if ( NULL == sfirst.ptr ) {
+
+        /* the free list hasn't been initialized yet, so skip
+         * the search of the free list.
+         */
+       fl_search_done = true;
+    }
+
+    while ( ! fl_search_done ) {
+
+        sfirst = atomic_load(&(lfht_ptr->fl_shead));
+        slast = atomic_load(&(lfht_ptr->fl_stail));
+
+        assert(sfirst.ptr);
+        assert(slast.ptr);
+
+        snext = atomic_load(&(sfirst.ptr->snext));
+
+        test_sfirst = atomic_load(&(lfht_ptr->fl_shead));
+        if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
+
+            if ( sfirst.ptr == slast.ptr ) {
+
+                if ( NULL == snext.ptr ) {
+
+                    /* the free list is empty */
+                    atomic_fetch_add(&(lfht_ptr->num_fl_req_denied_due_to_empty), 1);
+                    fl_search_done = true;
+                    break;
+
+                } 
+
+                /* attempt to set lfht_ptr->fl_tail to next.  It doesn't 
+                 * matter whether we succeed or fail, as if we fail, it 
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                new_slast.ptr = snext.ptr;
+                new_slast.sn  = slast.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_stail), &slast, new_slast) ) {
+
+                    atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                }
+            } else {
+
+                /* set up new_sfirst now in case we need it later.  */
+                assert(snext.ptr);
+                new_sfirst.ptr = snext.ptr;
+                new_sfirst.sn  = sfirst.sn + 1;
+
+                if ( atomic_load(&(sfirst.ptr->ref_count)) > 0 ) {
+
+                    /* The ref count on the entry at the head of the free list 
+                     * has a positive ref count, which means that there may be 
+                     * a pointer to it somewhere.  Rather than take the risk, 
+                     * let it sit on the free list until the ref count drops 
+                     * to zero.
+                     */
+                    atomic_fetch_add(&(lfht_ptr->num_fl_req_denied_due_to_ref_count), 1);
+                    fl_search_done = true;
+
+                } else if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_shead), &sfirst, new_sfirst) ) {
+
+                    /* the attempt to remove the first item from the free list
+                     * failed.  Update stats and try again.
+                     */
+                    atomic_fetch_add(&(lfht_ptr->num_fl_head_update_cols), 1);
+
+                } else {
+
+                    /* first has been removed from the free list.  Set fl_node_ptr to first,
+                     * update stats, and exit the loop by setting fl_search_done to true.
+                     */
+                    fl_node_ptr = sfirst.ptr;
+
+                    atomic_store(&(fl_node_ptr->tag), LFHT_FL_NODE_IN_USE);
+                    assert( 0x0ULL == atomic_load(&(fl_node_ptr->ref_count)));
+
+                    new_snext.ptr = NULL;
+                    new_snext.sn  = snext.sn + 1;
+
+                    assert(atomic_compare_exchange_strong(&(fl_node_ptr->snext), &snext, new_snext));
+
+#else /* LFHT__USE_SPTR */
+    if ( NULL == atomic_load(&(lfht_ptr->fl_head)) ) {
+
+        /* the free list hasn't been initialized yet, so skip
+         * the search of the free list.
+         */
+       fl_search_done = true;
+    }
+
+    while ( ! fl_search_done ) {
+
+        first = atomic_load(&(lfht_ptr->fl_head));
+        last = atomic_load(&(lfht_ptr->fl_tail));
+
+        assert(first);
+        assert(last);
+
+        next = atomic_load(&(first->next));
+
+        if ( first == atomic_load(&(lfht_ptr->fl_head)) ) {
+
+            if ( first == last ) {
+
+                if ( NULL == next ) {
+
+                    /* the free list is empty */
+                    atomic_fetch_add(&(lfht_ptr->num_fl_req_denied_due_to_empty), 1);
+                    fl_search_done = true;
+                    break;
+
+                } 
+
+                /* attempt to set lfht_ptr->fl_tail to next.  It doesn't 
+                 * matter whether we succeed or fail, as if we fail, it 
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_tail), &first, next) ) {
+
+                    atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                }
+            } else {
+
+                if ( atomic_load(&(first->ref_count)) > 0 ) {
+
+                    /* The ref count on the entry at the head of the free list 
+                     * has a positive ref count, which means that there may be 
+                     * a pointer to it somewhere.  Rather than take the risk, 
+                     * let it sit on the free list until the ref count drops 
+                     * to zero.
+                     */
+                    atomic_fetch_add(&(lfht_ptr->num_fl_req_denied_due_to_ref_count), 1);
+                    fl_search_done = true;
+
+                } else if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_head), &first, next) ) {
+
+                    /* the attempt to remove the first item from the free list
+                     * failed.  Update stats and try again.
+                     */
+                    atomic_fetch_add(&(lfht_ptr->num_fl_head_update_cols), 1);
+
+                } else {
+
+                    /* first has been removed from the free list.  Set fl_node_ptr to first,
+                     * update stats, and exit the loop by setting fl_search_done to true.
+                     */
+                    fl_node_ptr = first;
+
+                    atomic_store(&(fl_node_ptr->tag), LFHT_FL_NODE_IN_USE);
+                    assert( 0x0ULL == atomic_load(&(fl_node_ptr->ref_count)));
+                    assert(atomic_load(&(fl_node_ptr->next))); 
+
+                    /* don't set fl_node_ptr->next to NULL to avoid setting up an ABA bug */
+
+#endif /* LFHT__USE_SPTR */
+
+                    node_ptr = (struct lfht_node_t *)fl_node_ptr;
+
+                    assert(node_ptr);
+
+                    node_ptr->tag = LFHT_VALID_NODE;
+                    atomic_store(&(node_ptr->next), NULL);
+                    node_ptr->id = id;
+                    node_ptr->hash = hash;
+                    node_ptr->sentinel = sentinel;
+                    atomic_store(&(node_ptr->value), value);
+
+                    atomic_fetch_sub(&(lfht_ptr->fl_len), 1);
+                    atomic_fetch_add(&(lfht_ptr->num_nodes_drawn_from_fl), 1);
+
+                    fl_search_done = true;
+                }
+            } 
+        }
+    } /* while ( ! fl_search_done ) */
+
+    if ( NULL == fl_node_ptr ) {
+
+        fl_node_ptr = (struct lfht_fl_node_t *)malloc(sizeof(struct lfht_fl_node_t));
+
+        assert(fl_node_ptr);
+
+        atomic_fetch_add(&(lfht_ptr->num_nodes_allocated), 1);
+
+        atomic_init(&(fl_node_ptr->tag), LFHT_FL_NODE_IN_USE);
+        atomic_init(&(fl_node_ptr->ref_count), 0);
+        atomic_init(&(fl_node_ptr->sn), 0ULL);
+#if LFHT__USE_SPTR
+        snext.ptr = NULL;
+        snext.sn  = 0ULL;
+        atomic_init(&(fl_node_ptr->snext), snext);
+#else /* LFHT__USE_SPTR */
+        atomic_init(&(fl_node_ptr->next), NULL);
+#endif /* LFHT__USE_SPTR */
+
+        node_ptr = (struct lfht_node_t *)fl_node_ptr;
+
+        assert(node_ptr);
+
+        node_ptr->tag = LFHT_VALID_NODE;
+        atomic_init(&(node_ptr->next), NULL);
+        node_ptr->id = id;
+        node_ptr->hash = hash;
+        node_ptr->sentinel = sentinel;
+        atomic_init(&(node_ptr->value), value);
+    }
+    
+    assert(fl_node_ptr);
+
+    return(node_ptr);
+
+} /* lfht_create_node() */
+
+
+/************************************************************************
+ *
+ * lfht_delete
+ *
+ * Attenpt to find the target node in the lfht.
+ *
+ * If it is not found, return false.
+ *
+ * If it is found, attempt to mark it for deletion.
+ *
+ * In passing, complete the deletion of any nodes encountered that are
+ * already marked for deletion, and update stats accordingly.  Similarly, 
+ * update stats for restarts caused by collisions, successful or failed 
+ * deletions, etc.
+ *
+ *                                           JRM -- 6/13/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+bool lfht_delete(struct lfht_t * lfht_ptr, unsigned long long int id)
+{
+    bool done = false;
+    bool success = false;
+    int del_completions = 0;
+    int del_completion_cols = 0;
+    int del_init_cols = 0;
+    int del_retries = 0;
+    int nodes_visited = 0;
+    unsigned long long int hash;
+    struct lfht_node_t * bucket_head_ptr;;
+    struct lfht_node_t * first_node_ptr;
+    struct lfht_node_t * second_node_ptr;
+    struct lfht_node_t * marked_second_node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+#ifdef H5_HAVE_MULTITHREAD
+    assert((id & ID_MASK) <= LFHT__MAX_ID);
+#else /* H5_HAVE_MULTITHREAD */
+    assert(id <= LFHT__MAX_ID);
+#endif /* H5_HAVE_MULTITHREAD */
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+#ifdef H5_HAVE_MULTITHREAD
+    hash = lfht_id_to_hash((id & ID_MASK), false);
+#else /* H5_HAVE_MULTITHREAD */
+    hash = lfht_id_to_hash(id, false);
+#endif /* H5_HAVE_MULTITHREAD */
+
+    bucket_head_ptr = lfht_get_hash_bucket_sentinel(lfht_ptr, hash);
+
+    do { 
+        first_node_ptr = NULL;
+        second_node_ptr = NULL;
+        /* attempt to find the target */
+
+        /* in its current implementation, lfht_find_mod_point() will
+         * either succeed or trigger an assertion -- thus no need to
+         * check return value at present.
+         */
+        lfht_find_mod_point(lfht_ptr,
+                            bucket_head_ptr,
+                            &first_node_ptr,
+                            &second_node_ptr,
+                            &del_completion_cols,
+                            &del_completions,
+                            &nodes_visited,
+                            hash);
+
+        assert(first_node_ptr);
+
+        if ( hash == first_node_ptr->hash ) { 
+
+            assert(!first_node_ptr->sentinel);
+            assert(id == first_node_ptr->id);
+
+            /* hash exists in the SLL.  Attempt to mark the 
+             * node for deletion.  If we fail, that means that either:
+             *
+             * 1) another thread has beat us to marking *first_node_ptr as deleted.
+             *
+             * 2) another thread has either inserted a new node just after *first_node_ptr
+             *    or physically deleted *second_node_ptr.
+             *
+             * No worries if the former, but in latter case, we must try again.
+             */
+            marked_second_node_ptr = (struct lfht_node_t *)(((unsigned long long)(second_node_ptr)) | 0x01ULL);
+
+            if ( atomic_compare_exchange_strong(&(first_node_ptr->next), &second_node_ptr, 
+                                                marked_second_node_ptr) ) {
+
+                /* decrement the logical lfsll length.  We will decrement the physical list 
+                 * length when the node is physically deleted from the list.
+                 */
+                atomic_fetch_sub(&(lfht_ptr->lfsll_log_len), 1);
+
+                success = true;
+                done = true;
+
+            } else if ( 0 != (((unsigned long long)(second_node_ptr)) & 0x01ULL) ) {
+
+                /* recall that atomic_compare_exchamge_strong replaces the expected value
+                 * with the actual value on failure.  If the low order bit is set, we are 
+                 * in case 1) above -- another thread beat us to marking *first_node_ptr
+                 * as deleted.
+                 */
+
+                success = true;
+                done = true;
+                del_init_cols++;
+
+            } else {
+
+                /* a node has been added or deleted just after *first_node_ptr.  Must
+                 * retry the deletion.
+                 */
+                del_retries++;
+            }
+        } else {
+
+            /* target not in lfht */
+
+            success = false;
+            done = true;
+        }
+    }
+    while ( ! done );
+
+    /* update statistics */
+
+    assert(del_init_cols >= 0);
+    assert(del_completion_cols >= 0);
+    assert(del_completions >= 0);
+    assert(nodes_visited >= 0);
+    assert(del_retries >= 0);
+    
+    atomic_fetch_add(&(lfht_ptr->deletion_attempts), 1);
+
+    if ( success ) {
+
+        if ( del_init_cols == 0 ) {
+
+            atomic_fetch_add(&(lfht_ptr->deletion_starts), 1);
+
+        } else {
+
+            atomic_fetch_add(&(lfht_ptr->deletion_start_cols), 1);
+       }
+    } else {
+
+        atomic_fetch_add(&(lfht_ptr->deletion_failures), 1);
+    }
+
+    atomic_fetch_add(&(lfht_ptr->del_retries),                 (long long)del_retries);
+    atomic_fetch_add(&(lfht_ptr->del_restarts_due_to_del_col), (long long)del_completion_cols);
+    atomic_fetch_add(&(lfht_ptr->del_deletion_completions),    (long long)del_completions);
+    atomic_fetch_add(&(lfht_ptr->nodes_visited_during_dels),   (long long)nodes_visited);
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_delete() */
+
+
+/************************************************************************
+ *
+ * lfht_discard_node
+ *
+ *     Append the supplied instance of lfht_node_t 
+ *     (really lfht_fl_node_t) to the free list and increment 
+ *     lfht_ptr->fl_len.
+ *
+ *     If the free list length exceeds lfht_ptr->max_desired_fl_len,
+ *     attempt the remove the node at the head of the free list from 
+ *     the free list, and discard it and decrement lfht_ptr->fl_len
+ *     if successful
+ *
+ *                                          JRM -- 6/30/23
+ *
+ ************************************************************************/
+
+void lfht_discard_node(struct lfht_t * lfht_ptr, struct lfht_node_t * node_ptr, unsigned int expected_ref_count)
+{
+    bool done = false;
+    unsigned int in_use_tag = LFHT_FL_NODE_IN_USE;
+    long long int fl_len;
+    long long int max_fl_len;
+    struct lfht_node_t * next;
+    struct lfht_fl_node_t * fl_node_ptr;
+#if LFHT__USE_SPTR
+    struct lfht_flsptr_t snext = {NULL, 0ULL};
+    struct lfht_flsptr_t fl_stail;
+    struct lfht_flsptr_t fl_snext;
+    struct lfht_flsptr_t new_fl_snext;
+    struct lfht_flsptr_t test_fl_stail;
+    struct lfht_flsptr_t new_fl_stail;
+#else /* LFHT__USE_SPTR */
+    struct lfht_fl_node_t * fl_tail;
+    struct lfht_fl_node_t * fl_next;
+#endif /* LFHT__USE_SPTR */
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(node_ptr);
+    assert(node_ptr->tag == LFHT_VALID_NODE);
+
+    next = atomic_load(&(node_ptr->next));
+
+    assert(0x01ULL == (((unsigned long long)(next)) & 0x01ULL));
+
+    fl_node_ptr = (struct lfht_fl_node_t *)node_ptr;
+
+    assert(LFHT_FL_NODE_IN_USE == atomic_load(&(fl_node_ptr->tag)));
+    assert(expected_ref_count == atomic_load(&(fl_node_ptr->ref_count)));
+
+#if LFHT__USE_SPTR
+    snext = atomic_load(&(fl_node_ptr->snext));
+    assert(NULL == snext.ptr);
+#else /* LFHT__USE_SPTR */
+    /* fl_node_ptr->next may or may not be NULL, depending on whether it was 
+     * allocated directly from the heap, or from the free list.  In either 
+     * case, we must set it to NULL before appending it to the free list.
+     */
+    atomic_store(&(fl_node_ptr->next), NULL);
+#endif /* LFHT__USE_SPTR */
+
+    assert( atomic_compare_exchange_strong(&(fl_node_ptr->tag), &in_use_tag, LFHT_FL_NODE_ON_FL) );
+
+    atomic_store(&(fl_node_ptr->sn), atomic_fetch_add(&(lfht_ptr->next_sn), 1));
+
+    while ( ! done ) {
+
+#if LFHT__USE_SPTR
+        fl_stail = atomic_load(&(lfht_ptr->fl_stail));
+
+        assert(fl_stail.ptr);
+
+        /* it is possible that *fl_tail.ptr has passed through the free list 
+         * and been re-allocated between the time we loaded it, and now.
+         * If so, fl_stail_ptr->tag will no longer be LFHT_FL_NODE_ON_FL.
+         * This isn't a problem, as if so, the following if statement will fail.
+         */
+        // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_stail.ptr->tag)));
+
+        fl_snext = atomic_load(&(fl_stail.ptr->snext));
+
+        test_fl_stail = atomic_load(&(lfht_ptr->fl_stail));
+
+        if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
+
+            if ( NULL == fl_snext.ptr ) {
+
+                /* attempt to append fl_node_ptr by setting fl_tail->next to fl_node_ptr.  
+                 * If this succeeds, update stats and attempt to set lfht_ptr->fl_tail
+                 * to fl_node_ptr as well.  This may or may not succeed, but in either 
+                 * case we are done.
+                 */
+                new_fl_snext.ptr = fl_node_ptr;
+                new_fl_snext.sn  = fl_snext.sn + 1;
+                if ( atomic_compare_exchange_strong(&(fl_stail.ptr->snext), &fl_snext, new_fl_snext) ) {
+
+                    atomic_fetch_add(&(lfht_ptr->fl_len), 1);
+                    atomic_fetch_add(&(lfht_ptr->num_nodes_added_to_fl), 1);
+
+                    new_fl_stail.ptr = fl_node_ptr;
+                    new_fl_stail.sn  = fl_stail.sn + 1;
+                    if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_stail), &fl_stail, new_fl_stail) ) {
+#else /* LFHT__USE_SPTR */
+        fl_tail = atomic_load(&(lfht_ptr->fl_tail));
+
+        assert(fl_tail);
+        assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_tail->tag)));
+
+        fl_next = atomic_load(&(fl_tail->next));
+
+        if ( fl_tail == atomic_load(&(lfht_ptr->fl_tail)) ) {
+
+            if ( NULL == fl_next ) {
+
+                /* attempt to append fl_node_ptr by setting fl_tail->next to fl_node_ptr.  
+                 * If this succeeds, update stats and attempt to set lfht_ptr->fl_tail
+                 * to fl_node_ptr as well.  This may or may not succeed, but in either 
+                 * case we are done.
+                 */
+                if ( atomic_compare_exchange_strong(&(fl_tail->next), &fl_next, fl_node_ptr) ) {
+
+                    atomic_fetch_add(&(lfht_ptr->fl_len), 1);
+                    atomic_fetch_add(&(lfht_ptr->num_nodes_added_to_fl), 1);
+
+                    if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_tail), &fl_tail, fl_node_ptr) ) {
+#endif /* LFHT__USE_SPTR */
+
+                        atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                    }
+
+                    /* if appropriate, attempt to update lfht_ptr->max_fl_len.  In the
+                     * event of a collision, just ignore it and go on, as I don't see any 
+                     * reasonable way to recover.
+                     */
+                    if ( (fl_len = atomic_load(&(lfht_ptr->fl_len))) > 
+                         (max_fl_len = atomic_load(&(lfht_ptr->max_fl_len))) ) {
+
+                        atomic_compare_exchange_strong(&(lfht_ptr->max_fl_len), &max_fl_len, fl_len);
+                    }
+
+                    done = true;
+
+                } else {
+
+                    /* append failed -- update stats and try again */
+                    atomic_fetch_add(&(lfht_ptr->num_fl_append_cols), 1);
+
+                }
+            } else {
+
+                // assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_next->tag)));
+
+#if LFHT__USE_SPTR
+                /* attempt to set lfht_ptr->fl_stail to fl_next.  It doesn't 
+                 * matter whether we succeed or fail, as if we fail, it 
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                new_fl_stail.ptr = fl_snext.ptr;
+                new_fl_stail.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_stail), &fl_stail, new_fl_stail) ) {
+#else /* LFHT__USE_SPTR */
+                /* attempt to set lfht_ptr->fl_tail to fl_next.  It doesn't 
+                 * matter whether we succeed or fail, as if we fail, it 
+                 * just means that some other thread beat us to it.
+                 *
+                 * that said, it doesn't hurt to collect stats
+                 */
+                if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_tail), &fl_tail, fl_next) ) {
+#endif /* LFHT__USE_SPTR */
+
+                    atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                }
+            }
+        }
+    }
+#if 0 /* turn off node frees for now */
+    /* Test to see if the free list is longer than the max_desired_fl_len. 
+     * If so, attempt to remove an entry from the head of the free list
+     * and discard it.  No worries if this fails, as the max_desired_fl_len
+     * is a soft limit.
+     */
+    if ( atomic_load(&(lfht_ptr->fl_len)) > lfht_ptr->max_desired_fl_len ) {
+
+        bool fl_search_done = false;
+        struct lfht_fl_node_t * first;
+        struct lfht_fl_node_t * last;
+        struct lfht_fl_node_t * next;
+        struct lfht_fl_node_t * discard_fl_node_ptr = NULL;
+        struct lfht_node_t * discard_node_ptr = NULL;
+#if LFHT__USE_SPTR
+        struct lfht_flsptr_t sfirst;
+        struct lfht_flsptr_t new_sfirst;
+        struct lfht_flsptr_t test_sfirst;
+        struct lfht_flsptr_t slast;
+        struct lfht_flsptr_t new_slast;
+        struct lfht_flsptr_t snext;
+#endif /* LFHT__USE_SPTR */
+
+        while ( ! fl_search_done ) {
+
+#if LFHT__USE_SPTR
+            sfirst = atomic_load(&(lfht_ptr->fl_shead));
+            slast = atomic_load(&(lfht_ptr->fl_stail));
+
+            assert(sfirst.ptr);
+            assert(slast.ptr);
+
+            snext = atomic_load(&(sfirst.ptr->snext));
+
+            test_sfirst = atomic_load(&(lfht_ptr->fl_shead));
+            if ( ( test_sfirst.ptr == sfirst.ptr ) && ( test_sfirst.sn == sfirst.sn ) ) {
+
+                if ( sfirst.ptr == slast.ptr ) {
+
+                    if ( NULL == snext.ptr ) {
+
+                        /* the free list is empty */
+                        atomic_fetch_add(&(lfht_ptr->num_fl_frees_skiped_due_to_empty), 1);
+                        fl_search_done = true;
+                        break;
+
+                    } 
+
+                    /* attempt to set lfht_ptr->fl_stail to next.  It doesn't 
+                     * matter whether we succeed or fail, as if we fail, it 
+                     * just means that some other thread beat us to it.
+                     *
+                     * that said, it doesn't hurt to collect stats
+                     */
+                    assert(snext.ptr);
+                    new_slast.ptr = snext.ptr;
+                    new_slast.sn  = slast.sn + 1;
+                    if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_stail), &slast, new_slast) ) {
+
+                        atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                    }
+                } else {
+
+                    /* setup new_sfirst now in case we need it.  */
+                    assert(snext.ptr);
+                    new_sfirst.ptr = snext.ptr;
+                    new_sfirst.sn  = sfirst.sn + 1;
+                    if ( atomic_load(&(sfirst.ptr->ref_count)) > 0 ) {
+
+                        /* The ref count on the entry at the head of the free list 
+                         * has a positive ref count, which means that there may be 
+                         * a pointer to it somewhere.  Rather than take the risk, 
+                         * let it sit on the free list until the ref count drops 
+                         * to zero.
+                         */
+                        atomic_fetch_add(&(lfht_ptr->num_fl_frees_skiped_due_to_ref_count), 1);
+                        fl_search_done = true;
+
+                    } else if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_shead), &sfirst, new_sfirst) ) {
+
+                        /* the attempt to remove the first item from the free list
+                         * failed.  Update stats and try again.
+                         */
+                        atomic_fetch_add(&(lfht_ptr->num_fl_head_update_cols), 1);
+                        atomic_fetch_add(&(lfht_ptr->num_node_free_candidate_selection_restarts), 1);
+
+                    } else {
+
+                        /* first has been removed from the free list.  Set discard_fl_node_ptr to first,
+                         * update stats, and exit the loop by setting fl_search_done to true.
+                         */
+                        discard_fl_node_ptr = sfirst.ptr;
+#else /* LFHT__USE_SPTR */
+            first = atomic_load(&(lfht_ptr->fl_head));
+            last = atomic_load(&(lfht_ptr->fl_tail));
+
+            assert(first);
+            assert(last);
+
+            next = atomic_load(&(first->next));
+
+            if ( first == atomic_load(&(lfht_ptr->fl_head)) ) {
+
+                if ( first == last ) {
+
+                    if ( NULL == next ) {
+
+                        /* the free list is empty */
+                        atomic_fetch_add(&(lfht_ptr->num_fl_frees_skiped_due_to_empty), 1);
+                        fl_search_done = true;
+                        break;
+
+                    } 
+
+                    /* attempt to set lfht_ptr->fl_tail to next.  It doesn't 
+                     * matter whether we succeed or fail, as if we fail, it 
+                     * just means that some other thread beat us to it.
+                     *
+                     * that said, it doesn't hurt to collect stats
+                     */
+                    if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_tail), &first, next) ) {
+
+                        atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                    }
+                } else {
+
+                    if ( atomic_load(&(first->ref_count)) > 0 ) {
+
+                        /* The ref count on the entry at the head of the free list 
+                         * has a positive ref count, which means that there may be 
+                         * a pointer to it somewhere.  Rather than take the risk, 
+                         * let it sit on the free list until the ref count drops 
+                         * to zero.
+                         */
+                        atomic_fetch_add(&(lfht_ptr->num_fl_frees_skiped_due_to_ref_count), 1);
+                        fl_search_done = true;
+
+                    } else if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_head), &first, next) ) {
+
+                        /* the attempt to remove the first item from the free list
+                         * failed.  Update stats and try again.
+                         */
+                        atomic_fetch_add(&(lfht_ptr->num_fl_head_update_cols), 1);
+                        atomic_fetch_add(&(lfht_ptr->num_node_free_candidate_selection_restarts), 1);
+
+                    } else {
+
+                        /* first has been removed from the free list.  Set discard_fl_node_ptr to first,
+                         * update stats, and exit the loop by setting fl_search_done to true.
+                         */
+                        discard_fl_node_ptr = first;
+#endif /* LFHT__USE_SPTR */
+
+                        atomic_fetch_sub(&(lfht_ptr->fl_len), 1);
+                        atomic_fetch_add(&(lfht_ptr->num_nodes_freed), 1);
+                        fl_search_done = true;
+                    }
+                } 
+            } else {
+
+                /* lfht_ptr->fl_head got changed out from under us -- this is expected
+                 * from time to time, but collect stats to see how common it is.
+                 */
+                atomic_fetch_add(&(lfht_ptr->num_node_free_candidate_selection_restarts), 1);
+            }
+        } /* while ( ! fl_search_done ) */
+
+        if ( discard_fl_node_ptr ) {
+
+            assert(LFHT_FL_NODE_ON_FL == atomic_load(&(discard_fl_node_ptr->tag)));
+            assert(0 == atomic_load(&(discard_fl_node_ptr->ref_count)));
+#if LFHT__USE_SPTR
+            snext.ptr = NULL;
+            snext.sn  = 0ULL;
+            atomic_store(&(discard_fl_node_ptr->snext), snext);
+#else /* LFHT__USE_SPTR */
+            atomic_store(&(discard_fl_node_ptr->next), NULL);
+#endif /* LFHT__USE_SPTR */
+
+            discard_node_ptr = (struct lfht_node_t *)discard_fl_node_ptr;
+
+            assert(LFHT_VALID_NODE == discard_node_ptr->tag);
+
+            discard_node_ptr->tag = LFHT_INVALID_NODE;
+            atomic_store(&(discard_fl_node_ptr->tag), LFHT_FL_NODE_INVALID);
+
+            free(discard_node_ptr);
+        }
+    } /* if ( atomic_load(&(lfht_ptr->fl_len)) > lfht_ptr->max_desired_fl_len ) */
+#endif /* JRM */
+    return;
+
+} /* lfht_discard_node() */
+
+
+/************************************************************************
+ *
+ * lfht_dump_list
+ *
+ *     Print the contents of the lfht_t to the supplied file.  For now
+ *     this means displaying the contents of the LFSLL in the lock free
+ *     hash table.
+ *
+ *
+ *                                          JRM -- 6/14/23
+ *
+ ************************************************************************/
+
+void lfht_dump_list(struct lfht_t * lfht_ptr, FILE * file_ptr)
+{
+    long long int node_num = 0;
+    struct lfht_node_t * node_ptr;
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(file_ptr);
+
+    fprintf(file_ptr, "\n\n***** CONTENTS OF LFSLL IN THE LFHT *****\n");
+
+    fprintf(file_ptr, "\nLFSLL Logical / Physical Length = %lld/%lld, Free List Len = %lld.\n\n", 
+            atomic_load(&(lfht_ptr->lfsll_log_len)), atomic_load(&(lfht_ptr->lfsll_phys_len)),
+            atomic_load(&(lfht_ptr->fl_len)));
+
+    node_ptr = atomic_load(&(lfht_ptr->lfsll_root));
+
+    while ( node_ptr ) {
+
+        fprintf(file_ptr, 
+                "Node num = %lld, marked = %lld, sentinel = %d, id = 0x%lld, hash = 0x%llx, value = 0x%llx\n", 
+                node_num++, (((unsigned long long)(atomic_load(&(node_ptr->next)))) & 0x01ULL),
+                (int)(node_ptr->sentinel), node_ptr->id, node_ptr->hash, 
+                (unsigned long long)atomic_load(&(node_ptr->value)));
+
+        node_ptr = atomic_load(&(node_ptr->next));
+
+        /* Clear the low order bit of node ptr whether it is set or not. */
+        node_ptr = (struct lfht_node_t *)(((unsigned long long)(node_ptr)) & (~0x01ULL));
+    }
+
+    fprintf(file_ptr, "\n***** END LFHT CONTENTS *****\n\n");
+
+    return;
+
+} /* lfht_dump_list() */
+
+
+/************************************************************************
+ *
+ * lfht_dump_stats
+ *
+ *     Print the contents of the statistics fields of the supplied
+ *     intance of lfht_t to the supplied file.
+ *
+ *
+ *                                          JRM -- 6/14/23
+ *
+ ************************************************************************/
+
+void lfht_dump_stats(struct lfht_t * lfht_ptr, FILE * file_ptr)
+{
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(file_ptr);
+
+    fprintf(file_ptr, "\n\n***** LFSLL STATS *****\n");
+
+    fprintf(file_ptr, "\nCurrent logical / physical LFSLL length = %lld / %lld \n", 
+            atomic_load(&(lfht_ptr->lfsll_log_len)), atomic_load(&(lfht_ptr->lfsll_phys_len)));
+    fprintf(file_ptr, "Max logical / physical LFSLL length = %lld / %lld\n", 
+            atomic_load(&(lfht_ptr->max_lfsll_log_len)), atomic_load(&(lfht_ptr->max_lfsll_phys_len)));
+
+    fprintf(file_ptr, "\nFree List:\n");
+    fprintf(file_ptr, 
+            "Max / current FL Length = %lld /%lld, Nodes added / deleted from free list = %lld / %lld\n",
+            atomic_load(&(lfht_ptr->max_fl_len)),
+            atomic_load(&(lfht_ptr->fl_len)),
+            atomic_load(&(lfht_ptr->num_nodes_added_to_fl)), 
+            atomic_load(&(lfht_ptr->num_nodes_drawn_from_fl)));
+    fprintf(file_ptr, "FL head / tail / append cols = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht_ptr->num_fl_head_update_cols)),
+            atomic_load(&(lfht_ptr->num_fl_tail_update_cols)),
+            atomic_load(&(lfht_ptr->num_fl_append_cols)));
+    fprintf(file_ptr, "FL reqs failed due to empty / ref count = %lld / %lld.\n",
+            atomic_load(&(lfht_ptr->num_fl_req_denied_due_to_empty)),
+            atomic_load(&(lfht_ptr->num_fl_req_denied_due_to_ref_count)));
+    fprintf(file_ptr, "FL node ref count inc / decs = %lld / %lld, ref count inc retrys = %lld.\n",
+            atomic_load(&(lfht_ptr->num_fl_node_ref_cnt_incs)),
+            atomic_load(&(lfht_ptr->num_fl_node_ref_cnt_decs)),
+            atomic_load(&(lfht_ptr->num_fl_node_ref_cnt_inc_retrys)));
+    fprintf(file_ptr, 
+            "Nodes allocated / freed = %lld / %lld, candidate selection for free retries = %lld\n",
+            atomic_load(&(lfht_ptr->num_nodes_allocated)),
+            atomic_load(&(lfht_ptr->num_nodes_freed)),
+            atomic_load(&(lfht_ptr->num_node_free_candidate_selection_restarts)));
+    fprintf(file_ptr, "Frees skiped due to empty / ref_count = %lld / %lld.\n",
+            atomic_load(&(lfht_ptr->num_fl_frees_skiped_due_to_empty)),
+            atomic_load(&(lfht_ptr->num_fl_frees_skiped_due_to_ref_count)));
+
+    fprintf(file_ptr, "\nHash Buckets:\n");
+    fprintf(file_ptr, 
+            "Hash buckets defined / initialized = %lld / %lld, index_bits = %d, max index_bits = %d\n",
+            atomic_load(&(lfht_ptr->buckets_defined)),
+            atomic_load(&(lfht_ptr->buckets_initialized)),
+            atomic_load(&(lfht_ptr->index_bits)),
+            lfht_ptr->max_index_bits);
+    fprintf(file_ptr, "Index bits incr cols = %lld, buckets defined update cols / retries = %lld / %lld.\n",
+            atomic_load(&(lfht_ptr->index_bits_incr_cols)),
+            atomic_load(&(lfht_ptr->buckets_defined_update_cols)),
+            atomic_load(&(lfht_ptr->buckets_defined_update_retries)));
+    fprintf(file_ptr, "Hash bucket init cols / col sleeps = %lld / %lld\n", 
+            atomic_load(&(lfht_ptr->bucket_init_cols)),
+            atomic_load(&(lfht_ptr->bucket_init_col_sleeps)));
+    fprintf(file_ptr, "recursive bucket inits = %lld, sentinels traversed = %lld.\n",
+            atomic_load(&(lfht_ptr->recursive_bucket_inits)),
+            atomic_load(&(lfht_ptr->sentinels_traversed)));
+
+    fprintf(file_ptr, "\nInsertions:\n");
+    fprintf(file_ptr, "successful / failed = %lld/%lld, ins / del cols = %lld/%lld\n",
+            atomic_load(&(lfht_ptr->insertions)), atomic_load(&(lfht_ptr->insertion_failures)),
+            atomic_load(&(lfht_ptr->ins_restarts_due_to_ins_col)),
+            atomic_load(&(lfht_ptr->ins_restarts_due_to_del_col)));
+    fprintf(file_ptr, "del completions = %lld, nodes visited = %lld\n",
+            atomic_load(&(lfht_ptr->ins_deletion_completions)), 
+            atomic_load(&(lfht_ptr->nodes_visited_during_ins)));
+
+    fprintf(file_ptr, "\nDeletions:\n");
+    fprintf(file_ptr, "attempted / failed = %lld/%lld, starts / start cols = %lld/%lld, retries = %lld\n",
+            atomic_load(&(lfht_ptr->deletion_attempts)), atomic_load(&(lfht_ptr->deletion_failures)),
+            atomic_load(&(lfht_ptr->deletion_starts)), atomic_load(&(lfht_ptr->deletion_start_cols)),
+            atomic_load(&(lfht_ptr->del_retries)));
+    fprintf(file_ptr, "del completions = %lld, del col restarts = %lld, nodes visited = %lld\n",
+            atomic_load(&(lfht_ptr->del_deletion_completions)), 
+            atomic_load(&(lfht_ptr->del_restarts_due_to_del_col)), 
+            atomic_load(&(lfht_ptr->nodes_visited_during_dels)));
+
+    fprintf(file_ptr, "\nSearches:\n");
+    fprintf(file_ptr, "attempted / successful / failed = %lld/%lld/%lld\n",
+            atomic_load(&(lfht_ptr->searches)), atomic_load(&(lfht_ptr->successful_searches)),
+            atomic_load(&(lfht_ptr->failed_searches)));
+    fprintf(file_ptr, 
+            "marked/unmoard nodes visited in: successful search %lld/%lld, failed search %lld/%lld\n",
+            atomic_load(&(lfht_ptr->marked_nodes_visited_in_succ_searches)), 
+            atomic_load(&(lfht_ptr->unmarked_nodes_visited_in_succ_searches)), 
+            atomic_load(&(lfht_ptr->marked_nodes_visited_in_failed_searches)), 
+            atomic_load(&(lfht_ptr->unmarked_nodes_visited_in_failed_searches)));
+
+    if ( atomic_load(&(lfht_ptr->value_swaps)) > 0LL ) {
+
+        fprintf(file_ptr, "\nValue Swaps:\n");
+        fprintf(file_ptr, "attempted / successful / failed = %lld/%lld/%lld\n",
+                atomic_load(&(lfht_ptr->value_swaps)), atomic_load(&(lfht_ptr->successful_val_swaps)),
+                atomic_load(&(lfht_ptr->failed_val_swaps)));
+        fprintf(file_ptr, 
+            "marked/unmoard nodes visited in: successful value swaps %lld/%lld, failed value swaps %lld/%lld\n",
+                atomic_load(&(lfht_ptr->marked_nodes_visited_in_succ_val_swaps)), 
+                atomic_load(&(lfht_ptr->unmarked_nodes_visited_in_succ_val_swaps)), 
+                atomic_load(&(lfht_ptr->marked_nodes_visited_in_failed_val_swaps)), 
+                atomic_load(&(lfht_ptr->unmarked_nodes_visited_in_failed_val_swaps)));
+
+    } else {
+
+        fprintf(file_ptr, "\nNo Value Swaps.\n");
+    }
+
+    if ( atomic_load(&(lfht_ptr->value_searches)) > 0LL ) {
+
+        fprintf(file_ptr, "\nSearches by Value:\n");
+        fprintf(file_ptr, "attempted / successful / failed = %lld/%lld/%lld\n",
+                atomic_load(&(lfht_ptr->value_searches)), atomic_load(&(lfht_ptr->successful_val_searches)),
+                atomic_load(&(lfht_ptr->failed_val_searches)));
+        fprintf(file_ptr, 
+                "marked/unmoard nodes visited in value searches %lld/%lld, sentinels traversed %lld\n",
+                atomic_load(&(lfht_ptr->marked_nodes_visited_in_val_searches)), 
+                atomic_load(&(lfht_ptr->unmarked_nodes_visited_in_val_searches)), 
+                atomic_load(&(lfht_ptr->sentinels_traversed_in_val_searches)));
+
+    } else {
+
+        fprintf(file_ptr, "\nNo Searches by Value.\n");
+    }
+
+    if ( atomic_load(&(lfht_ptr->itter_inits)) > 0LL ) {
+
+        fprintf(file_ptr, "\nItterations:\n");
+        fprintf(file_ptr, "initiated / nexts / completed = %lld/%lld/%lld\n",
+                atomic_load(&(lfht_ptr->itter_inits)), atomic_load(&(lfht_ptr->itter_nexts)),
+                atomic_load(&(lfht_ptr->itter_ends)));
+        fprintf(file_ptr, 
+                "marked/unmoard nodes visited in itterations %lld/%lld, sentinels traversed %lld\n",
+                atomic_load(&(lfht_ptr->marked_nodes_visited_in_itters)), 
+                atomic_load(&(lfht_ptr->unmarked_nodes_visited_in_itters)), 
+                atomic_load(&(lfht_ptr->sentinels_traversed_in_itters)));
+
+    } else {
+
+        fprintf(file_ptr, "\nNo Itterations Initiated.\n");
+    }
+
+    fprintf(file_ptr, "\n***** END LFSLL STATS *****\n\n");
+
+    return;
+
+} /* lfht_dump_stats() */
+
+#if 0 /* original version */
+/************************************************************************
+ *
+ * lfht_enter()
+ *
+ * Function to be called on entry to any API call that touches the LFHT
+ * data structures.
+ *
+ * At present, this function exists to increment the ref_count on the 
+ * last node on the free list, and return a pointer to it.  This pointer
+ * is then used by lfht_exit() to decrement the same ref_count.
+ *
+ * Geven the frequency with which this function will be called, it may
+ * be useful to turn it into a macro.
+ *
+ *                                           JRM -- 6/30/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+struct lfht_fl_node_t * lfht_enter(struct lfht_t * lfht_ptr)
+{
+    bool done = false;
+    struct lfht_fl_node_t * fl_tail;
+    struct lfht_fl_node_t * fl_next;
+#if LFHT__USE_SPTR
+    struct lfht_flsptr_t fl_stail;
+    struct lfht_flsptr_t test_fl_stail;
+    struct lfht_flsptr_t fl_snext;
+#endif /* LFHT__USE_SPTR */
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+
+    while ( ! done ) {
+#if LFHT__USE_SPTR
+        fl_stail = atomic_load(&(lfht_ptr->fl_stail));
+
+        assert(fl_stail.ptr);
+
+        fl_next = atomic_load(&(fl_stail.ptr->next));
+
+        test_fl_stail = atomic_load(&(lfht_ptr->fl_stail));
+
+        if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
+
+            if ( NULL == fl_next ) {
+
+                atomic_fetch_add(&(fl_stail.ptr->ref_count), 1);
+
+                /* it is possible that lfht_ptr->fl_tail has changed in the 
+                 * time since we last checked.  If so, it is remotely 
+                 * possible that *fl_tail is no longer on the free list.
+                 *
+                 * If not, update stats and return fl_tail.
+                 *
+                 * If so, decrement fl_tail->ref_count, update stats, and 
+                 * try again.
+                 */
+                test_fl_stail = atomic_load(&(lfht_ptr->fl_stail));
+
+                if ( ( test_fl_stail.ptr == fl_stail.ptr ) && ( test_fl_stail.sn == fl_stail.sn ) ) {
+
+                    assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_stail.ptr->tag)));
+
+                    atomic_fetch_add(&(lfht_ptr->num_fl_node_ref_cnt_incs), 1);
+
+                    done = true;
+
+                } else {
+
+                    atomic_fetch_sub(&(fl_stail.ptr->ref_count), 1);
+                    atomic_fetch_add(&(lfht_ptr->num_fl_node_ref_cnt_inc_retrys), 1);
+                }
+            } else {
+
+                /* lfht_ptr->fl_stail doesn't point to the end of the free list.  
+                 * 
+                 * Attempt to set lfht_ptr->fl_stail to point to fl_next to move towards 
+                 * correcting this.
+                 *
+                 * This will fail if lfht_ptr->fl_stail != fl_stail -- which 
+                 * is important, as if this is true, it is possible that fl_next
+                 * is no longer on the free list.
+                 *
+                 * No immediate attempt to recover if we fail, but we do collect stats.
+                 */
+                fl_snext.ptr = fl_next;
+                fl_snext.sn  = fl_stail.sn + 1;
+                if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_stail), &fl_stail, fl_snext) ) {
+
+                    atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                }
+            }
+        }
+    } /* while ( ! done ) */
+
+    assert(fl_stail.ptr);
+    assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_stail.ptr->tag)));
+    assert(atomic_load(&(fl_stail.ptr->ref_count)) > 0);
+
+    return(fl_stail.ptr);
+#else /* LFHT__USE_SPTR */
+        fl_tail = atomic_load(&(lfht_ptr->fl_tail));
+
+        assert(fl_tail);
+
+        fl_next = atomic_load(&(fl_tail->next));
+
+        if ( fl_tail == atomic_load(&(lfht_ptr->fl_tail)) ) {
+            if ( NULL == fl_next ) {
+
+                atomic_fetch_add(&(fl_tail->ref_count), 1);
+
+                /* it is possible that lfht_ptr->fl_tail has changed in the 
+                 * time since we last checked.  If so, it is remotely 
+                 * possible that *fl_tail is no longer on the free list.
+                 *
+                 * If not, update stats and return fl_tail.
+                 *
+                 * If so, decrement fl_tail->ref_count, update stats, and 
+                 * try again.
+                 */
+                if ( fl_tail == atomic_load(&(lfht_ptr->fl_tail)) ) {
+
+                    assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_tail->tag)));
+
+                    atomic_fetch_add(&(lfht_ptr->num_fl_node_ref_cnt_incs), 1);
+
+                    done = true;
+
+                } else {
+
+                    atomic_fetch_sub(&(fl_tail->ref_count), 1);
+                    atomic_fetch_add(&(lfht_ptr->num_fl_node_ref_cnt_inc_retrys), 1);
+                }
+            } else {
+
+                /* lfht_ptr->fl_tail doesn't point to the end of the free list.  
+                 * 
+                 * Attempt to set lfht_ptr->fl_tail to point to fl_next to move towards 
+                 * correcting this.
+                 *
+                 * This will fail if lfht_ptr->fl_tail != fl_tail -- which 
+                 * is important, as if this is true, it is possible that fl_next
+                 * is no longer on the free list.
+                 *
+                 * No immediate attempt to recover if we fail, but we do collect stats.
+                 */
+                if ( ! atomic_compare_exchange_strong(&(lfht_ptr->fl_tail), &fl_tail, fl_next) ) {
+
+                    atomic_fetch_add(&(lfht_ptr->num_fl_tail_update_cols), 1);
+                }
+            }
+        }
+    } /* while ( ! done ) */
+
+    assert(fl_tail);
+    assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_tail->tag)));
+    assert(atomic_load(&(fl_tail->ref_count)) > 0);
+
+    return(fl_tail);
+#endif /* LFHT__USE_SPTR */
+
+} /* lfht_enter() */
+
+#else /* new version */
+
+/************************************************************************
+ *
+ * lfht_enter()
+ *
+ * Function to be called on entry to any API call that touches the LFHT
+ * data structures.
+ *
+ * At present, this function exists to insert an entry with refcount 1 
+ * at the end of the free list, or (if such a node already exists) to 
+ * increment its ref count.
+ *
+ * In either case, the pointer to the relevant node is returned to the
+ * caller,  where it is then used by lfht_exit() to decrement the same 
+ * ref_count.
+ *
+ * Geven the frequency with which this function will be called, it may
+ * be useful to turn it into a macro.
+ *
+ *                                           JRM -- 6/30/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+struct lfht_fl_node_t * lfht_enter(struct lfht_t * lfht_ptr)
+{
+    bool done = false;
+#if 0 
+    unsigned int curr_ref_count;
+#endif 
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr = NULL;
+#if LFHT__USE_SPTR
+#if 0
+    struct lfht_flsptr_t fl_stail;
+#endif
+#else /* LFHT__USE_SPTR */
+    struct lfht_fl_node_t * fl_tail;
+#endif /* LFHT__USE_SPTR */
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+#if 0
+    /* First, check to see if the node at the end of the 
+     * the free list has a positive ref count.  If it does,
+     * increment it with a atomic_compare_exchange_strong(),
+     * and return a pointer to the node.
+     */
+#if LFHT__USE_SPTR
+    fl_stail = atomic_load(&(lfht_ptr->fl_stail));
+
+    assert(fl_stail.ptr);
+
+    if ( 0 < (curr_ref_count = atomic_load(&(fl_stail.ptr->ref_count))) ) {
+
+        if ( atomic_compare_exchange_strong(&(fl_stail.ptr->ref_count), &curr_ref_count, curr_ref_count + 1) ) {
+
+            fl_node_ptr = fl_stail.ptr;
+            assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_node_ptr->tag)));
+            done = true;
+        }
+    }
+#else /* LFHT__USE_SPTR */
+    fl_tail = atomic_load(&(lfht_ptr->fl_tail));
+
+    assert(fl_tail);
+
+    if ( 0 < (curr_ref_count = atomic_load(&(fl_tail->ref_count))) ) {
+
+        if ( atomic_compare_exchange_strong(&(fl_tailr->ref_count), &curr_ref_count, curr_ref_count + 1) ) {
+
+            fl_node_ptr = fl_stail;
+            assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_node_ptr->tag)));
+            done = true;
+        }
+    }
+#endif /* LFHT__USE_SPTR */
+#endif
+    if ( ! done ) {
+
+        node_ptr = lfht_create_node(lfht_ptr, 0ULL, 1ULL, false, NULL);
+
+        assert(node_ptr);
+        assert(LFHT_VALID_NODE == node_ptr->tag);
+
+        atomic_store(&(node_ptr->next), (struct lfht_node_t *)0x01ULL);
+
+        fl_node_ptr = (struct lfht_fl_node_t *)node_ptr;
+
+        assert(LFHT_FL_NODE_IN_USE == fl_node_ptr->tag);
+        assert(0ULL == atomic_load(&(fl_node_ptr->ref_count)));
+
+        atomic_store(&(fl_node_ptr->ref_count), 1ULL);
+
+        lfht_discard_node(lfht_ptr, node_ptr, 1);
+
+        done = true;
+    }
+
+    assert(fl_node_ptr);
+    assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_node_ptr->tag)));
+    assert(atomic_load(&(fl_node_ptr->ref_count)) > 0);
+
+    return(fl_node_ptr);
+
+} /* lfht_enter() */
+
+#endif /* JRM */
+
+
+/************************************************************************
+ *
+ * lfht_exit()
+ *
+ * Function to be called on exit from any API call that touches the LFHT
+ * data structure.
+ *
+ * At present, this function exists to decrement the ref_count on the 
+ * free list node whose ref count was incremented by the lfht_enter()
+ * call.
+ *
+ *                                           JRM -- 6/24/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+void lfht_exit(struct lfht_t * lfht_ptr, struct lfht_fl_node_t * fl_node_ptr)
+{
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(fl_node_ptr);
+    assert(LFHT_FL_NODE_ON_FL == atomic_load(&(fl_node_ptr->tag)));
+    assert(atomic_load(&(fl_node_ptr->ref_count)) > 0);
+
+    atomic_fetch_sub(&(fl_node_ptr->ref_count), 1);
+    atomic_fetch_add(&(lfht_ptr->num_fl_node_ref_cnt_decs), 1LL);
+
+    return;
+
+} /* lfht_exit() */
+
+#if 0 /* old version */
+/************************************************************************
+ *
+ * lfht_find
+ *
+ * Search the supplied lfht looking for a node with the supplied id..
+ *
+ * If it is found, and the node is not marked for deletion, set *value_ptr
+ * equal to the value field of the node and return true.  
+ *
+ * Otherwise, return false.
+ *
+ *                                           JRM -- 7/1/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+bool lfht_find(struct lfht_t * lfht_ptr,
+               unsigned long long int id,
+               void ** value_ptr)
+
+{
+    bool success = false;
+    int marked_nodes_visited = 0;
+    int unmarked_nodes_visited = 0;
+    unsigned long long int hash;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(0x0ULL <= id);
+    assert(id <= LFHT__MAX_ID);
+    assert(value_ptr);
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+    hash = lfht_id_to_hash(id, false);
+
+    /* now attempt to find the target */
+
+    node_ptr = lfht_get_hash_bucket_sentinel(lfht_ptr, hash);
+
+    assert(LFHT_VALID_NODE == node_ptr->tag);
+    assert(0x0ULL == (((unsigned long long)(node_ptr)) & 0x01ULL));
+    assert(node_ptr->sentinel);
+    assert(node_ptr->hash < hash);
+
+    while ( node_ptr->hash < hash ) {
+
+        node_ptr = atomic_load(&(node_ptr->next));
+
+        /* test to see if node_ptr is marked.  If it, remove the
+         * mark so we can use it.
+         */
+        if ( ((unsigned long long)(node_ptr)) & 0x01ULL ) {
+
+            /* node is marked -- remove the mark and increment marked nodes visited */
+            node_ptr = (struct lfht_node_t *)(((unsigned long long)(node_ptr)) & (~0x01ULL));
+
+            marked_nodes_visited++;
+
+        } else {
+
+            unmarked_nodes_visited++;
+        }
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        if ( ( node_ptr->sentinel ) && ( node_ptr->hash < hash ) ) {
+
+            atomic_fetch_add(&(lfht_ptr->sentinels_traversed), 1);
+        }
+    }
+
+    if ( ( node_ptr->hash != hash ) ||
+         ( ((unsigned long long)atomic_load(&(node_ptr->next))) & 0x01ULL)) {
+
+        success = false;
+
+    } else {
+
+        assert(! node_ptr->sentinel);
+        assert(id == node_ptr->id);
+        success = true;
+        *value_ptr = atomic_load(&(node_ptr->value));
+    }
+
+    /* update statistics */
+
+    assert(marked_nodes_visited >= 0);
+    assert(unmarked_nodes_visited >= 0);
+    
+    atomic_fetch_add(&(lfht_ptr->searches), 1);
+
+    if ( success ) {
+
+        atomic_fetch_add(&(lfht_ptr->successful_searches), 1);
+        atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_succ_searches), marked_nodes_visited);
+        atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_succ_searches), unmarked_nodes_visited);
+
+    } else {
+
+        atomic_fetch_add(&(lfht_ptr->failed_searches), 1);
+        atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_failed_searches), marked_nodes_visited);
+        atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_failed_searches), unmarked_nodes_visited);
+    }
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_find() */
+
+#else /* new version */
+
+/************************************************************************
+ *
+ * lfht_find
+ *
+ * Search the supplied lfht looking for a node with the supplied id..
+ *
+ * If it is found, and the node is not marked for deletion, set *value_ptr
+ * equal to the value field of the node and return true.  
+ *
+ * Otherwise, return false.
+ *
+ *                                           JRM -- 7/1/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+bool lfht_find(struct lfht_t * lfht_ptr,
+               unsigned long long int id,
+               void ** value_ptr)
+
+{
+    bool success = false;
+    long long int marked_nodes_visited = 0;
+    long long int unmarked_nodes_visited = 0;
+    long long int sentinels_traversed = 0;
+    unsigned long long int hash;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+#ifdef H5_HAVE_MULTITHREAD
+    assert((id & ID_MASK) <= LFHT__MAX_ID);
+#else /* H5_HAVE_MULTITHREAD */
+    assert(id <= LFHT__MAX_ID);
+#endif /* H5_HAVE_MULTITHREAD */
+    assert(value_ptr);
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+#ifdef H5_HAVE_MULTITHREAD
+    hash = lfht_id_to_hash((id & ID_MASK), false);
+#else /* H5_HAVE_MULTITHREAD */
+    hash = lfht_id_to_hash(id, false);
+#endif /* H5_HAVE_MULTITHREAD */
+
+    /* now attempt to find the target */
+
+    node_ptr = lfht_find_internal(lfht_ptr, hash, &marked_nodes_visited, 
+                                  &unmarked_nodes_visited, &sentinels_traversed);
+
+    if ( ( NULL == node_ptr ) || ( node_ptr->hash != hash ) ||
+         ( ((unsigned long long)atomic_load(&(node_ptr->next))) & 0x01ULL)) {
+
+        success = false;
+
+    } else {
+
+        assert(! node_ptr->sentinel);
+        assert(hash == node_ptr->hash);
+        success = true;
+        *value_ptr = atomic_load(&(node_ptr->value));
+    }
+
+    /* update statistics */
+    
+    atomic_fetch_add(&(lfht_ptr->searches), 1);
+
+    if ( success ) {
+
+        atomic_fetch_add(&(lfht_ptr->successful_searches), 1);
+        atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_succ_searches), marked_nodes_visited);
+        atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_succ_searches), unmarked_nodes_visited);
+
+    } else {
+
+        atomic_fetch_add(&(lfht_ptr->failed_searches), 1);
+        atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_failed_searches), marked_nodes_visited);
+        atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_failed_searches), unmarked_nodes_visited);
+    }
+
+    if ( sentinels_traversed > 0 ) {
+
+        atomic_fetch_add(&(lfht_ptr->sentinels_traversed), sentinels_traversed);
+    }
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_find() */
+
+#endif /* new version */
+
+/************************************************************************
+ *
+ * lfht_find_id_by_value
+ *
+ * Search the supplied lfht looking for a node with the supplied value.
+ *
+ * If it is found, and the node is not marked for deletion, set *id_ptr
+ * equal to the associated id and return true.
+ *
+ * Otherwise, return false.
+ *
+ * Note that at present this function just does a simple scan of the 
+ * LFSLL used by the LFHT to store its entries -- as such it is very 
+ * in-efficient.  As I believe that this operation is rare, this 
+ * should be acceptable.  However, if this changes, it may be 
+ * necessary to re-visit this.
+ *
+ *                                           JRM -- 7/14/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+bool lfht_find_id_by_value(struct lfht_t * lfht_ptr,
+                           unsigned long long int *id_ptr,
+                           void * value)
+
+{
+    bool success = false;
+    bool marked;
+    unsigned long long int marked_nodes_visited = 0;
+    unsigned long long int unmarked_nodes_visited = 0;
+    unsigned long long int sentinels_traversed = 0;
+    unsigned long long int id;
+    struct lfht_node_t * next_ptr = NULL;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(id_ptr);
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+
+    /* now attempt to find the target */
+
+    node_ptr = atomic_load(&(lfht_ptr->lfsll_root));
+
+    assert(LFHT_VALID_NODE == node_ptr->tag);
+    assert(0x0ULL == (((unsigned long long)(node_ptr)) & 0x01ULL));
+    assert(node_ptr->sentinel);
+
+    while ( ( node_ptr ) && ( ! success ) ) {
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        next_ptr = atomic_load(&(node_ptr->next));
+
+        /* test to see if next_ptr is marked.  If it, remove the
+         * mark so we can use it.
+         */
+        if ( ((unsigned long long)(next_ptr)) & 0x01ULL ) {
+
+            assert(!(node_ptr->sentinel));
+
+            /* node is marked -- remove the mark and increment marked nodes visited */
+            next_ptr = (struct lfht_node_t *)(((unsigned long long)(next_ptr)) & (~0x01ULL));
+
+            marked = true;
+
+            marked_nodes_visited++;
+
+        } else {
+
+            marked = false;
+
+            if ( ! node_ptr->sentinel ) {
+
+                unmarked_nodes_visited++;
+            }
+        }
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        if ( node_ptr->sentinel ) {
+
+            sentinels_traversed++;
+
+        } else if ( ( ! marked ) && ( atomic_load(&(node_ptr->value)) == value ) ) {
+
+            id = node_ptr->id;
+            success = true;
+        }
+
+        node_ptr = next_ptr;
+    }
+
+    if ( success ) {
+
+        *id_ptr = id;
+    }
+    /* it is tempting to assert that lfht_ptr->lfsll_log_len == 0 if success is false.  
+     *
+     * However, there are two problems with this.  
+     *
+     * First, lfsll_log_len is updated only after the fact, and thus will be briefly 
+     * incorrect after each insertion and deletion.  
+     * 
+     * Second, the search for the first element will fail if entries are inserted at 
+     * the front of the lfsll after the scan for the first element has passed.  
+     *
+     * This is OK, as the result will be correct for some ordering of the insertions and 
+     * the search for the first element.  If the user wishes to avoid this race, it is 
+     * his responsibility to ensure that the hash table is quiecent during iterations.
+     */
+
+    /* update statistics */
+
+    atomic_fetch_add(&(lfht_ptr->value_searches), 1);
+
+    if ( success ) {
+
+        atomic_fetch_add(&(lfht_ptr->successful_val_searches), 1);
+
+    } else {
+
+        atomic_fetch_add(&(lfht_ptr->failed_val_searches), 1);
+    }
+
+    atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_val_searches), marked_nodes_visited);
+    atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_val_searches), unmarked_nodes_visited);
+    atomic_fetch_add(&(lfht_ptr->sentinels_traversed), sentinels_traversed);
+    atomic_fetch_add(&(lfht_ptr->sentinels_traversed_in_val_searches), sentinels_traversed);
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_find_id_by_value() */
+
+
+/************************************************************************
+ *
+ * lfht_find_internal
+ *
+ * Search the supplied lfht looking for a node with the supplied hash.
+ *
+ * If it is found, and the node is not marked for deletion, return a 
+ * pointer to the node.
+ *
+ * Otherwise, return NULL.
+ *
+ *                                           JRM -- 7/13/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+struct lfht_node_t * lfht_find_internal(struct lfht_t * lfht_ptr, 
+                                        unsigned long long int hash,
+                                        long long int * marked_nodes_visited_ptr,
+                                        long long int * unmarked_nodes_visited_ptr, 
+                                        long long int * sentinels_traversed_ptr)
+
+{
+    long long int marked_nodes_visited = 0;
+    long long int unmarked_nodes_visited = 0;
+    long long int sentinels_traversed = 0;
+    struct lfht_node_t * node_ptr = NULL;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(hash <= LFHT__MAX_HASH);
+    assert(marked_nodes_visited_ptr);
+    assert(unmarked_nodes_visited_ptr);
+    assert(sentinels_traversed_ptr);
+
+    /* attempt to find the target */
+
+    node_ptr = lfht_get_hash_bucket_sentinel(lfht_ptr, hash);
+
+    assert(LFHT_VALID_NODE == node_ptr->tag);
+    assert(0x0ULL == (((unsigned long long)(node_ptr)) & 0x01ULL));
+    assert(node_ptr->sentinel);
+    assert(node_ptr->hash < hash);
+
+    while ( node_ptr->hash < hash ) {
+
+        node_ptr = atomic_load(&(node_ptr->next));
+
+        /* test to see if node_ptr is marked.  If it, remove the
+         * mark so we can use it.
+         */
+        if ( ((unsigned long long)(node_ptr)) & 0x01ULL ) {
+
+            /* node is marked -- remove the mark and increment marked nodes visited */
+            node_ptr = (struct lfht_node_t *)(((unsigned long long)(node_ptr)) & (~0x01ULL));
+
+            marked_nodes_visited++;
+
+        } else {
+
+            unmarked_nodes_visited++;
+        }
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        if ( ( node_ptr->sentinel ) && ( node_ptr->hash < hash ) ) {
+
+            sentinels_traversed++;
+        }
+    }
+
+    if ( ( node_ptr->hash != hash ) ||
+         ( ((unsigned long long)atomic_load(&(node_ptr->next))) & 0x01ULL)) {
+
+        node_ptr = NULL;
+
+    } else {
+
+        assert(! node_ptr->sentinel);
+        assert(hash == node_ptr->hash);
+    }
+
+    *marked_nodes_visited_ptr   = marked_nodes_visited;
+    *unmarked_nodes_visited_ptr = unmarked_nodes_visited;
+    *sentinels_traversed_ptr    = sentinels_traversed;
+
+    return(node_ptr);
+
+} /* lfht_find_internal() */
+
+
+/************************************************************************
+ *
+ * lfht_find_mod_point
+ *
+ * Starting at the sentinel node pointed to by bucket_head, scan the 
+ * LFSLL in the hash table to find a pair of adjacent nodes such that 
+ * the hash of the first node has value less than or equal to the 
+ * supplied hash, and the hash of the second node has value greater 
+ * than the supplied hash.
+ *
+ * Observe that since the list is sorted in increasing hash order, the hash
+ * of the first node is the largest hash in the list that is less than 
+ * or equal to the supplied hash.  Similarly, the hash of the second 
+ * node is the smallest hash in the SLL that is greater than the 
+ * supplied hash.
+ *
+ * On success, return pointers to the first and second nodes in 
+ * *first_ptr_ptr and *second_ptr_ptr respectively.
+ *
+ * During the scan of the of the lfht, attempt to complete the deletion
+ * of any node encountered that is marked for deletion.  If this 
+ * attempt fails (due to a collision with another thread beating us
+ * to the physical deletion), restart the scan from the beginning 
+ * of the hash bucket.  Maintain a count of the number of collisions, and 
+ * return this value in *cols_ptr.
+ *
+ * Recall that the sentry nodes at the beginning of each hash bucket
+ * and end of the list can't be removed, which simplifies this restart.
+ *
+ * Similarly, maintain a count of the number of deletions completed,
+ * and return this value in *dels_ptr.
+ *
+ *                                           JRM -- 6/30/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+void lfht_find_mod_point(struct lfht_t * lfht_ptr,
+                         struct lfht_node_t * bucket_head_ptr,
+                         struct lfht_node_t ** first_ptr_ptr,
+                         struct lfht_node_t ** second_ptr_ptr,
+                         int * cols_ptr,
+                         int * dels_ptr,
+                         int * nodes_visited_ptr,
+                         unsigned long long int hash)
+{
+    bool done = false;
+    bool retry = false;
+    int cols = 0;
+    int dels = 0;
+    int nodes_visited = 0;
+    struct lfht_node_t * first_ptr = NULL;
+    struct lfht_node_t * second_ptr = NULL;
+    struct lfht_node_t * third_ptr = NULL;
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(bucket_head_ptr);
+    assert(first_ptr_ptr);
+    assert(NULL == *first_ptr_ptr);
+    assert(second_ptr_ptr);
+    assert(NULL == *second_ptr_ptr);
+    assert(cols_ptr);
+    assert(dels_ptr);
+    assert(nodes_visited_ptr);
+    assert(hash <= LFHT__MAX_HASH);
+
+    /* first, find the sentinel node marking the beginning of the 
+     * hash bucket that hash maps into.  Note that this sentinel 
+     * node may not exist -- if so, lfht_get_hash_bucket_sentinel()
+     * will create and insert it.
+     */
+
+    do { 
+        assert(!done);
+
+        retry = false;
+
+        first_ptr = bucket_head_ptr;
+
+        assert(LFHT_VALID_NODE == first_ptr->tag);
+        assert(0x0ULL == (((unsigned long long)(first_ptr)) & 0x01ULL));
+        assert(first_ptr->sentinel);
+        assert(first_ptr->hash < hash);
+
+        second_ptr = atomic_load(&(first_ptr->next));
+
+        assert(second_ptr);
+        assert(0x0ULL == (((unsigned long long)(second_ptr)) & 0x01ULL));
+        assert(LFHT_VALID_NODE == second_ptr->tag);
+   
+        do {
+            third_ptr = atomic_load(&(second_ptr->next));
+
+            /* if the low order bit on third_ptr is set, *second_ptr has 
+             * been marked for deletion.  Attempt to unlink and discard 
+             * *second_ptr if so, and repeat until *second_ptr no longer 
+             * marked for deletion.  If any deletion completion fails, we 
+             * must re-start the search for the mod point
+             */
+            while ( ((unsigned long long)(third_ptr)) & 0x01ULL ) 
+            {
+                assert(first_ptr);
+                assert(LFHT_VALID_NODE == first_ptr->tag);
+
+                assert(second_ptr);
+                assert(LFHT_VALID_NODE == second_ptr->tag);
+                assert(!(second_ptr->sentinel));
+
+                /* third_ptr has its low order bit set to indicate that 
+                 * *second_ptr is marked for deletion,  Before we use 
+                 * third_ptr, we must reset the low order bit.
+                 */
+                third_ptr = (struct lfht_node_t *)(((unsigned long long)(third_ptr)) & ~0x01ULL);
+
+                assert(third_ptr);
+                assert(LFHT_VALID_NODE == third_ptr->tag);
+
+                if ( ! atomic_compare_exchange_strong(&(first_ptr->next), &second_ptr, third_ptr) ) {
+
+                    /* compare and exchange failed -- some other thread
+                     * beat us to the unlink.  Increment cols, set retry
+                     * to TRUE and then restart the search at the head 
+                     * of the SLL.
+                     */
+                    cols++;
+                    retry = true;
+                    break;
+
+                } else {
+
+                    /* unlink of *second_ptr succeeded.  Decrement the logical list length,
+                     * increment dels, increment nodes_visited, discard *second_ptr, set 
+                     * second_ptr to third_ptr, and then load third_ptr
+                     */
+                    atomic_fetch_sub(&(lfht_ptr->lfsll_phys_len), 1);
+                    dels++;
+                    nodes_visited++;
+                    lfht_discard_node(lfht_ptr, second_ptr, 0);
+                    second_ptr = third_ptr;
+                    third_ptr = atomic_load(&(second_ptr->next));
+
+                    assert(first_ptr);
+                    assert(LFHT_VALID_NODE == first_ptr->tag);
+
+                    assert(second_ptr);
+                    assert(LFHT_VALID_NODE == second_ptr->tag);
+
+                }
+            } /* end while *second_ptr is marked for deletion */
+
+            if ( ! retry ) {
+
+                assert(first_ptr);
+                assert(LFHT_VALID_NODE == first_ptr->tag);
+
+                assert(second_ptr);
+                assert(LFHT_VALID_NODE == second_ptr->tag);
+
+                assert(first_ptr->hash <= hash);
+ 
+                if ( second_ptr->hash > hash ) {
+
+                    done = true;
+
+                } else {
+
+                    if ( second_ptr->sentinel ) {
+
+                        atomic_fetch_add(&(lfht_ptr->sentinels_traversed), 1);
+                    }
+
+                    first_ptr = second_ptr;
+                    second_ptr = third_ptr;
+                    nodes_visited++;
+                }
+            }
+
+        } while ( ( ! done ) && ( ! retry ) );
+
+        assert( ! ( done && retry ) );
+
+    } while ( retry );
+
+    assert(done);
+    assert(!retry);
+
+    assert(first_ptr->hash <= hash);
+    assert(hash < second_ptr->hash);
+
+    *first_ptr_ptr = first_ptr;
+    *second_ptr_ptr = second_ptr;
+    *cols_ptr += cols;
+    *dels_ptr += dels;
+    *nodes_visited_ptr += nodes_visited;
+
+    return;
+
+} /* lfht_find_mod_point() */
+
+
+/***********************************************************************************
+ *
+ * lfht_get_first()
+ *
+ * One of two API calls to support itteration through all entries in the 
+ * lock free hash table.  Note that the itteration will almost certainly not be in 
+ * id order, and that entries added during the itteration may or may not be included
+ * in the itteration.
+ *
+ * If the supplied instance of a lock free hash table is empty, return false.
+ *
+ * If it contains at least one entry, return the id, and value of the first 
+ * entry in *id_ptr, and *value_ptr respectively, and then return true.
+ *
+ *                                                  JRM -- 7/16/23
+ *
+ * Changes:
+ *
+ *  - None.
+ *
+ ***********************************************************************************/
+
+bool lfht_get_first(struct lfht_t * lfht_ptr, unsigned long long int * id_ptr, void ** value_ptr)
+{
+    bool success = false;
+    bool marked;
+    unsigned long long int marked_nodes_visited = 0;
+    unsigned long long int unmarked_nodes_visited = 0;
+    unsigned long long int sentinels_traversed = 0;
+    unsigned long long int id;
+    void * value;
+    struct lfht_node_t * next_ptr = NULL;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(id_ptr);
+    assert(value_ptr);
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+
+    /* search for the first entry in the hash table, if it exists */
+
+    node_ptr = atomic_load(&(lfht_ptr->lfsll_root));
+
+    assert(LFHT_VALID_NODE == node_ptr->tag);
+    assert(0x0ULL == (((unsigned long long)(node_ptr)) & 0x01ULL));
+    assert(node_ptr->sentinel);
+
+    while ( ( node_ptr ) && ( ! success ) ) {
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        next_ptr = atomic_load(&(node_ptr->next));
+
+        /* test to see if next_ptr is marked.  If it, remove the
+         * mark so we can use it.
+         */
+        if ( ((unsigned long long)(next_ptr)) & 0x01ULL ) {
+
+            assert(!(node_ptr->sentinel));
+
+            /* node is marked -- remove the mark and increment marked nodes visited */
+            next_ptr = (struct lfht_node_t *)(((unsigned long long)(next_ptr)) & (~0x01ULL));
+
+            marked = true;
+
+            marked_nodes_visited++;
+
+        } else {
+
+            marked = false;
+
+            if ( ! node_ptr->sentinel ) {
+
+                unmarked_nodes_visited++;
+            }
+        }
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        if ( node_ptr->sentinel ) {
+
+            sentinels_traversed++;
+
+        } else if ( ! marked ) {
+
+            id = node_ptr->id;
+            value = atomic_load(&(node_ptr->value));
+            success = true;
+        }
+
+        node_ptr = next_ptr;
+    }
+
+    if ( success ) {
+
+        *id_ptr    = id;
+        *value_ptr = value;
+    }
+
+    /* update statistics */
+    
+    atomic_fetch_add(&(lfht_ptr->itter_inits), 1);
+
+    if ( ! success ) {
+
+        atomic_fetch_add(&(lfht_ptr->itter_ends), 1);
+    }
+
+    atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_itters), marked_nodes_visited);
+    atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_itters), unmarked_nodes_visited);
+    atomic_fetch_add(&(lfht_ptr->sentinels_traversed), sentinels_traversed);
+    atomic_fetch_add(&(lfht_ptr->sentinels_traversed_in_itters), sentinels_traversed);
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_get_first() */
+
+
+/***********************************************************************************
+ *
+ * lfht_get_hash_bucket_sentinel()
+ *
+ *    Given a hash, find the sentinel node in the LFSLL marking the bucket into 
+ *    which the hash will fall, and return a pointer to it.
+ *
+ *    Usually, this is a trivial look up.  However, it is possible that the 
+ *    containing hash bucket hasn't been initialized yet.  In this case, it 
+ *    will be necessary to create the bucket before returning the pointer 
+ *    to the required sentinel.  Further, observe that this operation may 
+ *    be recursing if a sequence of containing buckets haven't been initialized.
+ *
+ *                                                JRM -- 6/30/23
+ *
+ * Changes:
+ *
+ *  - None.
+ *
+ ***********************************************************************************/
+
+struct lfht_node_t * lfht_get_hash_bucket_sentinel(struct lfht_t * lfht_ptr, unsigned long long int hash)
+{
+    int index_bits;
+    struct lfht_node_t * sentinel_ptr = NULL;
+    unsigned long long int hash_index;
+
+    index_bits = atomic_load(&(lfht_ptr->index_bits));
+
+    hash_index = lfht_hash_to_idx(hash, index_bits);
+
+    if ( NULL == atomic_load(&(lfht_ptr->bucket_idx[hash_index])) ) {
+
+        /* bucket doesn't exist -- create it */
+        lfht_create_hash_bucket(lfht_ptr, hash, atomic_load(&(lfht_ptr->index_bits)));
+    }
+
+    sentinel_ptr = atomic_load(&(lfht_ptr->bucket_idx[hash_index]));
+    assert(sentinel_ptr);
+    assert(0x0ULL == (((unsigned long long)(sentinel_ptr)) & 0x01ULL));
+    assert(LFHT_VALID_NODE == sentinel_ptr->tag);
+    assert(sentinel_ptr->sentinel);
+#if 1 /* JRM */
+    if ( sentinel_ptr->hash > hash ) {
+
+        fprintf(stderr, "\nhash_index = %lld, sentinel_ptr->hash = 0x%llx, hash = 0x%llx.\n",
+                hash_index, sentinel_ptr->hash, hash);
+    }
+#endif /* JRM */
+    assert(sentinel_ptr->hash < hash);
+
+    return(sentinel_ptr);
+
+} /* lfht_get_hash_bucket_sentinel() */
+
+
+/***********************************************************************************
+ *
+ * lfht_get_next()
+ *
+ * One of two API calls to support itteration through all entries in the 
+ * lock free hash table.  Note that the itteration will almost certainly not be in 
+ * id order, and that entries added during the itteration may or may not be included
+ * in the itteration.
+ *
+ * Compute the hash of the supplied old_id, and attempt to find the entry in the 
+ * hash table with the smallest hash that is greater than that of the old_id.  If 
+ * it exists, this is the next entry in the itteration.
+ *
+ * If no next entry exists, return false.
+ *
+ * Otherwise, return the id and value of the next entry in *id_ptr and *value_ptr,
+ * and return true.
+ *
+ *                                                  JRM -- 7/16/23
+ *
+ * Changes:
+ *
+ *  - None.
+ *
+ ***********************************************************************************/
+
+bool lfht_get_next(struct lfht_t * lfht_ptr, unsigned long long int old_id, 
+                   unsigned long long int * id_ptr, void ** value_ptr)
+{
+    bool success = false;
+    bool marked;
+    unsigned long long int marked_nodes_visited = 0;
+    unsigned long long int unmarked_nodes_visited = 0;
+    unsigned long long int sentinels_traversed = 0;
+    unsigned long long int id;
+    unsigned long long int old_hash;
+    void * value;
+    struct lfht_node_t * next_ptr = NULL;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(id_ptr);
+    assert(value_ptr);
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+    /* compute the hash of old_id.  The node with this hash should still be 
+     * in the hash table, but we have no way of enforcing this.  Thus, make
+     * no assumptions.
+     */
+    old_hash = lfht_id_to_hash(old_id, false);
+
+    /* now search for the node in the hash table with the smallest hash 
+     * that is greater than old_hash.  This algorithm is very similar to 
+     * that used in lfht_find_internal().
+     */
+    node_ptr = lfht_get_hash_bucket_sentinel(lfht_ptr, old_hash);
+
+    assert(LFHT_VALID_NODE == node_ptr->tag);
+    assert(0x0ULL == (((unsigned long long)(node_ptr)) & 0x01ULL));
+    assert(node_ptr->sentinel);
+    assert(node_ptr->hash < old_hash);
+
+    while ( ( node_ptr ) && ( ! success ) ) {
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        next_ptr = atomic_load(&(node_ptr->next));
+
+        /* test to see if next_ptr is marked.  If it, remove the
+         * mark so we can use it.
+         */
+        if ( ((unsigned long long)(next_ptr)) & 0x01ULL ) {
+
+            assert(!(node_ptr->sentinel));
+
+            /* node is marked -- remove the mark from next_ptr, and increment marked nodes visited */
+            next_ptr = (struct lfht_node_t *)(((unsigned long long)(next_ptr)) & (~0x01ULL));
+
+            marked = true;
+
+            marked_nodes_visited++;
+
+        } else {
+
+            marked = false;
+
+            if ( ! node_ptr->sentinel ) {
+
+                unmarked_nodes_visited++;
+            }
+        }
+
+        assert( LFHT_VALID_NODE == node_ptr->tag );
+
+        if ( node_ptr->sentinel ) {
+
+            sentinels_traversed++;
+
+        } else if ( ( ! marked ) && ( node_ptr->hash > old_hash ) ) {
+
+            id = node_ptr->id;
+            value = atomic_load(&(node_ptr->value));
+            success = true;
+        }
+
+        node_ptr = next_ptr;
+    }
+
+    if ( success ) {
+
+        *id_ptr    = id;
+        *value_ptr = value;
+    }
+
+    /* update statistics */
+
+    if ( success ) {
+
+        atomic_fetch_add(&(lfht_ptr->itter_nexts), 1);
+
+    } else {
+
+        atomic_fetch_add(&(lfht_ptr->itter_ends), 1);
+    }
+
+    atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_itters), marked_nodes_visited);
+    atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_itters), unmarked_nodes_visited);
+    atomic_fetch_add(&(lfht_ptr->sentinels_traversed), sentinels_traversed);
+    atomic_fetch_add(&(lfht_ptr->sentinels_traversed_in_itters), sentinels_traversed);
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_get_next() */
+
+
+/***********************************************************************************
+ *
+ * lfht_hash_to_bucket_idx()
+ *
+ *    Given a hash, compute the index of the containing bucket given the current 
+ *    value of index_bits.
+ *
+ *    Do this by first left shifting the supplied hash by one bit.
+ *
+ *    The copy the lfht_ptr->index_bits most significant bits of the hash into 
+ *    the least significant bits of the index in reverse order, and return the 
+ *    result.
+ *
+ *
+ *                                                JRM -- 6/29/23
+ *
+ * Changes:
+ *
+ *  - None.
+ *
+ ***********************************************************************************/
+
+unsigned long long lfht_hash_to_idx(unsigned long long hash, int index_bits)
+{
+    int i;
+    unsigned long long index = 0x0ULL;
+    unsigned long long hash_bit;
+    unsigned long long idx_bit;
+
+    assert(0 <= index_bits);
+    assert(LFHT__MAX_INDEX_BITS >= index_bits); 
+
+    hash >>= 1;
+
+    hash_bit = 0x01ULL << (LFHT__NUM_HASH_BITS - 1);
+    idx_bit = 0x01ULL;
+
+    for ( i = 0; i < index_bits; i++ ) {
+
+        if ( 0 != (hash_bit & hash) ) {
+
+            index |= idx_bit;
+        }
+        hash_bit >>= 1;
+        idx_bit <<= 1; 
+    }
+
+    return ( index );
+
+} /* lfht_hash_to_idx() */
+
+/***********************************************************************************
+ *
+ * lfht_id_to_hash()
+ *
+ *    Given an id, compute the reverse order hash and return it.
+ *
+ *    Do this by examining the LFHT__NUM_HASH_BITS bit in the id, and if it is 
+ *    set, set the first bit in the hash.  Then examine the LFHT__NUM_HASH_BITS - 1th
+ *    bit in the id, and if it is set, set the second bit in the hash.  Repeat until
+ *    the lower LFHT__NUM_HASH_BITS bits of the id have been examined, and the 
+ *    corresponding bits in the hash have been set where appropriate.  Observe that 
+ *    hash now contains the lower LFHT__NUM_HASH_BITS bits from the id in reverse
+ *    order.
+ *
+ *    We must now modify hash so that if it sentinel hash, no id will hash to it,
+ *    and it will always be the smallest value in its bucket.  Do this by left
+ *    shifting hash by 1, and then bit-or-ing it with 0x01 if the sentinal_hash
+ *    parameter is false.
+ *
+ *    Finally, return hash to the caller.
+ *
+ *                                                JRM -- 6/29/23
+ *
+ * Changes:
+ *
+ *  - None.
+ *
+ ***********************************************************************************/
+
+unsigned long long lfht_id_to_hash(unsigned long long id, bool sentinel_hash)
+{
+    int i;
+    unsigned long long id_bit;
+    unsigned long long hash_bit;
+    unsigned long long hash = 0;
+
+    id_bit = 0x01ULL << (LFHT__NUM_HASH_BITS - 1);
+    hash_bit = 0x01ULL;
+
+    for ( i = 0; i < LFHT__NUM_HASH_BITS; i++ ) {
+
+        if ( 0 != (id_bit & id) ) {
+
+            hash |= hash_bit;
+        }
+        id_bit >>= 1;
+        hash_bit <<= 1; 
+    }
+
+    hash <<= 1;
+
+    if ( ! sentinel_hash ) {
+
+        hash |= 0x01ULL;
+    }
+
+    return ( hash );
+
+} /* lfht_id_to_hash() */
+
+
+/************************************************************************
+ *
+ * lfht_init
+ *
+ *     Initialize an instance of lfht_t.
+ *
+ *                           JRM -- 6/30/23
+ *
+ ************************************************************************/
+
+void lfht_init(struct lfht_t * lfht_ptr)
+{
+    int i;
+    unsigned long long int mask = 0x0ULL;
+#if LFHT__USE_SPTR
+    struct lfht_flsptr_t init_lfht_flsptr = {NULL, 0x0ULL};
+    struct lfht_flsptr_t fl_shead;
+    struct lfht_flsptr_t fl_stail;
+    struct lfht_flsptr_t snext;
+#endif /* LFHT__USE_SPTR */
+
+#ifdef H5_HAVE_MULTITHREAD
+    assert(LFHT__NUM_HASH_BITS == ID_BITS + 1);
+#endif /* H5_HAVE_MULTITHREAD */
+
+
+    struct lfht_node_t * head_sentinel_ptr = NULL;
+    struct lfht_node_t * tail_sentinel_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr = NULL;
+
+    assert(lfht_ptr);
+
+    lfht_ptr->tag = LFHT_VALID;
+
+
+    /* lock free singly linked list */
+    atomic_init(&(lfht_ptr->lfsll_root), NULL);
+    atomic_init(&(lfht_ptr->lfsll_log_len), 0ULL);
+    atomic_init(&(lfht_ptr->lfsll_phys_len), 2ULL);
+
+
+    /* free list */
+#if LFHT__USE_SPTR
+    atomic_init(&(lfht_ptr->fl_shead), init_lfht_flsptr);
+    atomic_init(&(lfht_ptr->fl_stail), init_lfht_flsptr);
+#else /* LFHT__USE_SPTR */
+    atomic_init(&(lfht_ptr->fl_head), NULL);
+    atomic_init(&(lfht_ptr->fl_tail), NULL);
+#endif /* LFHT__USE_SPTR */
+    atomic_init(&(lfht_ptr->fl_len), 1LL);
+    lfht_ptr->max_desired_fl_len = LFHT__MAX_DESIRED_FL_LEN;
+    atomic_init(&(lfht_ptr->next_sn), 0ULL);
+
+
+    /* hash bucket index */
+    atomic_init(&(lfht_ptr->index_bits), 0);
+    lfht_ptr->max_index_bits = LFHT__MAX_INDEX_BITS;
+    for ( i = 0; i <= LFHT__NUM_HASH_BITS; i++ ) {
+
+        lfht_ptr->index_masks[i] = mask;
+        mask <<= 1;
+        mask |= 0x01ULL;
+    }
+    atomic_init(&(lfht_ptr->buckets_defined), 1);
+    atomic_init(&(lfht_ptr->buckets_initialized), 0);
+    for ( i = 0; i < LFHT__BASE_IDX_LEN; i++ ) {
+
+        atomic_init(&((lfht_ptr->bucket_idx)[i]), NULL);
+    }
+
+
+    /* statistics */
+    atomic_init(&(lfht_ptr->max_lfsll_log_len), 0LL);
+    atomic_init(&(lfht_ptr->max_lfsll_phys_len), 0LL);
+
+    atomic_init(&(lfht_ptr->max_fl_len), 1LL);
+    atomic_init(&(lfht_ptr->num_nodes_allocated), 0LL);
+    atomic_init(&(lfht_ptr->num_nodes_freed), 0LL);
+    atomic_init(&(lfht_ptr->num_node_free_candidate_selection_restarts), 0LL);
+    atomic_init(&(lfht_ptr->num_nodes_added_to_fl), 0LL);
+    atomic_init(&(lfht_ptr->num_nodes_drawn_from_fl), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_head_update_cols), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_tail_update_cols), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_append_cols), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_req_denied_due_to_empty), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_req_denied_due_to_ref_count), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_node_ref_cnt_incs), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_node_ref_cnt_inc_retrys), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_node_ref_cnt_decs), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_frees_skiped_due_to_empty), 0LL);
+    atomic_init(&(lfht_ptr->num_fl_frees_skiped_due_to_ref_count), 0LL);
+
+    atomic_init(&(lfht_ptr->index_bits_incr_cols), 0LL);
+    atomic_init(&(lfht_ptr->buckets_defined_update_cols), 0LL);
+    atomic_init(&(lfht_ptr->buckets_defined_update_retries), 0LL);
+    atomic_init(&(lfht_ptr->bucket_init_cols), 0LL);
+    atomic_init(&(lfht_ptr->bucket_init_col_sleeps), 0LL);
+    atomic_init(&(lfht_ptr->recursive_bucket_inits), 0LL);
+    atomic_init(&(lfht_ptr->sentinels_traversed), 0LL);
+
+    atomic_init(&(lfht_ptr->insertions), 0LL);
+    atomic_init(&(lfht_ptr->insertion_failures), 0LL);
+    atomic_init(&(lfht_ptr->ins_restarts_due_to_ins_col), 0LL);
+    atomic_init(&(lfht_ptr->ins_restarts_due_to_del_col), 0LL);
+    atomic_init(&(lfht_ptr->ins_deletion_completions), 0LL);
+    atomic_init(&(lfht_ptr->nodes_visited_during_ins), 0LL);
+
+    atomic_init(&(lfht_ptr->deletion_attempts), 0LL);
+    atomic_init(&(lfht_ptr->deletion_starts), 0LL);
+    atomic_init(&(lfht_ptr->deletion_start_cols), 0LL);
+    atomic_init(&(lfht_ptr->deletion_failures), 0LL);
+    atomic_init(&(lfht_ptr->del_restarts_due_to_del_col), 0LL);
+    atomic_init(&(lfht_ptr->del_retries), 0LL);
+    atomic_init(&(lfht_ptr->del_deletion_completions), 0LL);
+    atomic_init(&(lfht_ptr->nodes_visited_during_dels), 0LL);
+
+    atomic_init(&(lfht_ptr->searches), 0LL);
+    atomic_init(&(lfht_ptr->successful_searches), 0LL);
+    atomic_init(&(lfht_ptr->failed_searches), 0LL);
+    atomic_init(&(lfht_ptr->marked_nodes_visited_in_succ_searches), 0LL);
+    atomic_init(&(lfht_ptr->unmarked_nodes_visited_in_succ_searches), 0LL);
+    atomic_init(&(lfht_ptr->marked_nodes_visited_in_failed_searches), 0LL);
+    atomic_init(&(lfht_ptr->unmarked_nodes_visited_in_failed_searches), 0LL);
+
+    atomic_init(&(lfht_ptr->value_swaps), 0LL);
+    atomic_init(&(lfht_ptr->successful_val_swaps), 0LL);
+    atomic_init(&(lfht_ptr->failed_val_swaps), 0LL);
+    atomic_init(&(lfht_ptr->marked_nodes_visited_in_succ_val_swaps), 0LL);
+    atomic_init(&(lfht_ptr->unmarked_nodes_visited_in_succ_val_swaps), 0LL);
+    atomic_init(&(lfht_ptr->marked_nodes_visited_in_failed_val_swaps), 0LL);
+    atomic_init(&(lfht_ptr->unmarked_nodes_visited_in_failed_val_swaps), 0LL);
+
+    atomic_init(&(lfht_ptr->value_searches), 0LL);
+    atomic_init(&(lfht_ptr->successful_val_searches), 0LL);
+    atomic_init(&(lfht_ptr->failed_val_searches), 0LL);
+    atomic_init(&(lfht_ptr->marked_nodes_visited_in_val_searches), 0LL);
+    atomic_init(&(lfht_ptr->unmarked_nodes_visited_in_val_searches), 0LL);
+    atomic_init(&(lfht_ptr->sentinels_traversed_in_val_searches), 0LL);
+
+    atomic_init(&(lfht_ptr->itter_inits), 0LL);
+    atomic_init(&(lfht_ptr->itter_nexts), 0LL);
+    atomic_init(&(lfht_ptr->itter_ends), 0LL);
+    atomic_init(&(lfht_ptr->marked_nodes_visited_in_itters), 0LL);
+    atomic_init(&(lfht_ptr->unmarked_nodes_visited_in_itters), 0LL);
+    atomic_init(&(lfht_ptr->sentinels_traversed_in_itters), 0LL);
+
+
+    /* setup hash table */
+
+    head_sentinel_ptr = lfht_create_node(lfht_ptr, 0ULL, 0ULL, true, NULL);
+    assert(head_sentinel_ptr);
+    assert(head_sentinel_ptr->tag == LFHT_VALID_NODE);
+
+    tail_sentinel_ptr = lfht_create_node(lfht_ptr, 0ULL, 0ULL, true, NULL);
+    tail_sentinel_ptr->hash = LLONG_MAX;
+    assert(tail_sentinel_ptr);
+    assert(tail_sentinel_ptr->tag == LFHT_VALID_NODE);
+
+    assert(NULL == atomic_load(&(tail_sentinel_ptr->next)));
+    atomic_store(&(head_sentinel_ptr->next), tail_sentinel_ptr);
+    atomic_store(&(lfht_ptr->lfsll_root), head_sentinel_ptr);
+
+    assert(NULL == atomic_load(&(tail_sentinel_ptr->next)));
+    atomic_store(&(head_sentinel_ptr->next), tail_sentinel_ptr);
+    atomic_store(&(lfht_ptr->lfsll_root), head_sentinel_ptr);
+
+    /* insert the zero-th bucket sentinel manually. */
+    atomic_store(&((lfht_ptr->bucket_idx)[0]), head_sentinel_ptr);
+    atomic_fetch_add(&(lfht_ptr->buckets_initialized), 1);
+
+
+    /* Setup the free list.
+     *
+     * The free list must always have at least one node.  Allocate, 
+     * initialize, and insert a node in the free list. 
+     */
+    fl_node_ptr = (struct lfht_fl_node_t *)lfht_create_node(lfht_ptr, 0ULL, 0ULL, false, NULL);
+    assert(fl_node_ptr);
+    assert(LFHT_FL_NODE_IN_USE == fl_node_ptr->tag);
+    atomic_store(&(fl_node_ptr->tag), LFHT_FL_NODE_ON_FL);
+#if LFHT__USE_SPTR
+    snext = atomic_load(&(fl_node_ptr->snext));
+    assert(NULL == snext.ptr);
+    assert(0 == atomic_load(&(fl_node_ptr->ref_count)));
+    fl_shead.ptr = fl_node_ptr;
+    fl_shead.sn  = 1ULL;
+    atomic_store(&(lfht_ptr->fl_shead), fl_shead);
+    fl_stail.ptr = fl_node_ptr;
+    fl_stail.sn  = 1ULL;
+    atomic_store(&(lfht_ptr->fl_stail), fl_stail);
+#else /* LFHT__USE_SPTR */
+    assert(NULL == atomic_load(&(fl_node_ptr->next)));
+    assert(0 == atomic_load(&(fl_node_ptr->ref_count)));
+    atomic_store(&(lfht_ptr->fl_head), fl_node_ptr);
+    atomic_store(&(lfht_ptr->fl_tail), fl_node_ptr);
+#endif /* LFHT__USE_SPTR */
+
+    return;
+
+} /* lfht_init() */
+
+
+/************************************************************************
+ *
+ * lfht_swap_value()
+ *
+ * Search the supplied lfht looking for a node with the supplied id..
+ *
+ * If it is found, and the node is not marked for deletion, set the 
+ * node's value to the supplied new_value, set *old_value_ptr to 
+ * the old value of the node, and return true.
+ *
+ * Otherwise, return false.
+ *
+ *                                           JRM -- 7/15/23
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ ************************************************************************/
+
+bool lfht_swap_value(struct lfht_t * lfht_ptr,
+                     unsigned long long int id,
+                     void * new_value,
+                     void ** old_value_ptr)
+
+{
+    bool success = false;
+    long long int marked_nodes_visited = 0;
+    long long int unmarked_nodes_visited = 0;
+    long long int sentinels_traversed = 0;
+    unsigned long long int hash;
+    struct lfht_node_t * node_ptr = NULL;
+    struct lfht_fl_node_t * fl_node_ptr;
+    
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+    assert(id <= LFHT__MAX_ID);
+    assert(old_value_ptr);
+
+    fl_node_ptr = lfht_enter(lfht_ptr);
+
+    hash = lfht_id_to_hash(id, false);
+
+    /* now attempt to find the target */
+
+    node_ptr = lfht_find_internal(lfht_ptr, hash, &marked_nodes_visited, 
+                                  &unmarked_nodes_visited, &sentinels_traversed);
+
+    if ( ( NULL == node_ptr ) || ( node_ptr->hash != hash ) ||
+         ( ((unsigned long long)atomic_load(&(node_ptr->next))) & 0x01ULL)) {
+
+        success = false;
+
+    } else {
+
+        assert(! node_ptr->sentinel);
+        assert(hash == node_ptr->hash);
+        *old_value_ptr = atomic_exchange(&(node_ptr->value), new_value);
+        success = true;
+    }
+
+    /* update statistics */
+
+    assert(marked_nodes_visited >= 0);
+    assert(unmarked_nodes_visited >= 0);
+    assert(sentinels_traversed >= 0);
+    
+    atomic_fetch_add(&(lfht_ptr->value_swaps), 1);
+
+    if ( success ) {
+
+        atomic_fetch_add(&(lfht_ptr->successful_val_swaps), 1);
+        atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_succ_val_swaps), marked_nodes_visited);
+        atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_succ_val_swaps), unmarked_nodes_visited);
+
+    } else {
+
+        atomic_fetch_add(&(lfht_ptr->failed_val_swaps), 1);
+        atomic_fetch_add(&(lfht_ptr->marked_nodes_visited_in_failed_val_swaps), marked_nodes_visited);
+        atomic_fetch_add(&(lfht_ptr->unmarked_nodes_visited_in_failed_val_swaps), unmarked_nodes_visited);
+    }
+
+    if ( sentinels_traversed > 0 ) {
+
+        atomic_fetch_add(&(lfht_ptr->sentinels_traversed), sentinels_traversed);
+    }
+
+    lfht_exit(lfht_ptr, fl_node_ptr);
+
+    return(success);
+
+} /* lfht_swap_value() */

--- a/hdf5/src/lfht.h
+++ b/hdf5/src/lfht.h
@@ -1,0 +1,729 @@
+/* Lock free hash table code */
+
+#include <stdatomic.h>
+
+#if 0
+#define LFHT__NUM_HASH_BITS     48
+#define LFHT__MAX_HASH          0x1FFFFFFFFFFFFULL
+#define LFHT__MAX_ID             0xFFFFFFFFFFFFULL
+#else
+/* Note that LFHT__NUM_HASH_BITS must be one greater than the number of bits 
+ * required to express the largest possible ID.  This is necessary as the 
+ * current implementation of the LFHT doesn't allow duplicate hash codes, 
+ * and one additional bit is needed to differentiate between hash codes of 
+ * IDs and those of sentinel nodes..
+ */
+#define LFHT__NUM_HASH_BITS     57
+#define LFHT__MAX_HASH          0x3FFFFFFFFFFFFFFULL
+#define LFHT__MAX_ID            0x1FFFFFFFFFFFFFFULL
+
+#endif
+#define LFHT__MAX_INDEX_BITS    10
+#define LFHT__USE_SPTR          1
+
+
+/***********************************************************************************
+ * struct lfht_node_t
+ *
+ * Node in the lock free singly linked list that is used to store entries in the 
+ * lock free hash table.  The fields of the node are discussed individually below:
+ *
+ * tag:		Unsigned integer set to LFHT_VALID_NODE whenever the node is either
+ *              in the SLL or the free list, and to LFHT_INVALID_NODE just before 
+ *              it is discarded.
+ *
+ * next:        Atomic pointer to the next entry in the SLL, or NULL if there is 
+ *              no next entry.  Note that due to the alignment guarantees of 
+ *              malloc() & calloc(), the least significant few bits (at least three
+ *              in all cases investigated to date) will be zero.  
+ *
+ *              This fact is used to allow atomic marking of the node for deletion.
+ *              If the low order bit of the next pointer is 1, the node is logically
+ *              deleted from the SLL.  It will be physically deleted from the SLL
+ *              by a subsequent insert or delete call.  See section 9.8 of 
+ *              "The Art of Multiprocessor Programming" by Herlihy, Luchangco, 
+ *              Shavit, and Spear for further details.
+ *
+ * id:          ID associated with the contents of the node.  This field is 
+ *              logically undefined if the node is a sentinel node
+ *
+ * hash:        For regular node, this is the hash value computed from the id.
+ *              For sentinel nodes, this is the smallest value that can map to 
+ *              the associated hash table bucket -- see section 13.3.3 of 
+ *              "The Art of Multiprocessor Programming" by Herlihy, Luchangco,
+ *              Shavit, and Spear for further details.
+ *
+ *              Note that duplicate hash codes cannot appear in the LFSLL, and that 
+ *              nodes in the LFSLL appear in strictly increasing order.
+ *
+ * sentinel:    Boolean flag that is true if the node is a sentinel node, and 
+ *              false otherwise.
+ *
+ * value:       Pointer to whatever structure is used to contain the value associated
+ *              with the id, or NULL if the node is a sentinel node.
+ *
+ *              This field is atomic, as we allow the client code to modify it in
+ *              an existing entry in the hash table.
+ *              
+ ***********************************************************************************/
+
+#define LFHT_VALID_NODE    0x1066
+#define LFHT_INVALID_NODE  0xDEAD
+
+typedef struct lfht_node_t {
+
+    unsigned int tag;
+    struct lfht_node_t * _Atomic next;
+    unsigned long long int id;
+    unsigned long long int hash;
+    bool sentinel;
+    void * _Atomic value;
+
+} lfht_node_t;
+
+
+/***********************************************************************************
+ * struct lfht_flsptr_t
+ *
+ * The lfht_flsptr_t combines a pointer to lfht_fl_node_t with a serial number in 
+ * a 128 bit package.  
+ *
+ * Unfortunately, this means that operations on atomic instances of this structure  
+ * may or may not be truly atomic.  Instead, the C11 run time may maintain atomicity
+ * with a mutex.  While this may have performance implications, there should be no
+ * correctness implications.
+ *
+ * The combination of a pointer and a serial number is needed to address ABA 
+ * bugs.
+ *
+ * ptr:         Pointer to an instance of flht_lf_node_t.
+ *
+ * sn:          Serial number that should be incremented by 1 each time a new
+ *              value is assigned to fl_ptr.
+ *
+ ***********************************************************************************/
+
+typedef struct lfht_flsptr_t {
+
+    struct lfht_fl_node_t * ptr;
+    unsigned long long int  sn;
+
+} lfht_flsptr_t;
+
+
+/***********************************************************************************
+ * struct lfht_fl_node_t
+ *
+ * Node in the free list for the lock free singly linked list on which entries 
+ * in the lock free hash table are stored.  The fields of the node are discussed 
+ * individually below:
+ *
+ * lfht_node:   Instance of lfht_node_t which is initialized and returned to the 
+ *              lfht code by lfht_create_node.  
+ *
+ *              If no node is available on the free list, an instance of 
+ *              lfht_fl_node_t is allocated and initialized.  Its pointer is 
+ *              then cast to a pointer to lfht_node_t, and returned to the 
+ *              caller.
+ *
+ *              A node is available on the free list if the list contains more
+ *              that one entry, and the ref count on the first node in the list 
+ *              is zero.  In this case, the first node is removed from the free 
+ *              list, re-initialzed, its pointer cast to a pointer to lfht_node_t, 
+ *              and returned to the caller.
+ *
+ * tag:		Atomic unsigned integer set to LFHT_FL_NODE_IN_USE whenever the 
+ *              node is in the SLL, to LFHT_FL_NODE_ON_FL when the node is on the 
+ *              free list, and to LFHT_FL_NODE_INVALID just before the instance of 
+ *              lfht_fl_node_t is freed.
+ *
+ * ref_count:   If this instance of lfht_fl_node_t is at the tail of the free 
+ *              list, the ref_count is incremented whenever a thread enters one
+ *              of the LFHT API calls, and decremented when the API call exits.
+ *
+ * sn:          Unique, sequential serial number assigned to each node when it 
+ *              is placed on the free list.  Used for debugging.
+ *
+#if LFHT__USE_SPTR
+ * snext;       Atomic instance of struct lfht_flsptr_t, which contains a 
+ *              pointer (ptr) to the next node on the free list for the lock 
+ *              free singly linked list, and a serial number (sn) which must be 
+ *              incremented each time a new value is assigned to snext.
+ *
+ *              The objective here is to prevent ABA bugs, which would 
+ *              otherwise occasionally allow leakage of a node.
+#else
+ * next:        Atomic pointer to the next entry in the free list, or NULL if 
+ *              there is no next entry.  
+#endif
+ *              
+ ***********************************************************************************/
+
+#define LFHT_FL_NODE_IN_USE          0x1492 /*  5266 */
+#define LFHT_FL_NODE_ON_FL           0xBEEF /* 48879 */
+#define LFHT_FL_NODE_INVALID         0xDEAD /* 57005 */
+
+typedef struct lfht_fl_node_t {
+
+    struct lfht_node_t lfht_node;
+    _Atomic unsigned int tag;
+    _Atomic unsigned int ref_count;
+    _Atomic unsigned long long int sn;
+#if LFHT__USE_SPTR
+   _Atomic struct lfht_flsptr_t snext;
+#else /* LFHT__USE_SPTR */
+    struct lfht_fl_node_t * _Atomic next;
+#endif /* LFHT__USE_SPTR */
+
+} lfht_fl_node_t;
+
+
+/*********************************************************************************** 
+ * struct lfht_t 
+ * 
+ * Root of a lock free hash table (LFHT). 
+ * 
+ * Entries in the hash table are stored in a lock free singly linked list (LFSLL). 
+ * 
+ * Each hash bucket has a sentinel node in the linked list that marks the 
+ * beginning of the bucket.  Pointers to the sentinel nodes are stored in 
+ * the index. 
+ * 
+ * Section 13.3.3 of "The Art of Multiprocessor Programming" by Herlihy, 
+ * Luchangco, Shavit, and Spear describes most of the details of the algorithm. 
+ * However, that discussion presumes implementation in a language with 
+ * garbage collection -- which simplifies matters greatly. 
+ * 
+ * The basic problem here is that we can't free a node that has been 
+ * removed from the LFSLL until we know that all references to it have been 
+ * discarded.  This is a problem, as an arbitrary number of threads may 
+ * have a pointer to a node at the point at which it is physically deleted 
+ * from the LFSLL. 
+ * 
+ * We solve this problem as follows: 
+ * 
+ * First, don't allow any node on the LFSLL to become visible outside of 
+ * the LFHT package.  As a result, we know that all pointers to a discarded 
+ * node have been discarded as well once all threads that were active in the 
+ * LFHT code at the point that the node was discarded have exited the LFHT 
+ * code.  We know this, as any such pointers must have been allocated on the 
+ * stack, and were therefore discarded when the associated threads left the 
+ * LFHT package. 
+ * 
+ * Second, maintain a free list of discarded nodes, and decorate each discarded 
+ * node with a reference count (see declarations of lfht_node_t and lfht_fl_node_t 
+ * above).  
+ *
+ * Ideally, on entry to the LFHT package, each thread must increment the
+ * reference count on the last node on the free list, and then decrement it
+ * on exit. However, until I can find a way to make this operation atomic, this
+ * is not workable, as the tail node may advance to the head of the free list
+ * and be re-allocated in the time between the read of the pointer to the last
+ * element on the free list, and the increment of the indicated ref_count.
+ *
+ * Instead, on entry to the LFHT package, each thread allocates a node, sets its
+ * ref_count to 1, and releases it to the free list.  On exit, it decrements
+ * the node’s ref_count back to zero.  This has the same net effect, but is not as
+ * efficient.  Needless to say, this issue should be revisited for the production
+ * version.   
+ * 
+ * If we further require that nodes on the free list are only removed from 
+ * the head of the list (either for re-use or discard), and then only when their 
+ * reference counts are zero, we have that nodes are only released to the 
+ * heap or re-used if all threads that were active in LFHT package at the point 
+ * at which the node was place on the free list have since exited the LFHT 
+ * package. 
+ * 
+ * Between them, these two adaptions solve the problem of avoiding accesses to 
+ * nodes that have been returned to the heap. 
+ * 
+ * Finally, observe that the LFSLL code is simplified if it always contains two 
+ * sentinel nodes with (effectively) values negative and positive infinity -- 
+ * thus avoiding operations that touch the ends of the list.
+ * 
+ * In this context, the index sentinel node with hash value zero is created 
+ * at initialization time and serves as the node with value negative infinity. 
+ * However, since a sentinel node with hash positive infinity is not created 
+ * by the index, we add a sentinel node with hash LLONG_MAX at initialization 
+ * to serve this purpose. 
+ * 
+ * Note that the LFSLL used in the implementation of the LFHT is a modified 
+ * version of the lock free singly linked list discussed in chapter 9 of 
+ * "The Art of Multiprocessor Programming" by Herlihy, Luchangco, Shavit, 
+ * and Spear. 
+ * 
+ * The fields of lfht_t are discussed individually below. 
+ * 
+ * 
+ * tag:         Unsigned integer set to LFHT_VALID when the instance of lfht_t 
+ *              is initialized, and to LFHT_INVALID just before the memory for 
+ *              the instance of struct lfHT_t is discarded. 
+ * 
+ * 
+ * Lock Free Singly Linked List related fields: 
+ * 
+ * lfsll_root:  Atomic Pointer to the head of the SLL.  Other than during setup, 
+ *              this field will always point to the first sentinal node in the 
+ *              index, whose hash will be zero. 
+ * 
+ * lfsll_log_len:  Atomic integer used to maintain a count of the number of nodes 
+ *              in the SLL less the sentry nodes and the regular nodes that 
+ *              have been marked for deletion. 
+ * 
+ *              Note that due to the delay between the insertion or deletion 
+ *              of a node, and the update of the field, this count may be off 
+ *              for brief periods of time. 
+ * 
+ * lfsll_phys_len:  Atomic integer used to maintain a count of the actual number 
+ *              of nodes in the SLL.  This includes the sentry nodes, and any 
+ *              nodes that have been marked for deletion, but that have not 
+ *              been physically deleted. 
+ * 
+ *              Note that due to the delay between the insertion or deletion 
+ *              of a node, and the update of the field, this count may be off 
+ *              for brief periods of time. 
+ * 
+ * 
+ * Free list related fields: 
+ *
+#if LFHT__USE_SPTR
+ * 
+ * fl_shead:    Atomic instance of struct lfht_flsptr_t, which contains a 
+ *              pointer (ptr) to the head of the free list for the lock free 
+ *              singly linked list, and a serial number (sn) which must be 
+ *              incremented each time a new value is assigned to fl_shead. 
+ * 
+ *              The objective here is to prevent ABA bugs, which would 
+ *              otherwise occasionally allow allocation of free list 
+ *              nodes with positive ref counts. 
+ * 
+ * fl_stail:    Atomic instance of struct lfht_flsptr_t, which contains a 
+ *              pointer (ptr) to the tail of the free list for the lock free 
+ *              singly linked list, and a serial number (sn) which must be 
+ *              incremented each time a new value is assigned to fl_stail. 
+ * 
+ *              The objective here is to prevent ABA bugs, which would 
+ *              otherwise occasionally allow the tail of the free list to 
+ *              get ahead of the head -- resulting in the increment of the 
+ *              ref count on nodes that are no longer in the free list. 
+ *
+#else
+ *
+ * fl_head:     Pointer to the head of the free list for the lock free singly 
+ *              linked list. Once initialized, the free list will always contain
+ *              at least one entry, and is logically empty if it contains only
+ *              one entry (i.e. fl_head == fl_tail != NULL).
+ *
+ * fl_tail:     Pointer to the tail of the free list for the lock free singly
+ *              linked list.  Once initialized, the free list will always contain
+ *              at least one entry, and is logically empty if it contains only
+ *              one entry (i.e. fl_head == fl_tail != NULL).
+ *
+ #endif
+ * 
+ * fl_len:      Atomic integer used to maintain a count of the number of nodes 
+ *              on the free list.  Note that due to the delay between free list 
+ *              insertions and deletions, and the update of this field, this 
+ *              count may be off for brief periods of time. 
+ * 
+ *              Further, since the free list must always contain at least one 
+ *              entry.  When correct, fl_len will be one greater than the number 
+ *              of nodes available on the free list. 
+ * 
+ * max_desired_fl_len: Integer field containing the desired maximum free list 
+ *              length.  This is of necessity a soft limit as entries cannot 
+ *              be removed from the head of the free list unless their 
+ *              reference counts are zero.  Further, at most one entry is 
+ *              removed from the head of the free list per call to 
+ *              lfht_discard_node(). 
+ * 
+ * next_sn:     Serial number to be assigned to the next node placed on the 
+ *              free list. 
+ * 
+ *
+ * Hash Bucket Index: 
+ * 
+ * index_bits:  Number of index bits currently in use. 
+ * 
+ * max_index_bits:  Maximum value that index_bits is allowed to attain.  If 
+ *              this field is set to zero, the lock free hash table becomes 
+ *              a lock free singly linked list, as only one hash bucket is 
+ *              permitted. 
+ * 
+ * index_masks: Array of unsigned long long containing the bit masks used to 
+ *              compute the index into the hash bucket array from a hash code. 
+ * 
+ * buckets_defined: Convenience field.  This is simply 2 ** index_bits. 
+ *              Needless to say, buckets_initialized must always be less than 
+ *              or equal to buckets_initialized. 
+ * 
+ * buckets_initialized: Number of hash buckets that have been initialized -- 
+ *              that is, their sentinel nodes have been created, and inserted 
+ *              into the LFSLL, and a pointer to the sentinel node has been 
+ *              copied into the bucket_idx. 
+ * 
+ * bucket_idx:  Array of pointers to lfht_node_t.  Each entry in the array is 
+ *              either NULL, or contains a pointer to the sentinel node marking 
+ *              the beginning of the hash bucket indicated by its index in the 
+ *              array. 
+ * 
+ * Statistics Fields:
+ *
+ * The following fields are used to record statistics on the operation of the 
+ * SLL for purposes of debugging and optimization.  All fields are atomic.
+ *
+ * max_lfsll_log_len: Maximum logical length of the LFSLL.  In the multi-thread 
+ *              case, this number should be viewed as aproximate.
+ *
+ * max_lfsll_phys_len: Maximum physical length of the LFSLL.  In the multi-thread 
+ *              case, this number should be viewed as aproximate.
+ *
+ *
+ * max_fl_len:  Maximum number of nodes that have resided on the free list
+ *              at any point during the current run.  In the multi-thread
+ *              case, this number should be viewed as aproximate.
+ *
+ * num_nodes_allocated: Number of nodes allocated from the heap.
+ * 
+ * num_nodes_freed: Number of nodes freed.
+ *
+ * num_node_free_candidate_selection_restarts: Number of times the attempt
+ *              to pull a node from the head of the free list and free 
+ *              had to be restared due to a change in fl_head.
+ *
+ * num_nodes_added_to_fl: Number of nodes added to the free list.
+ *
+ * num_nodes_drawn_from_fl: Number of nodes drawn from the free list for 
+ *              re-use.
+ *
+ * num_fl_head_update_cols: Number of collisions when updating the fl_head
+ *              for a node withdrawal.
+ *
+ * num_fl_tail_update_cols: Number of collisions when updating the fl_tail
+ *              for an additions.
+ *
+ * num_fl_append_cols: Number of collisions when appending a newly freed
+ *              node to the end of the free list.
+ *
+ * num_fl_req_denied_due_to_empty: Number of free list requests denied 
+ *              because the free list was (logically) empty. (recall that
+ *              the free list must always have at least one entry.).
+ *
+ * num_fl_req_denied_due_to_ref_count: Number of free list requests 
+ *              denied because the entry at the head of the free list 
+ *              had a positive ref count.
+ *
+ * num_fl_node_ref_cnt_incs: Number of time the ref count on some node 
+ *              on the free list has been incremented.
+ *
+ * num_fl_node_ref_cnt_inc_retrys: Number of times a ref count increment
+ *              on some node on the free list had to me un-done due to 
+ *              a change in fl_tail.
+ *
+ * num_fl_node_ref_cnt_decs: Number of times the ref count on some 
+ *              node on the free list has been decremented.
+ *
+ * num_fl_frees_skiped_due_to_empty:  Number of times that 
+ *              lfsll_discard_node() has attempted to find a node to 
+ *              free, but been unable to do so because the free list 
+ *              is empty.  Assuming a reasonable max_desired_fl_len,
+ *              this is very improbable -- however, since we must
+ *              check for the possibility, we may as well make note 
+ *              of it if it occurs.
+ *
+ * num_fl_frees_skiped_due_to_ref_count: Number of times that
+ *              lfsll_discard_node() has attempted to find a node to
+ *              free, but been unable to do so because the first item
+ *              on the free list has a positive ref count.  Absent 
+ *              either a very small max_desired_fl_len or a very large
+ *              number of threads, this is also improbable -- but again,
+ *              since we must check for it, we log it if it occurs.
+ *
+ *
+ * index_bits_incr_cols: Number of times there have been index bits 
+ *              increment collisions.
+ *
+ * buckets_defined_update_cols: Number of collisions between threads 
+ *              attempting to update bucket_defined.
+ *
+ * buckets_defined_update_retries: Number of retries updating 
+ *               buckets_defined.
+ *
+ * bucket_init_cols: Number of times there have been bucket initization 
+ *              collisions.
+ *
+ * bucket_init_col_sleeps:  Number of times a losing thread in the race 
+ *              to initialize a hash bucket has had to sleep while 
+ *              waiting for the sinner to complete the job.
+ *
+ * insertions:  Number of entries that have been inserted into the SLL.
+ *
+ * insertion_failure: Number of times an insertion attempt has failed.
+ *
+ * ins_restarts_due_to_ins_col: Number of times an insertion has had to restart 
+ *              due to a failed compare and swap when inserting the new node.
+ *
+ * ins_restarts_due_to_del_col: Number of times an insertion has had to restart
+ *              due to a collision while removing a node marked for deletion.
+ *
+ * ins_deletion_completions: Number of node deletions completed in passing
+ *              during insertions.
+ *
+ * nodes_visited_during_ins: Number of nodes visited during insertions.
+ *
+ *
+ * deletion_attemps:  Number of times that a deletion from the SLL has been 
+ *              requested.
+ *
+ * deletions_starts:  Number of entries that have been marked for deletion
+ *              from the SLL.
+ *
+ * deletion_start_cols: Number of failed attempts to mark an entry in the SLL
+ *              for deletion.
+ *
+ * deletion_failures: Number of times that a deletion request has failed because
+ *              the target can't be found.
+ *
+ * del_restarts_due_to_del_col: Number of times a deletion has had to restart
+ *              due to a collision while removing a node marked for deletion.
+ *
+ * del_retries: Number of time marking a mode as deleted has had to be retried
+ *              due to an un-expected value in the next field -- typically, 
+ *              this is due to a node insertion / deletion just after the 
+ *              the target in the interval between finding the target and 
+ *              marking it.
+ *
+ * del_deletion_completions: Number of node deletions completed in passing
+ *              during deletions.
+ *
+ * nodes_visited_during_dels: Number of nodes visited during deletions.
+ *
+ *
+ * searches:    Number of searches.
+ *
+ * successful_searches: Number of successful searches.
+ *
+ * failed_searches: Number of failed searches.
+ *
+ * marked_nodes_visited_in_succ_searches:  Number of marked nodes visited 
+ *              during successful searches.
+ *
+ * unmarked_nodes_visited_in_succ_searches:  Number of unmarked nodes visited 
+ *              during successful searches.
+ *
+ * marked_nodes_visited_in_failed_searches: Number of marked nodes visited during 
+ *              failed searches.
+ *
+ * unmarked_nodes_visited_in_failed_searches: Number of unmarked nodes visited 
+ *              during failed searches.
+ *
+ *
+ * searches:    Number of value spaps.
+ *
+ * successful_val_swaps: Number of successful value swaps.
+ *
+ * failed_val_swaps: Number of failed value swaps.
+ *
+ * marked_nodes_visited_in_succ_val_swaps:  Number of marked nodes visited 
+ *              during successful value swaps.
+ *
+ * unmarked_nodes_visited_in_succ_val_swaps:  Number of unmarked nodes visited 
+ *              during successful value swaps.
+ *
+ * marked_nodes_visited_in_failed_val_swaps: Number of marked nodes visited during 
+ *              failed val swaps.
+ *
+ * unmarked_nodes_visited_in_failed_val_swaps: Number of unmarked nodes visited 
+ *              during failed val swaps.
+ *
+ *
+ * value_searches: Searches for entries by value instead of id.
+ *
+ * successful_val_searches: Successful searches for entries by value.
+ *
+ * failed_val_searches: Failed searches for entries by value.
+ *
+ * marked_nodes_visited_in_val_searches; Marked nodes visited during searches by
+ *              value.
+ *
+ * unmarked_nodes_visited_in_val_searches: Unmarked nodes other than sentinels 
+ *              visited during searches by value.
+ *
+ * sentinels_traversed_in_val_searches: Sentinel nodes traversed during searches
+ *              by value.
+ *
+ * itter_inits: Number of times that an itteration through the entries in the 
+ *              hash table has been initiated via a call to lfht_get_next().
+ *
+ * itter_nexts: Number of times the next element in an itteration through the 
+ *              entries in the hash table has been returned.
+ *
+ * itter_ends:  Number of times that an itterations through the entries in 
+ *              the hash table has been followed to its end.
+ *
+ * marked_nodes_visited_in_itters: Marked nodes visited during itterations
+ *               trhough the entries in the hash table.
+ *
+ * unmarked_nodes_visited_in_itters: Un-marked nodes that are not sentinels 
+ *               visited during itterations through the entries in the hash table.
+ *
+ * sentinels_traversed_in_itters: Number of sentinel nodes traversed during
+ *               itterations through the entries in the hash table.
+ *
+ ***********************************************************************************/
+
+#define LFHT_VALID                     0x628
+#define LFHT_INVALID                   0xDEADBEEF
+#define LFHT__MAX_DESIRED_FL_LEN       256
+#define LFHT__BASE_IDX_LEN             1024
+
+typedef struct lfht_t
+{
+   unsigned int tag;
+
+
+   /* LFSLL: */
+
+   struct lfht_node_t * _Atomic lfsll_root;
+   _Atomic long unsigned long int lfsll_log_len;
+   _Atomic long unsigned long int lfsll_phys_len;
+
+
+   /* Free List: */
+
+#if LFHT__USE_SPTR
+   _Atomic struct lfht_flsptr_t fl_shead;
+   _Atomic struct lfht_flsptr_t fl_stail;
+#else /* LFHT__USE_SPTR */
+   struct lfht_fl_node_t * _Atomic fl_head;
+   struct lfht_fl_node_t * _Atomic fl_tail;
+#endif /* LFHT__USE_SPTR */
+   _Atomic long long int fl_len;
+   int max_desired_fl_len;
+   _Atomic unsigned long long int next_sn;
+
+
+   /* hash bucket index */
+
+   _Atomic int index_bits;
+   int max_index_bits;
+   unsigned long long int index_masks[LFHT__NUM_HASH_BITS + 1];
+   _Atomic unsigned long long int buckets_defined;
+   _Atomic unsigned long long int buckets_initialized;
+   _Atomic (struct lfht_node_t *) bucket_idx[LFHT__BASE_IDX_LEN];
+
+
+   /* statistics: */
+   _Atomic unsigned long long int max_lfsll_log_len;
+   _Atomic unsigned long long int max_lfsll_phys_len;
+   
+   _Atomic long long int max_fl_len;
+   _Atomic long long int num_nodes_allocated;
+   _Atomic long long int num_nodes_freed;
+   _Atomic long long int num_node_free_candidate_selection_restarts;
+   _Atomic long long int num_nodes_added_to_fl;
+   _Atomic long long int num_nodes_drawn_from_fl;
+   _Atomic long long int num_fl_head_update_cols;
+   _Atomic long long int num_fl_tail_update_cols;
+   _Atomic long long int num_fl_append_cols;
+   _Atomic long long int num_fl_req_denied_due_to_empty;
+   _Atomic long long int num_fl_req_denied_due_to_ref_count;
+   _Atomic long long int num_fl_node_ref_cnt_incs;
+   _Atomic long long int num_fl_node_ref_cnt_inc_retrys;
+   _Atomic long long int num_fl_node_ref_cnt_decs;
+   _Atomic long long int num_fl_frees_skiped_due_to_empty;
+   _Atomic long long int num_fl_frees_skiped_due_to_ref_count;
+
+   _Atomic long long int index_bits_incr_cols;
+   _Atomic long long int buckets_defined_update_cols;
+   _Atomic long long int buckets_defined_update_retries;
+   _Atomic long long int bucket_init_cols;
+   _Atomic long long int bucket_init_col_sleeps;
+   _Atomic long long int recursive_bucket_inits;
+   _Atomic long long int sentinels_traversed;
+ 
+   _Atomic long long int insertions;
+   _Atomic long long int insertion_failures;
+   _Atomic long long int ins_restarts_due_to_ins_col;
+   _Atomic long long int ins_restarts_due_to_del_col;
+   _Atomic long long int ins_deletion_completions;
+   _Atomic long long int nodes_visited_during_ins;
+ 
+   _Atomic long long int deletion_attempts;
+   _Atomic long long int deletion_starts;
+   _Atomic long long int deletion_start_cols;
+   _Atomic long long int deletion_failures;
+   _Atomic long long int del_restarts_due_to_del_col;
+   _Atomic long long int del_retries;
+   _Atomic long long int del_deletion_completions;
+   _Atomic long long int nodes_visited_during_dels;
+ 
+   _Atomic long long int searches;
+   _Atomic long long int successful_searches;
+   _Atomic long long int failed_searches;
+   _Atomic long long int marked_nodes_visited_in_succ_searches;
+   _Atomic long long int unmarked_nodes_visited_in_succ_searches;
+   _Atomic long long int marked_nodes_visited_in_failed_searches;
+   _Atomic long long int unmarked_nodes_visited_in_failed_searches;
+ 
+   _Atomic long long int value_swaps;
+   _Atomic long long int successful_val_swaps;
+   _Atomic long long int failed_val_swaps;
+   _Atomic long long int marked_nodes_visited_in_succ_val_swaps;
+   _Atomic long long int unmarked_nodes_visited_in_succ_val_swaps;
+   _Atomic long long int marked_nodes_visited_in_failed_val_swaps;
+   _Atomic long long int unmarked_nodes_visited_in_failed_val_swaps;
+ 
+   _Atomic long long int value_searches;
+   _Atomic long long int successful_val_searches;
+   _Atomic long long int failed_val_searches;
+   _Atomic long long int marked_nodes_visited_in_val_searches;
+   _Atomic long long int unmarked_nodes_visited_in_val_searches;
+   _Atomic long long int sentinels_traversed_in_val_searches;
+ 
+   _Atomic long long int itter_inits;
+   _Atomic long long int itter_nexts;
+   _Atomic long long int itter_ends;
+   _Atomic long long int marked_nodes_visited_in_itters;
+   _Atomic long long int unmarked_nodes_visited_in_itters;
+   _Atomic long long int sentinels_traversed_in_itters;
+
+} lfht_t;
+
+
+bool lfht_add(struct lfht_t * lfht_ptr, unsigned long long int id, void * value);
+bool lfht_add_internal(struct lfht_t * lfht_ptr, struct lfht_node_t * bucket_head_ptr,
+                       unsigned long long int id, unsigned long long int hash, bool sentinel, void * value,
+                       struct lfht_node_t ** new_node_ptr_ptr);
+void lfht_clear(struct lfht_t * lfht_ptr);
+void lfht_clear_stats(struct lfht_t * lfht_ptr);
+void lfht_create_hash_bucket(struct lfht_t * lfht_ptr, unsigned long long int hash, int index_bits);
+struct lfht_node_t * lfht_create_node(struct lfht_t * lfht_ptr, unsigned long long int id,
+                                      unsigned long long int hash, bool sentinel, void * value);
+void lfht_discard_node(struct lfht_t * lfht_ptr, struct lfht_node_t * node_ptr, unsigned int expected_ref_count);
+bool lfht_delete(struct lfht_t * lfht_ptr, unsigned long long int id);
+void lfht_dump_list(struct lfht_t * lfht_ptr, FILE * file_ptr);
+void lfht_dump_stats(struct lfht_t * lfht_ptr, FILE * file_ptr);
+struct lfht_fl_node_t * lfht_enter(struct lfht_t * lfht_ptr);
+void lfht_exit(struct lfht_t * lfht_ptr, struct lfht_fl_node_t * fl_node_ptr);
+bool lfht_find(struct lfht_t * lfht_ptr, unsigned long long int id, void ** value_ptr);
+bool lfht_find_id_by_value(struct lfht_t * lfht_ptr, unsigned long long int *id_ptr, void * value);
+struct lfht_node_t * lfht_find_internal(struct lfht_t * lfht_ptr, unsigned long long int hash,
+                                        long long int * marked_nodes_visited_ptr,
+                                        long long int * unmarked_nodes_visited_ptr,
+                                        long long int * sentinels_traversed_ptr);
+void lfht_find_mod_point(struct lfht_t * lfht_ptr, struct lfht_node_t * bucket_head_ptr,
+                         struct lfht_node_t ** first_ptr_ptr, struct lfht_node_t ** second_ptr_ptr,
+                         int * cols_ptr, int * dels_ptr, int * nodes_visited_ptr,
+                         unsigned long long int hash);
+bool lfht_get_first(struct lfht_t * lfht_ptr, unsigned long long int * id_ptr, void ** value_ptr);
+struct lfht_node_t * lfht_get_hash_bucket_sentinel(struct lfht_t * lfht_ptr, unsigned long long int hash);
+bool lfht_get_next(struct lfht_t * lfht_ptr, unsigned long long int old_id, unsigned long long int * id_ptr,
+                   void ** value_ptr);
+unsigned long long lfht_hash_to_idx(unsigned long long hash, int index_bits);
+unsigned long long lfht_id_to_hash(unsigned long long id, bool sentinel_hash);
+void lfht_init(struct lfht_t * lfht_ptr);
+bool lfht_swap_value(struct lfht_t * lfht_ptr, unsigned long long int id, void * new_value,
+                     void ** old_value_ptr);
+
+

--- a/hdf5/src/lfht.txt
+++ b/hdf5/src/lfht.txt
@@ -1,0 +1,63 @@
+            Lock Free Hash Table Notes:
+                     8/10/23
+
+
+Overview:
+
+The lock free hash table (lfht) is based on the lock free hash table 
+algorithm presented in section 13.3 of second edition of "The Art of 
+Multiprocessor Programming" by  Herlihy, Luchangco, Shavit, & Spear.
+The underlying lock free singly linked list is adapted from section 
+9.8 of the same volume.
+
+At least as presented in the above volume, these algorithms are 
+heavily dependent on garbage collection.  For purposes of the lock 
+free hash table, this problem is dealt with via a free list that 
+does not release an entry for re-use until all threads that were 
+active in the lfht at the time that an entry was place on the free
+list have exited the lfht -- thus guaranteeing that no thread
+currently in the lfht has a pointer to the entry.
+
+The free list is implemented using the lock free queue presented 
+in section 10.5 of the above volume.  To address the ABA issues
+endemic in this algorithm, the pointers used are combined with 
+a version number in a 128 bit atomic structure.
+
+As with the lfht, the lock free queue is heavily dependent on 
+garbage collection.  In particular, it is possible for thread 
+local copies of the tail pointer to become wildly out of date, 
+pointing to entries that have already been re-allocated.  This 
+is not a problem for re-allocated entries, but it does cause
+problems if an entry has been returned to the heap. 
+
+In its current configurations, lfht collects extensive stats,
+that have proved very helpful in test and debug.
+
+
+Known Issues:
+
+At present, the garbage collection issues in the free list are 
+addressed by not releasing entries to the heap until the lfht
+is shut down.  Addressing this issue is on my todo, with two 
+possible solutions in hand.  
+
+While the size of the hash table in the lfht is adjusted 
+dynamically, its maximum size is currently limited to 1024 hash 
+buckets.  Again, addressing this is on my todo.
+
+The test suite for the lfht is in lfht_tests.c.  This test 
+suite is extensive, and currently takes about 17 hours to 
+complete.  At of this writing, it completes without failure 
+on the three machines it has been run on (a Debian box, and 
+two Macs).  However, Valgrind / Helgrind complains about 
+multiple issues.  While I suspect most of these are false 
+positives, they must be reviewed and addressed as appropriate.
+
+At present, any errors detected by the test suite trigger 
+assertion failures.  This test code will have to be revised 
+to conform with HDF5 regression test standards.
+
+Finally, the code needs a cleanup.  
+
+
+

--- a/hdf5/src/lfht_tests.c
+++ b/hdf5/src/lfht_tests.c
@@ -1,0 +1,4061 @@
+#include <sys/time.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include "lfht.h"
+#include "lfht.c"
+
+#define MAX_NUM_THREADS         32
+
+void lfht_verify_list_lens(struct lfht_t * lfht_ptr);
+void lfht_dump_interesting_stats(struct lfht_t * lfht_ptr);
+
+void lfht_hash_fcn_test(void);
+void lfht_hash_to_index_test(void);
+
+void lfht_lfsll_serial_test_1(void);
+void lfht_lfsll_serial_test_2(void);
+void lfht_lfsll_serial_test_3(void);
+
+void lfht_serial_test_1(void);
+void lfht_serial_test_2(void);
+void lfht_serial_test_3(void);
+
+void * lfht_mt_test_fcn_1(void * args);
+void * lfht_mt_test_fcn_2(void * args);
+
+void lfht_lfsll_mt_test_fcn_1__serial_test();
+void lfht_lfsll_mt_test_fcn_2__serial_test();
+
+void lfht_mt_test_fcn_1__serial_test();
+void lfht_mt_test_fcn_2__serial_test();
+
+void lfht_lfsll_mt_test_1(int nthreads);
+void lfht_lfsll_mt_test_2(int nthreads);
+void lfht_lfsll_mt_test_3(int nthreads);
+
+void lfht_mt_test_1(int run, int nthreads);
+void lfht_mt_test_2(int run, int nthreads);
+void lfht_mt_test_3(int run, int nthreads);
+
+
+/***********************************************************************************
+ *
+ * lfht_verify_list_lens()()
+ *
+ *     For the supplied instance of lfht_t, verify that the lfsll_phys_len and 
+ *     fl_len fields are correct.
+ *
+ *     Any discrepency will trigger an assertion.
+ *
+ *                                                   JRM -- 7/7/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_verify_list_lens(struct lfht_t * lfht_ptr)
+{
+    bool marked_for_deletion;
+    int lfsll_log_len = 0;
+    int lfsll_phys_len = 0;
+    int num_sentinels = 0;
+    int fl_len = 0;
+    struct lfht_node_t * node_ptr;
+    struct lfht_node_t * next;
+    struct lfht_fl_node_t * fl_node_ptr;
+#if LFHT__USE_SPTR
+    struct lfht_flsptr_t fl_shead;
+    struct lfht_flsptr_t fl_stail;
+    struct lfht_flsptr_t snext;
+#endif /* LFHT__USE_SPTR */
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+
+    node_ptr = atomic_load(&(lfht_ptr->lfsll_root));
+
+    while ( node_ptr ) {
+
+        lfsll_phys_len++;
+
+        next = atomic_load(&(node_ptr->next));
+
+        marked_for_deletion = ( 1 == (((unsigned long long int)(next)) & 0x01ULL) );
+
+        if ( node_ptr->sentinel ) {
+
+            num_sentinels++;
+            assert(!marked_for_deletion);
+
+        } else if ( ! marked_for_deletion ) {
+
+            lfsll_log_len++;
+        }
+
+        node_ptr = (struct lfht_node_t *)(((unsigned long long)(next)) & (~0x01ULL));
+    }
+
+    assert(num_sentinels  == atomic_load(&(lfht_ptr->buckets_initialized)) + 1);
+    assert(lfsll_log_len  == atomic_load(&(lfht_ptr->lfsll_log_len)));
+    assert(lfsll_phys_len == atomic_load(&(lfht_ptr->lfsll_phys_len)));
+
+#if LFHT__USE_SPTR
+    fl_shead = atomic_load(&(lfht_ptr->fl_shead));
+    fl_stail = atomic_load(&(lfht_ptr->fl_stail));
+    fl_node_ptr = fl_shead.ptr;
+
+    if ( fl_shead.sn > fl_stail.sn ) {
+        fprintf(stdout, "\n fl_shead.sn = %lld, fl_stail.sh = %lld\n", fl_shead.sn, fl_stail.sn);
+    }
+
+    while( fl_node_ptr ) {
+
+        assert(0ULL == atomic_load(&(fl_node_ptr->ref_count)));
+        fl_len++;
+        snext = atomic_load(&(fl_node_ptr->snext));
+        fl_node_ptr = snext.ptr;
+    }
+#else /* LFHT__USE_SPTR */
+    fl_node_ptr = atomic_load(&(lfht_ptr->fl_head));
+
+    while( fl_node_ptr ) {
+
+        fl_len++;
+        fl_node_ptr = atomic_load(&(fl_node_ptr->next));
+    }
+#endif /* LFHT__USE_SPTR */
+
+    assert(fl_len == atomic_load(&(lfht_ptr->fl_len)));
+
+    return;
+
+} /* lfht_verify_list_lens() */
+
+
+/***********************************************************************************
+ *
+ * lfht_dump_interesting_stats()()
+ *
+ *     For the supplied instance of lfht_t, test to see if any of the "interesting"
+ *     stats are non-zero, and if so, display the value.
+ *
+ *                                                   JRM -- 7/12/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_dump_interesting_stats(struct lfht_t * lfht_ptr)
+{
+    bool marked_for_deletion;
+    unsigned long long int buckets_defined_update_cols;
+    unsigned long long int buckets_defined_update_retries;
+    unsigned long long int bucket_init_cols;
+    unsigned long long int bucket_init_col_sleeps;
+    unsigned long long int recursive_bucket_inits;
+    unsigned long long int sentinels_traversed;
+
+    assert(lfht_ptr);
+    assert(LFHT_VALID == lfht_ptr->tag);
+
+    buckets_defined_update_cols    = atomic_load(&(lfht_ptr->buckets_defined_update_cols));
+    buckets_defined_update_retries = atomic_load(&(lfht_ptr->buckets_defined_update_retries));
+    bucket_init_cols               = atomic_load(&(lfht_ptr->bucket_init_cols));
+    bucket_init_col_sleeps         = atomic_load(&(lfht_ptr->bucket_init_col_sleeps));
+    recursive_bucket_inits         = atomic_load(&(lfht_ptr->recursive_bucket_inits));
+    sentinels_traversed            = atomic_load(&(lfht_ptr->sentinels_traversed));
+
+    if ( ( buckets_defined_update_cols > 0 ) ||
+         ( buckets_defined_update_retries > 0 ) ) {
+
+        fprintf(stdout, "\n\n");
+
+        if ( ( buckets_defined_update_cols > 0 ) || ( buckets_defined_update_retries ) ) {
+
+            fprintf(stdout, "buckets_defined update cols / retries = %lld / %lld.\n", 
+                    buckets_defined_update_cols, buckets_defined_update_retries);
+        }
+
+        if ( ( bucket_init_cols ) || ( bucket_init_col_sleeps ) ) {
+
+            fprintf(stdout, "bucket init cols / bucket init col sleeps = %lld / %lld.\n", 
+                    bucket_init_cols, bucket_init_col_sleeps);
+        }
+#if 0
+        if ( ( recursive_bucket_inits ) || ( sentinels_traversed ) ) {
+
+            fprintf(stdout, "recursive bucket inits / sentinels traversed = %lld / %lld.\n", 
+                    recursive_bucket_inits, sentinels_traversed);
+        }
+#endif
+    }
+
+    return;
+
+} /* lfht_verify_list_lens() */
+
+
+/***********************************************************************************
+ *
+ * lfht_hash_fcn_test()
+ *
+ *     Verify that lfht_id_to_hash() generates the correct results.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *     Note that the ids, and the expected values for the regular and sentinel hashes 
+ *     depend on the value of LFHT__NUM_HASH_BITS -- and will have to be adjusted if 
+ *     this constant changes.
+ *
+ *                                                   JRM -- 6/17/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_hash_fcn_test(void)
+{
+    int i;
+    int num_tests = 17;
+#if ( LFHT__NUM_HASH_BITS == 48 )
+    unsigned long long int ids[] = { 
+        0x0000000000000ULL, 0x0000000000001ULL, 0x0000000000002ULL, 0x0000000000003ULL,
+        0x0000000000004ULL, 0x0000000000005ULL, 0x0000000000006ULL, 0x0000000000007ULL,
+        0x0000000000008ULL, 0x0000000000009ULL, 0x000000000000AULL, 0x000000000000BULL,
+        0x000000000000CULL, 0x000000000000DULL, 0x000000000000EULL, 0x000000000000FULL,
+        0x0FFFFFFFFFFFFULL };
+    unsigned long long int regular_hashes[] = { 
+        0x0000000000001ULL, 0x1000000000001ULL, 0x0800000000001ULL, 0x1800000000001ULL,
+        0x0400000000001ULL, 0x1400000000001ULL, 0x0C00000000001ULL, 0x1C00000000001ULL,
+        0x0200000000001ULL, 0x1200000000001ULL, 0x0A00000000001ULL, 0x1A00000000001ULL,
+        0x0600000000001ULL, 0x1600000000001ULL, 0x0E00000000001ULL, 0x1E00000000001ULL,
+        0x1FFFFFFFFFFFFULL };
+    unsigned long long int sentinel_hashes[] = { 
+        0x0000000000000ULL, 0x1000000000000ULL, 0x0800000000000ULL, 0x1800000000000ULL,
+        0x0400000000000ULL, 0x1400000000000ULL, 0x0C00000000000ULL, 0x1C00000000000ULL,
+        0x0200000000000ULL, 0x1200000000000ULL, 0x0A00000000000ULL, 0x1A00000000000ULL,
+        0x0600000000000ULL, 0x1600000000000ULL, 0x0E00000000000ULL, 0x1E00000000000ULL,
+        0x1FFFFFFFFFFFEULL };
+#else /* LFHT__NUM_HASH_BITS == 57 */
+    unsigned long long int ids[] = { 
+        0x0000000000000000ULL, 0x0000000000000001ULL, 0x0000000000000002ULL, 0x0000000000000003ULL,
+        0x0000000000000004ULL, 0x0000000000000005ULL, 0x0000000000000006ULL, 0x0000000000000007ULL,
+        0x0000000000000008ULL, 0x0000000000000009ULL, 0x000000000000000AULL, 0x000000000000000BULL,
+        0x000000000000000CULL, 0x000000000000000DULL, 0x000000000000000EULL, 0x000000000000000FULL,
+        0x01FFFFFFFFFFFFFFULL };
+    unsigned long long int regular_hashes[] = { 
+        0x0000000000000001ULL, 0x0200000000000001ULL, 0x0100000000000001ULL, 0x0300000000000001ULL,
+        0x0080000000000001ULL, 0x0280000000000001ULL, 0x0180000000000001ULL, 0x0380000000000001ULL,
+        0x0040000000000001ULL, 0x0240000000000001ULL, 0x0140000000000001ULL, 0x0340000000000001ULL,
+        0x00c0000000000001ULL, 0x02C0000000000001ULL, 0x01C0000000000001ULL, 0x03C0000000000001ULL,
+        0x03FFFFFFFFFFFFFFULL };
+    unsigned long long int sentinel_hashes[] = { 
+        0x0000000000000000ULL, 0x0200000000000000ULL, 0x0100000000000000ULL, 0x0300000000000000ULL,
+        0x0080000000000000ULL, 0x0280000000000000ULL, 0x0180000000000000ULL, 0x0380000000000000ULL,
+        0x0040000000000000ULL, 0x0240000000000000ULL, 0x0140000000000000ULL, 0x0340000000000000ULL,
+        0x00c0000000000000ULL, 0x02C0000000000000ULL, 0x01C0000000000000ULL, 0x03C0000000000000ULL,
+        0x03FFFFFFFFFFFFFEULL };
+
+    assert(LFHT__NUM_HASH_BITS == 57);
+#endif /* LFHT__NUM_HASH_BITS == 57 */
+
+    fprintf(stdout, "LFHT hash function test ...");
+
+    for (i = 0; i < num_tests; i++ ) {
+
+        if ( regular_hashes[i] != lfht_id_to_hash(ids[i], false) ) {
+
+            fprintf(stdout, "\nhash test %d: regular hassh of 0x%llx = 0x%llx (0x%llx expected)\n",
+                    i, ids[i], lfht_id_to_hash(ids[i], false), regular_hashes[i]);
+        }
+
+        if ( sentinel_hashes[i] != lfht_id_to_hash(ids[i], true) ) {
+
+            fprintf(stdout, "\nhash test %d: sentinel hassh of 0x%llx = 0x%llx (0x%llx expected)\n",
+                    i, ids[i], lfht_id_to_hash(ids[i], true), sentinel_hashes[i]);
+        }
+    }
+
+    assert(LFHT__MAX_HASH == lfht_id_to_hash(LFHT__MAX_ID, false));
+
+    fprintf(stdout, " Done.\n");
+
+    return;
+
+} /* lfht_hash_fcn_test() */
+
+
+/***********************************************************************************
+ *
+ * lfht_hash_to_index_test()
+ *
+ *     Test functioning of the hash to index function
+ *     
+ *     Compute the hash values for ids 0 to 1023 and store in an array.
+ *
+ *     For each hash value, and for index_bits 0 to 3, compute the index of 
+ *     the hash bucket each hash value maps to.
+ *
+ *     Verify that the computed index values are expected.
+ *
+ *     Take down the lfsll and return.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *                                                   JRM -- 7/3/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_hash_to_index_test(void)
+{
+    void * value = NULL;
+    unsigned long long int i;
+    int index_bits; 
+    unsigned long long int hash[16];
+    unsigned long long int index[4][16];
+    unsigned long long int expected_index[4][16] = 
+    {
+       /* 0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15 */
+        { 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 },
+        { 0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1 },
+        { 0,  1,  2,  3,  0,  1,  2,  3,  0,  1,  2,  3,  0,  1,  2,  3 },
+        { 0,  1,  2,  3,  4,  5,  6,  7,  0,  1,  2,  3,  4,  5,  6,  7 }
+    };
+
+    fprintf(stdout, "LFHT hash to index test ...");
+
+    fflush(stdout);
+
+    for ( i = 0; i < 16; i++ ) {
+
+        hash[i] = lfht_id_to_hash(i, false);
+    }
+
+    for ( index_bits = 0; index_bits < 4; index_bits++ ) {
+
+        for ( i = 0; i < 16; i++ ) {
+
+            index[index_bits][i] = lfht_hash_to_idx(hash[i], index_bits);
+        }
+    }
+
+#if 0
+    /* print tables */
+
+    fprintf(stdout, "\n\nHASH to index by index_bits\n");
+    for ( i = 0; i < 16; i++ ) {
+
+        fprintf(stdout, "0x%013llx: ", hash[i]);
+
+        for ( index_bits = 0; index_bits < 4; index_bits++ ) {
+
+            fprintf(stdout, "%lld ", index[index_bits][i]);
+        }
+
+        fprintf(stdout, "\n");
+    }
+#endif
+ 
+    for ( i = 0; i < 16; i++ ) {
+        for ( index_bits = 0; index_bits < 4; index_bits++ ) {
+            assert(index[index_bits][i] == expected_index[index_bits][i]);
+        }
+    }
+
+    fprintf(stdout, " Done.\n");
+
+    return;
+
+} /* lfht_hash_to_index_test() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_serial_test_1()
+ *
+ *     Initial smoke check.  
+ *
+ *     Setup the hash table, but set max_index_bits to zero, which has the effect
+ *     of converting the lock free hash table into a lock free singly linked list.
+ *
+ *     Insert a node and verify that the inserion succeeds.  Do it again and
+ *     verify that it fails.
+ *
+ *     Search for the node just inserted, and verify that it succeeds.  Search 
+ *     for a non-existant node and verify that the search fails.
+ *
+ *     Search for the node just inserted by value and verify that it succeeds.
+ *     Search again for the value of a non-existant node and verify that it fails.
+ *
+ *     Do a value swap on the node just inserted -- verify that it succeeds.
+ *
+ *     Start an itteration on the hash table -- verify that the id and value 
+ *     (after the swap) are returned.
+ *
+ *     Attempt to get the next node in the itteration -- verity that it fails.
+ *
+ *     Delete a non-existant node and verify that it fails.
+ *
+ *     Delete a real node and verify that it succeeds.  Do it again and verify 
+ *     that it fails.
+ *
+ *     Check statistics, and verify that they are as expected.
+ *
+ *     Take down the lfsll and return.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *                                                   JRM -- 7/3/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_serial_test_1(void)
+{
+    unsigned long long int id;
+    void * value = NULL;
+    struct lfht_t lfht;
+
+    fprintf(stdout, "LFHT LFSLL serial test 1 ...");
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table 
+     * to funtion as a lock free singly linked list, as it forces all entries 
+     * into a single hash bucket.
+     */
+    lfht.max_index_bits = 0;
+
+
+    /* insert 1 -- should succeed */
+    assert(lfht_add(&lfht, 0x01ULL, (void *)(0x01ULL)));
+
+    /* insert 1 again -- should fail */
+    assert(!lfht_add(&lfht, 0x01ULL, (void *)(0x01ULL)));
+
+    /* attempt to find 1 -- should succeed */
+    assert(lfht_find(&lfht, 0x01ULL, &value));
+    assert((void *)(0x01ULL) == value);
+
+    /* attempt to find 2 -- should fail */
+    assert(!lfht_find(&lfht, 0x02ULL, &value));
+
+    /* Search for 1 by value -- should succeed. */
+    assert(lfht_find_id_by_value(&lfht, &id, (void *)(0x01ULL)));
+    assert(0x01ULL == id);
+
+    /* Search for 2 by value -- should fail */
+    assert(!lfht_find_id_by_value(&lfht, &id, (void *)(0x02ULL)));
+
+    /* Do a value swap on 1 -- should succeed */
+    assert(lfht_swap_value(&lfht, 0x01ULL, (void *)(0x011ULL), &value));
+    assert((void *)(0x01ULL) == value);
+
+    /* get first -- should succeed and return 1 with its new value */
+    assert(lfht_get_first(&lfht, &id, &value));
+    assert(0x01ULL == id);
+    assert((void *)(0x011ULL) == value);
+
+    /* get next -- should fail */
+    assert(!lfht_get_next(&lfht, 0x01ULL, &id, &value));
+ 
+    /* attempt to delete 2 -- should fail */
+    assert(!lfht_delete(&lfht, 0x02ULL));
+
+    /* attempt to delete 1 -- should succeed */
+    assert(lfht_delete(&lfht, 0x01ULL));
+
+    /* attempt to delete 1 -- should fail */
+    assert(!lfht_delete(&lfht, 0x01ULL));
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(2 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(1 == atomic_load(&(lfht.insertions)));
+    assert(1 == atomic_load(&(lfht.insertion_failures)));
+    assert(0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+    assert(0 == atomic_load(&(lfht.ins_deletion_completions)));
+    assert(1 == atomic_load(&(lfht.nodes_visited_during_ins)));
+
+    assert(3 == atomic_load(&(lfht.deletion_attempts)));
+    assert(2 == atomic_load(&(lfht.deletion_failures)));
+    assert(1 == atomic_load(&(lfht.deletion_starts)));
+    assert(0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(1 == atomic_load(&(lfht.del_deletion_completions)));
+    assert(0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+    assert(2 == atomic_load(&(lfht.nodes_visited_during_dels)));
+
+    assert(2 == atomic_load(&(lfht.searches)));
+    assert(1 == atomic_load(&(lfht.successful_searches)));
+    assert(1 == atomic_load(&(lfht.failed_searches)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_searches)));
+    assert(1 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_searches)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_failed_searches)));
+    assert(1 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_searches)));
+
+    assert(1 == atomic_load(&(lfht.value_swaps)));
+    assert(1 == atomic_load(&(lfht.successful_val_swaps)));
+    assert(0 == atomic_load(&(lfht.failed_val_swaps)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_val_swaps)));
+    assert(1 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_val_swaps)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_failed_val_swaps)));
+    assert(0 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_val_swaps)));
+
+    assert(2 == atomic_load(&(lfht.value_searches)));
+    assert(1 == atomic_load(&(lfht.successful_val_searches)));
+    assert(1 == atomic_load(&(lfht.failed_val_searches)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_val_searches)));
+    assert(2 == atomic_load(&(lfht.unmarked_nodes_visited_in_val_searches)));
+    assert(3 == atomic_load(&(lfht.sentinels_traversed_in_val_searches)));
+
+    assert(1 == atomic_load(&(lfht.itter_inits)));
+    assert(0 == atomic_load(&(lfht.itter_nexts)));
+    assert(1 == atomic_load(&(lfht.itter_ends)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_itters)));
+    assert(2 == atomic_load(&(lfht.unmarked_nodes_visited_in_itters)));
+    assert(3 == atomic_load(&(lfht.sentinels_traversed_in_itters)));
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done.\n");
+
+    return;
+
+} /* lfht_lfsll_serial_test_1() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_serial_test_2()
+ *
+ *     A more extensive smoke check.  
+ *
+ *     Setup the hash table, but set max_index_bits to zero, which has the effect
+ *     of converting the lock free hash table into a lock free singly linked list.
+ *
+ *     Insert values [0,99] into the lfht's lfsll in increasing order, and verify 
+ *     that the insertions succeed.
+ *
+ *     Delete value [0,99] from the lfht's lfsll in decreasing order, and verify 
+ *     that the deletions succeed.
+ *
+ *     Insert values [100,199 in decreasing order, and verify that the 
+ *     insertions succeed.
+ *
+ *     Search for values [0,199] in the lfht's lfsll in increasing order.  Verify 
+ *     that the searches of [0,99] fail, and that the searches for [100,199]
+ *     succeed.
+ *
+ *     Insert value [0,199] into the lfht's lfsll in increasing order.  Verify 
+ *     that the insertions of [0,99] succeed and that the insertions of 
+ *     [100,199] fail.  
+ *
+ *     Itterate through the hash table.  For each id found, set its value to
+ *     its current value + 1000.
+ *
+ *     Search for the the odd values in the interval [1000,1199] in decreasing 
+ *     order, and verify that the search return the odd ids in the range [0,199].
+ *     Then delete the odd numbered values in the interval [0,199] in decreasing
+ *     order, and verify that the deletions succeed.
+ *
+ *     Search for the values [0,199] in increasing order and verify that 
+ *     searches for odd numbers fail and that searches for even numbers 
+ *     succeed.
+ *
+ *     Insert the odd numbered values in the interval [0,199] in decreasing
+ *     order, and verify that the insertions succeed.
+ *
+ *     Delete the odd numbered values in the interval [0,199] in decreasing
+ *     order (a second time), and verify that the deletions succeed.
+ *
+ *     Delete the even numbered values in the interval [0,199] in increasing
+ *     order, and verify that the deletions succeed.
+ *
+ *     Check statistics, and verify that they are as expected.
+ *
+ *     Take down the lfht and return.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *                                                   JRM -- 7/2/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_serial_test_2(void)
+{
+    long long int i;
+    unsigned long long int id;
+    void * value;
+    struct lfht_t lfht;
+
+    fprintf(stdout, "LFHT LFSLL serial test 2 ...");
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table 
+     * to funtion as a lock free singly linked list, as it forces all entries 
+     * into a single hash bucket.
+     */
+    lfht.max_index_bits = 0;
+
+
+    for ( i = 0; i < 100; i++ ) {
+
+        assert(lfht_add(&lfht, i, (void *)i));
+    }
+
+    for ( i = 99; i >= 0 ; i-- ) {
+
+        assert(lfht_delete(&lfht, i));
+    }
+
+    for ( i = 199; i > 99; i-- ) {
+
+        assert(lfht_add(&lfht, i, (void *)i));
+    }
+
+    for ( i = 0; i < 200; i++ ) {
+
+        if ( i < 100 ) {
+
+            assert(!lfht_find(&lfht, i, &value));
+
+        } else {
+
+            assert(lfht_find(&lfht, i, &value));
+            assert((void *)i == value);
+        }
+    }
+
+    for ( i = 0; i < 200; i++ ) {
+
+        if ( i < 100 ) {
+
+            assert(lfht_add(&lfht, i, (void *)i));
+
+        } else {
+
+            assert(!lfht_add(&lfht, i, (void *)i));
+        }
+    }
+
+    assert(lfht_get_first(&lfht, &id, &value));
+    do {
+
+        assert(lfht_swap_value(&lfht, id, (void *)(((unsigned long long int)value) + 1000ULL), &value));
+        assert((void *)id == value);
+    }
+    while (lfht_get_next(&lfht, id, &id, &value));
+
+    for ( i = 199; i >= 0 ; i -= 2 ) {
+
+        assert(!lfht_find_id_by_value(&lfht, &id, (void *)(i)));
+        assert(lfht_find_id_by_value(&lfht, &id, (void *)(i + 1000ULL)));
+        assert(id == i);
+        assert(lfht_delete(&lfht, i));
+    }
+
+    for ( i = 0; i < 200; i++ ) {
+
+        if ( i % 2 == 1 ) {
+
+            assert(!lfht_find(&lfht, i, &value));
+
+        } else {
+
+            assert(lfht_find(&lfht, i, &value));
+            assert((void *)(i + 1000ULL) == value);
+        }
+    }
+
+    for ( i = 199; i >= 0 ; i -= 2 ) {
+
+        assert(lfht_add(&lfht, i, (void *)i));
+    }
+
+    for ( i = 199; i >= 0 ; i -= 2 ) {
+
+        assert(lfht_delete(&lfht, i));
+    }
+
+    for ( i = 0; i < 200  ; i += 2 ) {
+
+        assert(lfht_delete(&lfht, i));
+    }
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(3 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(  400 == atomic_load(&(lfht.insertions)));
+    assert(  100 == atomic_load(&(lfht.insertion_failures)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+    assert(    2 == atomic_load(&(lfht.ins_deletion_completions)));
+    assert(35024 == atomic_load(&(lfht.nodes_visited_during_ins)));
+
+    assert(  400 == atomic_load(&(lfht.deletion_attempts)));
+    assert(    0 == atomic_load(&(lfht.deletion_failures)));
+    assert(  400 == atomic_load(&(lfht.deletion_starts)));
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(  397 == atomic_load(&(lfht.del_deletion_completions)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+    assert(30901 == atomic_load(&(lfht.nodes_visited_during_dels)));
+
+    assert(  400 == atomic_load(&(lfht.searches)));
+    assert(  200 == atomic_load(&(lfht.successful_searches)));
+    assert(  200 == atomic_load(&(lfht.failed_searches)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_searches)));
+    assert(10100 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_searches)));
+    assert(   99 == atomic_load(&(lfht.marked_nodes_visited_in_failed_searches)));
+    assert(15078 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_searches)));
+
+    assert(  200 == atomic_load(&(lfht.value_swaps)));
+    assert(  200 == atomic_load(&(lfht.successful_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.failed_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_val_swaps)));
+    assert(20100 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_failed_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_val_swaps)));
+
+    assert(  200 == atomic_load(&(lfht.value_searches)));
+    assert(  100 == atomic_load(&(lfht.successful_val_searches)));
+    assert(  100 == atomic_load(&(lfht.failed_val_searches)));
+    assert(  405 == atomic_load(&(lfht.marked_nodes_visited_in_val_searches)));
+    assert(27727 == atomic_load(&(lfht.unmarked_nodes_visited_in_val_searches)));
+    assert(  300 == atomic_load(&(lfht.sentinels_traversed_in_val_searches)));
+
+    assert(    1 == atomic_load(&(lfht.itter_inits)));
+    assert(  199 == atomic_load(&(lfht.itter_nexts)));
+    assert(    1 == atomic_load(&(lfht.itter_ends)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_itters)));
+    assert(20300 == atomic_load(&(lfht.unmarked_nodes_visited_in_itters)));
+    assert(  202 == atomic_load(&(lfht.sentinels_traversed_in_itters)));
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done.\n");
+
+    return;
+
+} /* lfht_lfsll_serial_test_2() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_serial_test_3()
+ *
+ *     A yet more extensive smoke check.
+ *
+ *     Setup the hash table, but set max_index_bits to zero, which has the effect
+ *     of converting the lock free hash table into a lock free singly linked list.
+ *
+ *     For each id in [0,9999]:
+ *
+ *        0) Attempt to insert the id into the LFHT's LFSLL -- should succeed
+ *        1) Attempt to find the id in the LFHT's LFSLL -- should succeed
+ *        2) Attempt to find the id by value in the LFHT's LFSLL -- should succeed
+ *        3) Attempt to delete the id from the LFHT's LFSLL -- should succeed
+ *        4) Attempt to find the id in the LFHT's LFSLL -- should fail
+ *        5) Attempt to delete the id from the LFHT's LFSLL -- should fail
+ *        6) Attempt to insert the id into the LFHT's LFSLL -- should succeed
+ *        7) Attempt to find the id in the LFHT's LFSLL -- should succeed
+ *        8) Attempt to insert the id into the LFHT's LFSLL -- should fail
+ *        9) Attempt to delete the id from the LFHT's LFSLL -- should succeed
+ *
+ *     in the order given.  However, randomly intersperse the list of 
+ *     operations on any given id with the same lists of operations on 
+ *     other id.
+ *
+ *     Half way through the above, scan through the id's and swap the values.
+ *     Then iterate through the entries in the entries in the hash table 
+ *     and swap the values back.
+ *
+ *     Check statistics, and verify that they are as expected.
+ *
+ *     Take down the lfht and return.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *                                                   JRM -- 7/3/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_serial_test_3(void)
+{
+    bool first_pass = true;
+    long long int i;
+    unsigned long long int id;
+    unsigned int seed;
+    int count = 0;
+    int log[10000];
+    void * value;
+    struct timeval t;
+    struct lfht_t lfht;
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT LFSLL serial test 3 (seed = 0x%x) ...", seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table 
+     * to funtion as a lock free singly linked list, as it forces all entries 
+     * into a single hash bucket.
+     */
+    lfht.max_index_bits = 0;
+
+
+    for (i = 0; i < 10000; i++)
+        log[i] = 0;
+
+    while ( count < 100000 ) {
+
+        i = rand() % 10000;
+
+        switch ( log[i] ) {
+
+            case 0:
+                assert(lfht_add(&lfht, i, (void *)i));
+                log[i]++;
+                count++;
+                break;
+
+            case 1:
+                assert(lfht_find(&lfht, i, &value));
+                assert((void *)i == value);
+                log[i]++;
+                count++;
+                break;
+
+            case 2:
+                assert(lfht_find_id_by_value(&lfht, &id, (void *)i));
+                assert(i == id);
+                log[i]++;
+                count++;
+                break;
+
+            case 3: 
+                assert(lfht_delete(&lfht, i));
+                log[i]++;
+                count++;
+                break;
+
+            case 4:
+                assert(!lfht_find(&lfht, i, &value));
+                log[i]++;
+                count++;
+                break;
+
+            case 5: 
+                assert(!lfht_delete(&lfht, i));
+                log[i]++;
+                count++;
+                break;
+
+            case 6:
+                assert(lfht_add(&lfht, i, (void *)i));
+                log[i]++;
+                count++;
+                break;
+
+            case 7:
+                assert(lfht_find(&lfht, i, &value));
+                assert((void *)i == value);
+                log[i]++;
+                count++;
+                break;
+
+            case 8:
+                assert(!lfht_add(&lfht, i, (void *)i));
+                log[i]++;
+                count++;
+                break;
+
+            case 9: 
+                assert(lfht_delete(&lfht, i));
+                log[i]++;
+                count++;
+                break;
+
+            default:
+                /* do nothing */
+                break;
+        }
+
+
+        /* count can be 50000 for several itterations through the while
+         * loop.  Use the first_pass variable to ensure that the enclosed
+         * block of code is only executed onec.
+         */
+        if ( ( count == 50000 ) && ( first_pass ) ) {
+
+            int counter_1 = 0;
+            int counter_2 = 0;
+            int counter_3 = 0;
+
+            first_pass = false;
+
+            for (i = 0; i < 10000; i++) {
+
+                if ( lfht_swap_value(&lfht, (unsigned long long int)i, (void *)(i + 10000LL), &value) ) {
+
+                    counter_1++;
+                    assert((long long int)value == i);
+                } else {
+
+                    counter_3++;
+                }
+            }
+            assert(counter_1 + counter_3 == 10000);
+
+            assert(lfht_get_first(&lfht, &id, &value));
+            do {
+
+                assert(lfht_swap_value(&lfht, id, (void *)(id), &value));
+                assert((void *)(id + 10000ULL) == value);
+                counter_2++;
+            }
+            while (lfht_get_next(&lfht, id, &id, &value));
+
+            assert(counter_1 == counter_2);
+            assert(counter_1 == atomic_load(&(lfht.lfsll_log_len)));
+            assert(counter_3 == atomic_load(&(lfht.failed_val_swaps)));
+            assert(counter_1 + counter_2 == atomic_load(&(lfht.successful_val_swaps)));
+            assert(counter_1 + counter_2 + counter_3 == atomic_load(&(lfht.value_swaps)));
+        }
+    }
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(3 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(20000 == atomic_load(&(lfht.insertions)));
+    assert(10000 == atomic_load(&(lfht.insertion_failures)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(30000 == atomic_load(&(lfht.deletion_attempts)));
+    assert(10000 == atomic_load(&(lfht.deletion_failures)));
+    assert(20000 == atomic_load(&(lfht.deletion_starts)));
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert(atomic_load(&(lfht.ins_deletion_completions)) + 
+           atomic_load(&(lfht.del_deletion_completions)) +
+           atomic_load(&(lfht.lfsll_phys_len)) - 2 == 20000);
+
+    assert(30000 == atomic_load(&(lfht.searches)));
+    assert(20000 == atomic_load(&(lfht.successful_searches)));
+    assert(10000 == atomic_load(&(lfht.failed_searches)));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_lfsll_serial_test_3() */
+
+
+/***********************************************************************************
+ *
+ * lfht_serial_test_1()
+ *
+ *     Initial smoke check.  
+ *
+ *     Setup the hash table.
+ *
+ *     Insert a node and verify that the inserion succeeds.  Do it again and
+ *     verify that it fails.
+ *
+ *     Search for the node just inserted, and verify that it succeeds.  Search 
+ *     for a non-existant node and verify that the search fails.
+ *
+ *     Search for the node just inserted by value and verify that it succeeds.
+ *     Search again for the value of a non-existant node and verify that it fails.
+ *
+ *     Do a value swap on the node just inserted -- verify that it succeeds.
+ *
+ *     Start an itteration on the hash table -- verify that the id and value 
+ *     (after the swap) are returned.
+ *
+ *     Attempt to get the next node in the itteration -- verity that it fails.
+ *
+ *     Delete a non-existant node and verify that it fails.
+ *
+ *     Delete a real node and verify that it succeeds.  Do it again and verify 
+ *     that it fails.
+ *
+ *     Check statistics, and verify that they are as expected.
+ *
+ *     Take down the lfht and return.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *                                                   JRM -- 7/3/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_serial_test_1(void)
+{
+    unsigned long long int id;
+    void * value = NULL;
+    struct lfht_t lfht;
+
+    fprintf(stdout, "LFHT serial test 1 ...");
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+
+    /* insert 1 -- should succeed */
+    assert(lfht_add(&lfht, 0x01ULL, (void *)(0x01ULL)));
+
+    /* insert 1 again -- should fail */
+    assert(!lfht_add(&lfht, 0x01ULL, (void *)(0x01ULL)));
+
+    /* attempt to find 1 -- should succeed */
+    assert(lfht_find(&lfht, 0x01ULL, &value));
+    assert((void *)(0x01ULL) == value);
+
+    /* attempt to find 2 -- should fail */
+    assert(!lfht_find(&lfht, 0x02ULL, &value));
+
+    /* Search for 1 by value -- should succeed. */
+    assert(lfht_find_id_by_value(&lfht, &id, (void *)(0x01ULL)));
+    assert(0x01ULL == id);
+
+    /* Search for 2 by value -- should fail */
+    assert(!lfht_find_id_by_value(&lfht, &id, (void *)(0x02ULL)));
+
+    /* Do a value swap on 1 -- should succeed */
+    assert(lfht_swap_value(&lfht, 0x01ULL, (void *)(0x011ULL), &value));
+    assert((void *)(0x01ULL) == value);
+
+    /* get first -- should succeed and return 1 with its new value */
+    assert(lfht_get_first(&lfht, &id, &value));
+    assert(0x01ULL == id);
+    assert((void *)(0x011ULL) == value);
+
+    /* get next -- should fail */
+    assert(!lfht_get_next(&lfht, 0x01ULL, &id, &value));
+
+    /* attempt to delete 2 -- should fail */
+    assert(!lfht_delete(&lfht, 0x02ULL));
+
+    /* attempt to delete 1 -- should succeed */
+    assert(lfht_delete(&lfht, 0x01ULL));
+
+    /* attempt to delete 1 -- should fail */
+    assert(!lfht_delete(&lfht, 0x01ULL));
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(2 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(1 == atomic_load(&(lfht.insertions)));
+    assert(1 == atomic_load(&(lfht.insertion_failures)));
+    assert(0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+    assert(0 == atomic_load(&(lfht.ins_deletion_completions)));
+    assert(1 == atomic_load(&(lfht.nodes_visited_during_ins)));
+
+    assert(3 == atomic_load(&(lfht.deletion_attempts)));
+    assert(2 == atomic_load(&(lfht.deletion_failures)));
+    assert(1 == atomic_load(&(lfht.deletion_starts)));
+    assert(0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(1 == atomic_load(&(lfht.del_deletion_completions)));
+    assert(0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+    assert(2 == atomic_load(&(lfht.nodes_visited_during_dels)));
+
+    assert(2 == atomic_load(&(lfht.searches)));
+    assert(1 == atomic_load(&(lfht.successful_searches)));
+    assert(1 == atomic_load(&(lfht.failed_searches)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_searches)));
+    assert(1 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_searches)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_failed_searches)));
+    assert(1 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_searches)));
+
+    assert(1 == atomic_load(&(lfht.value_swaps)));
+    assert(1 == atomic_load(&(lfht.successful_val_swaps)));
+    assert(0 == atomic_load(&(lfht.failed_val_swaps)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_val_swaps)));
+    assert(1 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_val_swaps)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_failed_val_swaps)));
+    assert(0 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_val_swaps)));
+
+    assert(2 == atomic_load(&(lfht.value_searches)));
+    assert(1 == atomic_load(&(lfht.successful_val_searches)));
+    assert(1 == atomic_load(&(lfht.failed_val_searches)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_val_searches)));
+    assert(2 == atomic_load(&(lfht.unmarked_nodes_visited_in_val_searches)));
+    assert(3 == atomic_load(&(lfht.sentinels_traversed_in_val_searches)));
+
+    assert(1 == atomic_load(&(lfht.itter_inits)));
+    assert(0 == atomic_load(&(lfht.itter_nexts)));
+    assert(1 == atomic_load(&(lfht.itter_ends)));
+    assert(0 == atomic_load(&(lfht.marked_nodes_visited_in_itters)));
+    assert(2 == atomic_load(&(lfht.unmarked_nodes_visited_in_itters)));
+    assert(3 == atomic_load(&(lfht.sentinels_traversed_in_itters)));
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done.\n");
+
+    return;
+
+} /* lfht_serial_test_1() */
+
+
+/***********************************************************************************
+ *
+ * lfht_serial_test_2()
+ *
+ *     A more extensive smoke check.  
+ *
+ *     Setup the hash table.
+ *
+ *     Insert values [0,99] into the lfht in increasing order, and verify 
+ *     that the insertions succeed.
+ *
+ *     Delete value [0,99] from the lfht in decreasing order, and verify 
+ *     that the deletions succeed.
+ *
+ *     Insert values [100,199 in decreasing order, and verify that the 
+ *     insertions succeed.
+ *
+ *     Search for values [0,199] in the lfht in increasing order.  Verify 
+ *     that the searches of [0,99] fail, and that the searches for [100,199]
+ *     succeed.
+ *
+ *     Insert value [0,199] into the lfht in increasing order.  Verify 
+ *     that the insertions of [0,99] succeed and that the insertions of 
+ *     [100,199] fail.  
+ *
+ *     Itterate through the hash table.  For each id found, set its value to
+ *     its current value + 1000.
+ *
+ *     Search for the the odd values in the interval [1000,1199] in decreasing 
+ *     order, and verify that the search return the odd ids in the range [0,199].
+ *     Then delete the odd numbered values in the interval [0,199] in decreasing
+ *     order, and verify that the deletions succeed.
+ *
+ *     Search for the values [0,199] in increasing order and verify that 
+ *     searches for odd numbers fail and that searches for even numbers 
+ *     succeed.
+ *
+ *     Insert the odd numbered values in the interval [0,199] in decreasing
+ *     order, and verify that the insertions succeed.
+ *
+ *     Delete the odd numbered values in the interval [0,199] in decreasing
+ *     order (a second time), and verify that the deletions succeed.
+ *
+ *     Delete the even numbered values in the interval [0,199] in increasing
+ *     order, and verify that the deletions succeed.
+ *
+ *     Check statistics, and verify that they are as expected.
+ *
+ *     Take down the lfht and return.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *                                                   JRM -- 7/2/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_serial_test_2(void)
+{
+    long long int i;
+    unsigned long long int id;
+    void * value;
+    struct lfht_t lfht;
+
+    fprintf(stdout, "LFHT serial test 2 ...");
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+
+    for ( i = 0; i < 100; i++ ) {
+
+        assert(lfht_add(&lfht, i, (void *)i));
+    }
+
+    for ( i = 99; i >= 0 ; i-- ) {
+
+        assert(lfht_delete(&lfht, i));
+    }
+
+    for ( i = 199; i > 99; i-- ) {
+
+        assert(lfht_add(&lfht, i, (void *)i));
+    }
+
+    for ( i = 0; i < 200; i++ ) {
+
+        if ( i < 100 ) {
+
+            assert(!lfht_find(&lfht, i, &value));
+
+        } else {
+
+            assert(lfht_find(&lfht, i, &value));
+            assert((void *)i == value);
+        }
+    }
+
+    for ( i = 0; i < 200; i++ ) {
+
+        if ( i < 100 ) {
+
+            assert(lfht_add(&lfht, i, (void *)i));
+
+        } else {
+
+            assert(!lfht_add(&lfht, i, NULL));
+        }
+    }
+
+    assert(lfht_get_first(&lfht, &id, &value));
+    do {
+
+        assert(lfht_swap_value(&lfht, id, (void *)(((unsigned long long int)value) + 1000ULL), &value));
+        assert((void *)id == value);
+    }
+    while (lfht_get_next(&lfht, id, &id, &value));
+
+    for ( i = 199; i >= 0 ; i -= 2 ) {
+
+        assert(!lfht_find_id_by_value(&lfht, &id, (void *)(i)));
+        assert(lfht_find_id_by_value(&lfht, &id, (void *)(i + 1000ULL)));
+        assert(id == i);
+        assert(lfht_delete(&lfht, i));
+    }
+
+    for ( i = 0; i < 200; i++ ) {
+
+        if ( i % 2 == 1 ) {
+
+            assert(!lfht_find(&lfht, i, &value));
+
+        } else {
+
+            assert(lfht_find(&lfht, i, &value));
+            assert((void *)(i + 1000ULL) == value);
+        }
+    }
+
+    for ( i = 199; i >= 0 ; i -= 2 ) {
+
+        assert(lfht_add(&lfht, i, NULL));
+    }
+
+    for ( i = 199; i >= 0 ; i -= 2 ) {
+
+        assert(lfht_delete(&lfht, i));
+    }
+
+    for ( i = 0; i < 200  ; i += 2 ) {
+
+        assert(lfht_delete(&lfht, i));
+    }
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert( 0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(65 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(  400 == atomic_load(&(lfht.insertions)));
+    assert(  100 == atomic_load(&(lfht.insertion_failures)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+    assert(   32 == atomic_load(&(lfht.ins_deletion_completions)));
+    assert( 1389 == atomic_load(&(lfht.nodes_visited_during_ins)));
+
+    assert(  400 == atomic_load(&(lfht.deletion_attempts)));
+    assert(    0 == atomic_load(&(lfht.deletion_failures)));
+    assert(  400 == atomic_load(&(lfht.deletion_starts)));
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(  336 == atomic_load(&(lfht.del_deletion_completions)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+    assert( 1344 == atomic_load(&(lfht.nodes_visited_during_dels)));
+
+    assert(  400 == atomic_load(&(lfht.searches)));
+    assert(  200 == atomic_load(&(lfht.successful_searches)));
+    assert(  200 == atomic_load(&(lfht.failed_searches)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_searches)));
+    assert(  728 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_searches)));
+    assert(   84 == atomic_load(&(lfht.marked_nodes_visited_in_failed_searches)));
+    assert(  440 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_searches)));
+
+    assert(  200 == atomic_load(&(lfht.value_swaps)));
+    assert(  200 == atomic_load(&(lfht.successful_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.failed_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_succ_val_swaps)));
+    assert(  728 == atomic_load(&(lfht.unmarked_nodes_visited_in_succ_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_failed_val_swaps)));
+    assert(    0 == atomic_load(&(lfht.unmarked_nodes_visited_in_failed_val_swaps)));
+
+    assert(  200 == atomic_load(&(lfht.value_searches)));
+    assert(  100 == atomic_load(&(lfht.successful_val_searches)));
+    assert(  100 == atomic_load(&(lfht.failed_val_searches)));
+    assert( 2948 == atomic_load(&(lfht.marked_nodes_visited_in_val_searches)));
+    assert(27727 == atomic_load(&(lfht.unmarked_nodes_visited_in_val_searches)));
+    assert( 5744 == atomic_load(&(lfht.sentinels_traversed_in_val_searches)));
+
+    assert(    1 == atomic_load(&(lfht.itter_inits)));
+    assert(  199 == atomic_load(&(lfht.itter_nexts)));
+    assert(    1 == atomic_load(&(lfht.itter_ends)));
+    assert(    0 == atomic_load(&(lfht.marked_nodes_visited_in_itters)));
+    assert(  928 == atomic_load(&(lfht.unmarked_nodes_visited_in_itters)));
+    assert(  233 == atomic_load(&(lfht.sentinels_traversed_in_itters)));
+
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done.\n");
+
+    return;
+
+} /* lfht_serial_test_2() */
+
+
+/***********************************************************************************
+ *
+ * lfht_serial_test_3()
+ *
+ *     A yet more extensive smoke check.
+ *
+ *     Setup the hash table.
+ *
+ *     For each id in [0,9999]:
+ *
+ *        0) Attempt to insert the id into the LFHTL -- should succeed
+ *        1) Attempt to find the id in the LFHT -- should succeed
+ *        2) Attempt to find the id by value in the LFHT -- should succeed
+ *        3) Attempt to delete the id from the LFHT -- should succeed
+ *        4) Attempt to find the id in the LFHT -- should fail
+ *        5) Attempt to delete the id from the LFHT -- should fail
+ *        6) Attempt to insert the id into the LFHT -- should succeed
+ *        7) Attempt to find the id in the LFHT -- should succeed
+ *        8) Attempt to insert the id into the LFHT -- should fail
+ *        9) Attempt to delete the id from the LFHT -- should succeed
+ *
+ *     in the order given.  However, randomly intersperse the list of 
+ *     operations on any given id with the same lists of operations on 
+ *     other id.
+ *
+ *     Half way through the above, scan through the id's and swap the values.
+ *     Then iterate through the entries in the entries in the hash table 
+ *     and swap the values back.
+ *
+ *     Check statistics, and verify that they are as expected.
+ *
+ *     Take down the lfht and return.
+ *
+ *     Any failure should trigger an assertion.
+ *
+ *                                                   JRM -- 7/3/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_serial_test_3(void)
+{
+    bool first_pass = true;
+    long long int i;
+    unsigned long long int id;
+    unsigned int seed;
+    int count = 0;
+    int log[10000];
+    void * value;
+    struct timeval t;
+    struct lfht_t lfht;
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT serial test 3 (seed = 0x%x) ...", seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+
+    for (i = 0; i < 10000; i++)
+        log[i] = 0;
+
+    while ( count < 100000 ) {
+
+        i = rand() % 10000;
+
+        switch ( log[i] ) {
+
+            case 0:
+                assert(lfht_add(&lfht, i, (void *)i));
+                log[i]++;
+                count++;
+                break;
+
+            case 1:
+                assert(lfht_find(&lfht, i, &value));
+                assert((void *)i == value);
+                log[i]++;
+                count++;
+                break;
+
+            case 2:
+                assert(lfht_find_id_by_value(&lfht, &id, (void *)i));
+                assert(i == id);
+                log[i]++;
+                count++;
+                break;
+
+            case 3: 
+                assert(lfht_delete(&lfht, i));
+                log[i]++;
+                count++;
+                break;
+
+            case 4:
+                assert(!lfht_find(&lfht, i, &value));
+                log[i]++;
+                count++;
+                break;
+
+            case 5: 
+                assert(!lfht_delete(&lfht, i));
+                log[i]++;
+                count++;
+                break;
+
+            case 6:
+                assert(lfht_add(&lfht, i, (void *)i));
+                log[i]++;
+                count++;
+                break;
+
+            case 7:
+                assert(lfht_find(&lfht, i, &value));
+                assert((void *)i == value);
+                log[i]++;
+                count++;
+                break;
+
+            case 8:
+                assert(!lfht_add(&lfht, i, (void *)i));
+                log[i]++;
+                count++;
+                break;
+
+            case 9: 
+                assert(lfht_delete(&lfht, i));
+                log[i]++;
+                count++;
+                break;
+
+            default:
+                /* do nothing */
+                break;
+        }
+
+        /* count can be 50000 for several itterations through the while
+         * loop.  Use the first_pass variable to ensure that the enclosed
+         * block of code is only executed onec.
+         */
+        if ( ( count == 50000 ) && ( first_pass ) ) {
+
+            int counter_1 = 0;
+            int counter_2 = 0;
+            int counter_3 = 0;
+
+            first_pass = false;
+
+            for (i = 0; i < 10000; i++) {
+
+                if ( lfht_swap_value(&lfht, (unsigned long long int)i, (void *)(i + 10000LL), &value) ) {
+
+                    counter_1++;
+                    assert((long long int)value == i);
+                } else {
+
+                    counter_3++;
+                }
+            }
+            assert(counter_1 + counter_3 == 10000);
+
+            assert(lfht_get_first(&lfht, &id, &value));
+            do {
+
+                assert(lfht_swap_value(&lfht, id, (void *)(id), &value));
+                assert((void *)(id + 10000ULL) == value);
+                counter_2++;
+            }
+            while (lfht_get_next(&lfht, id, &id, &value));
+
+            assert(counter_1 == counter_2);
+            assert(counter_1 == atomic_load(&(lfht.lfsll_log_len)));
+            assert(counter_3 == atomic_load(&(lfht.failed_val_swaps)));
+            assert(counter_1 + counter_2 == atomic_load(&(lfht.successful_val_swaps)));
+            assert(counter_1 + counter_2 + counter_3 == atomic_load(&(lfht.value_swaps)));
+        }
+    }
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(   0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(2049 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(20000 == atomic_load(&(lfht.insertions)));
+    assert(10000 == atomic_load(&(lfht.insertion_failures)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(30000 == atomic_load(&(lfht.deletion_attempts)));
+    assert(10000 == atomic_load(&(lfht.deletion_failures)));
+    assert(20000 == atomic_load(&(lfht.deletion_starts)));
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert(atomic_load(&(lfht.ins_deletion_completions)) + 
+           atomic_load(&(lfht.del_deletion_completions)) +
+           atomic_load(&(lfht.lfsll_phys_len)) - 
+           atomic_load(&(lfht.buckets_initialized)) - 1 == 20000);
+
+    assert(30000 == atomic_load(&(lfht.searches)));
+    assert(20000 == atomic_load(&(lfht.successful_searches)));
+    assert(10000 == atomic_load(&(lfht.failed_searches)));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_serial_test_3() */
+
+
+/***********************************************************************************
+ *
+ * struct lfht_mt_test_params_t
+ *
+ * Structure used to pass control information into and results out of LFHT 
+ * multi-thread test functions.  The individual fields in this structure are 
+ * discussed below.
+ *
+ * lfht_ptr:    Pointer of the instance of lfht_t that forms the root of the 
+ *              target LFHT
+ *
+ * start_id:    When scanning through a list of ids and performing a set 
+ *              of operations on each element of this list, this is the 
+ *              first id, which must be non-negative.
+ *
+ * step:        When scanning through a list of ids and performing a set
+ *              of operations on each element of this list, this is the difference
+ *              between each id in the list.  While the absolute value of 
+ *              step must be greater than or equal to 1, step may be either 
+ *              positive or negative.  
+ *
+ *              Note, however, that the resulting ids must be non-negative.
+ *
+ *              Not always used.
+ *
+ * num_vals:    When scanning through a list of ids and performing a set
+ *              of operations on each element of this list, this is the number
+ *              of ids in the list.
+ *
+ * itterations: Number of times the test function is to repeat.  
+ *
+ *              Not always used.
+ *
+ * ins_fails:   Long long int used to report the number of failed insertions
+ *              reported by lfht_add().
+ *
+ * del_fails:   Long long int used to report the number of failed deletions 
+ *              reported by lfht_delete().
+ *
+ * search_fails: Long long int used to report the number of failed searches
+ *              reported by lfht_find().  
+ *
+ * search_by_val_fails: Long long int used to report the number of failed searches
+ *              by value reported by lfht_find_id_by_value().
+ *
+ * swap_val_fails: Long long int used to report the number of faild value swaps
+ *              reported by lfht_swap_value().
+ *
+ * ins_successes: Long long int used to report the number of successful insertions
+ *              reported by lfht_add().  
+ *
+ *              Not always used.
+ *
+ * del_successes: Long long int used to report the number of successful deletions 
+ *              reported by lfht_delete().  
+ *
+ *              Not always used.
+ *
+ * search_successes: Long long int used to report the number of successful searches
+ *              reported by lfht_find().  
+ *
+ *              Not always used.
+ *
+ * search_by_val_successes: Long long int used to report the number of successful 
+ *              searches by value reported by lfht_find_id_by_value().  
+ *
+ *              Not always used.
+ *
+ * swap_val_successes: Long long int used to report the number of successful 
+ *              value swaps reported by lfht_swap_value().
+ *
+ *              Not always used.
+ *
+ * itter_inits: Long long int used to report the number of calls to lfht_get_first().
+ *
+ * itter_nexts: Long long int used to report the number of calls to lfht_get_next()
+ *              that return true.
+ *
+ * itter_ends:  Long long int used to report the number of calls to lfht_get_next()
+ *              that return false.
+ *
+ ***********************************************************************************/
+
+struct lfht_mt_test_params_t {
+
+    struct lfht_t *lfht_ptr;
+
+    unsigned long long int start_id;
+    long long int step;
+    unsigned long long int num_ids;
+    unsigned long long int itterations;
+
+    long long int ins_fails;
+    long long int del_fails;
+    long long int search_fails;
+    long long int search_by_val_fails;
+    long long int swap_val_fails;
+
+    long long int ins_successes;
+    long long int del_successes;
+    long long int search_successes;
+    long long int search_by_val_successes;
+    long long int swap_val_successes;
+
+    long long int itter_inits;
+    long long int itter_nexts;
+    long long int itter_ends;
+
+} lfht_mt_test_params_t;
+
+
+/***********************************************************************************
+ *
+ * lfht_mt_test_fcn_1()
+ *
+ *     This function is intended to be executed by one or more threads 
+ *     in a LFHT multi-thread test.
+ *
+ *     For each id (params_ptr->start_id + n * params_ptr->step) whern 
+ *     0 <= n < params_ptr->num_ids,
+ *
+ *        0) Attempt to insert the id into the LFHT 
+ *        1) Attempt to find the id in the LFHT
+ *        2) Attempt to find the id by value in the LFHT
+ *           This is a very expensive operation, so only 
+ *           do it in one case in 32.
+ *        3) Attempt to delete the id from the LFHT
+ *        4) Attempt to find the id in the LFHT
+ *        5) Attempt to delete the id from the LFHT
+ *        6) Attempt to insert the id into the LFHT
+ *        7) Attempt to find the id in the LFHT
+ *        8) Attempt to insert the id into the LFHT
+ *        9) Attempt to delete the id from the LFHT
+ *
+ *     in the order given.  However, randomly intersperse the list of 
+ *     operations on any given id with the same lists of operations on 
+ *     other ids.
+ *
+ *     Note that at present, params_ptr->num_ids may not exceed 10,000.
+ *
+ *     Failed insertions, deletions, searches, and searches by value are counted, 
+ *     and the counts returned in params_ptr->ins_fails, params_ptr->del_fails, 
+ *     params_ptr->search_fails, and params_ptr->search_by_val_fails.
+ *
+ *
+ *                                                   JRM -- 6/18/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void * lfht_mt_test_fcn_1(void * args )
+{
+    struct lfht_mt_test_params_t * params_ptr;
+    bool first_pass = true;
+    long long int i;
+    long long int ins_fails = 0;
+    long long int del_fails = 0;
+    long long int search_fails = 0;
+    long long int search_by_val_fails = 0;
+    long long int swap_val_fails = 0;
+    long long int swap_val_successes = 0;
+    long long int itter_inits = 0;
+    long long int itter_nexts = 0;
+    long long int itter_ends = 0;
+    unsigned long long int val_swap_offset = 1000000;
+    unsigned long long int id;
+    unsigned long long int new_id;
+    int count = 0;
+    int log[10000];
+    void * value;
+
+    params_ptr = (struct lfht_mt_test_params_t *)args;
+
+    assert(params_ptr);
+    assert(params_ptr->lfht_ptr);
+    assert(LFHT_VALID == params_ptr->lfht_ptr->tag);
+    assert((params_ptr->step >= 1) || ( params_ptr->step <= -1));
+    assert((params_ptr->num_ids > 0) && (params_ptr->num_ids <= 10000));
+
+    for (i = 0; i < 10000; i++)
+        log[i] = 0;
+
+    while ( count < 10 * params_ptr->num_ids ) {
+
+        i = rand() % params_ptr->num_ids;
+
+        id = params_ptr->start_id + (i * params_ptr->step);
+
+        assert(0 <= id);
+
+        switch ( log[i] ) {
+
+            case 0:
+                if ( ! lfht_add(params_ptr->lfht_ptr, id, (void *)id) ) {
+
+                    ins_fails++;
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 1:
+                
+                if ( ! lfht_find(params_ptr->lfht_ptr, id, &value) ) {
+
+                    search_fails++;
+
+                } else {
+
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 2:
+                /* lfht_find_id_by_value() is very expensive, so only do it roughly 
+                 * one time in 32.
+                 */
+                if ( 0 == (rand() & 0x1F) ) {
+
+                    if ( ! lfht_find_id_by_value(params_ptr->lfht_ptr, &new_id, (void *)id) ) {
+
+                        search_by_val_fails++;
+
+                    } else {
+
+                        assert(new_id == id);
+                    }
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 3: 
+                if ( ! lfht_delete(params_ptr->lfht_ptr, id) ) {
+
+                    del_fails++;
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 4:
+                if ( ! lfht_find(params_ptr->lfht_ptr, id, &value) ) {
+
+                    search_fails++;
+
+                } else {
+ 
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 5: 
+                if ( ! lfht_delete(params_ptr->lfht_ptr, id) ) {
+
+                    del_fails++;
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 6:
+                if ( ! lfht_add(params_ptr->lfht_ptr, id, (void *)id) ) {
+
+                    ins_fails++;
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 7:
+                if ( ! lfht_find(params_ptr->lfht_ptr, id, &value) ) {
+
+                    search_fails++;
+
+                } else {
+
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 8:
+                if ( ! lfht_add(params_ptr->lfht_ptr, id, (void *)id) ) {
+
+                    ins_fails++;
+                }
+                log[i]++;
+                count++;
+                break;
+
+            case 9: 
+                if ( ! lfht_delete(params_ptr->lfht_ptr, id) ) {
+
+                   del_fails++;
+                }
+                log[i]++;
+                count++;
+                break;
+
+            default:
+                /* do nothing */
+                break;
+        }
+
+        /* count can be 50000 for several itterations through the while
+         * loop.  Use the first_pass variable to ensure that the enclosed
+         * block of code is only executed onec.
+         */
+        if ( ( count == 50000 ) && ( first_pass ) ) {
+
+            first_pass = false;
+            assert(0 == swap_val_successes);
+            assert(0 == swap_val_fails);
+            for (i = 0; i < 10000; i++) {
+
+                id = params_ptr->start_id + (i * params_ptr->step);
+
+                if ( lfht_swap_value(params_ptr->lfht_ptr, id, 
+                                     (void *)(id + val_swap_offset), &value) ) {
+
+                    swap_val_successes++;
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+
+                } else {
+
+                    swap_val_fails++;
+                }
+            }
+            assert(swap_val_successes + swap_val_fails == 10000LL);
+
+            itter_inits++;
+            if ( lfht_get_first(params_ptr->lfht_ptr, &id, &value) ) {
+
+                if ( lfht_swap_value(params_ptr->lfht_ptr, id, (void *)(id), &value) ) {
+
+                    swap_val_successes++;
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+
+                } else {
+
+                    swap_val_fails++;
+                }
+
+                while (lfht_get_next(params_ptr->lfht_ptr, id, &id, &value)) {
+
+                    if ( lfht_swap_value(params_ptr->lfht_ptr, id, (void *)(id), &value) ) {
+
+                        swap_val_successes++;
+                        assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+
+                    } else {
+
+                        swap_val_fails++;
+                    }
+                    itter_nexts++;
+                }
+            }
+            itter_ends++;
+        }
+    }
+
+    params_ptr->ins_fails           = ins_fails;
+    params_ptr->del_fails           = del_fails;
+    params_ptr->search_fails        = search_fails;
+    params_ptr->search_by_val_fails = search_by_val_fails;
+    params_ptr->swap_val_fails      = swap_val_fails;
+
+    params_ptr->itter_inits         = itter_inits;
+    params_ptr->itter_nexts         = itter_nexts;
+    params_ptr->itter_ends          = itter_ends;
+
+    return(NULL);
+
+} /* lfht_mt_test_fcn_1() */
+
+
+/***********************************************************************************
+ *
+ * lfht_mt_test_fcn_2()
+ *
+ *     This function is intended to be executed by one or more threads 
+ *     in a LFHT multi-thread test.
+ *
+ *     Proceed as follows:
+ *
+ *     1) pick a random id in the supplied range.
+ *
+ *     2) Pick a random number in the range [0.99].
+ *
+ *        If it is in [0,3], attempt to insert the random id in the LFHT
+ *
+ *        If it is in [4,7], attempt to delete the random id from the LFHT
+ *
+ *        If it is 8, search for a random value in the LFHT
+ *
+ *        If it is 9, attempt to modify the value of a random id in the LFHT
+ *
+ *        Otherwise, search for the random id in the LFHT.
+ *
+ *        Record the results in *params_ptr.
+ *
+ *     3) Pick a random number in the range [0, params_ptr->itterations - 1].  On 
+ *        this itteration, operate as above, but after that operation is complete,
+ *        itterate through all entries in the LFHT, and verify that their values 
+ *        are as expected.
+ *
+ *     Repeat until the specified number of operations have been attempted.
+ *
+ *                                                   JRM -- 6/27/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void * lfht_mt_test_fcn_2(void * args )
+{
+    struct lfht_mt_test_params_t * params_ptr;
+    int operation;
+    long long int i = 0;
+    long long int itterateration_pass;
+    long long int ins_fails = 0;
+    long long int del_fails = 0;
+    long long int search_fails = 0;
+    long long int search_by_val_fails = 0;
+    long long int swap_val_fails = 0;
+    long long int ins_successes = 0;
+    long long int del_successes = 0;
+    long long int search_successes = 0;
+    long long int search_by_val_successes = 0;
+    long long int swap_val_successes = 0;
+    long long int itter_inits = 0;
+    long long int itter_nexts = 0;
+    long long int itter_ends = 0;
+    long long int id;
+    long long int test_id;
+    unsigned long long int val_swap_offset = 1000000;
+    int count = 0;
+    int log[10000];
+    void * value = NULL;
+
+    params_ptr = (struct lfht_mt_test_params_t *)args;
+
+    assert(params_ptr);
+    assert(params_ptr->lfht_ptr);
+    assert(LFHT_VALID == params_ptr->lfht_ptr->tag);
+    assert(params_ptr->num_ids > 0);
+    assert(params_ptr->itterations > 0);
+
+    itterateration_pass = (long long int)(rand() % params_ptr->itterations);
+    assert(0 <= itterateration_pass);
+    assert(itterateration_pass < params_ptr->itterations);
+
+    while ( i < params_ptr->itterations ) {
+
+        id = (long long int)((rand() % params_ptr->num_ids) + params_ptr->start_id);
+
+        operation = rand() % 100;
+
+        switch ( operation ) {
+
+            case 0:
+            case 1:
+            case 2: 
+            case 3: /* insert value */
+                if ( lfht_add(params_ptr->lfht_ptr, id, (void *)id) ) {
+
+                    ins_successes++;
+
+                } else {
+
+                    ins_fails++;
+                }
+                break;
+
+            case 4:
+            case 5:
+            case 6:
+            case 7: /* delete value */
+                if ( lfht_delete(params_ptr->lfht_ptr, id) ) {
+
+                    del_successes++;
+
+                } else {
+
+                    del_fails++;
+                }
+                break;
+
+            case 8: /* search by value */
+                if ( lfht_find_id_by_value(params_ptr->lfht_ptr, &test_id, (void *)id) ) {
+
+                    search_by_val_successes++;
+                    assert(test_id == id);
+
+                } else {
+
+                    search_by_val_fails++;
+                }
+                break;
+
+            case 9: /* swap value */
+                if ( lfht_swap_value(params_ptr->lfht_ptr, id, 
+                                     (void *)(id + val_swap_offset), &value) ) {
+
+                    swap_val_successes++;
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+
+                } else {
+
+                    swap_val_fails++;
+                }
+                break;
+
+            default:
+                if ( lfht_find(params_ptr->lfht_ptr, id, &value) ) {
+
+                    search_successes++;
+
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+
+                } else {
+
+                    search_fails++;
+                }
+                break;
+        }
+
+        if ( i == itterateration_pass ) {
+
+            itter_inits++;
+            if ( lfht_get_first(params_ptr->lfht_ptr, &id, &value) ) {
+
+                assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+
+                while (lfht_get_next(params_ptr->lfht_ptr, id, &id, &value)) {
+
+                    assert(((void *)id == value) || ((void *)(id + val_swap_offset) == value));
+                    itter_nexts++;
+                }
+            }
+
+            itter_ends++;
+        }
+
+        i++;
+    } 
+
+    params_ptr->ins_successes           = ins_successes;
+    params_ptr->ins_fails               = ins_fails;
+
+    params_ptr->del_successes           = del_successes;
+    params_ptr->del_fails               = del_fails;
+
+    params_ptr->search_successes        = search_successes;
+    params_ptr->search_fails            = search_fails;
+
+    params_ptr->search_by_val_successes = search_by_val_successes;
+    params_ptr->search_by_val_fails     = search_by_val_fails;
+
+    params_ptr->swap_val_successes      = swap_val_successes;
+    params_ptr->swap_val_fails          = swap_val_fails;
+
+    params_ptr->itter_inits             = itter_inits;
+    params_ptr->itter_nexts             = itter_nexts;
+    params_ptr->itter_ends              = itter_ends;
+
+    return(NULL);
+
+} /* lfht_mt_test_fcn_2() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_mt_test_fcn_1__serial_test()
+ *
+ *     Serial test of lfht_mt_test_fcn_1() with the lock free hash table 
+ *     configured to function as a lock free singly linked list.
+ *
+ *                                                   JRM -- 6/19/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_mt_test_fcn_1__serial_test()
+{
+    unsigned int seed;
+    int count = 0;
+    int log[10000];
+    struct timeval t;
+    struct lfht_t lfht;
+    struct lfht_mt_test_params_t params = {
+        /* lfht_ptr                = */ NULL,
+        /* start_id                = */ 50000LL,
+        /* step                    = */ -3LL,
+        /* num_ids                 = */ 10000LL,
+        /* iterations              = */ 0,   /* not used in this case */
+        /* ins_fails               = */ 0LL,
+        /* del_fails               = */ 0LL,
+        /* search_fails            = */ 0LL,
+        /* search_by_val_fails     = */ 0LL,
+        /* swap_val_fails          = */ 0LL,
+        /* ins_successes           = */ 0LL, /* not used in this case */
+        /* del_successes           = */ 0LL, /* not used in this case */
+        /* search_successes        = */ 0LL, /* not used in this case */
+        /* search_by_val_successes = */ 0LL, /* not used in this case */
+        /* swap_val_successes      = */ 0LL, /* not used in this case */
+        /* itter_inits             = */ 0LL,
+        /* itter_nexts             = */ 0LL,
+        /* itter_ends              = */ 0LL
+    };
+
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT LFSLL serial test of lfht_mt_test_fcn_1 (seed = 0x%x) ...", seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table
+     * to funtion as a lock free singly linked list, as it forces all entries
+     * into a single hash bucket.
+     */
+    lfht.max_index_bits = 0;
+
+    params.lfht_ptr = &lfht;
+
+    lfht_mt_test_fcn_1((void *)(&params));
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(params.ins_fails == atomic_load(&(lfht.insertion_failures)));
+    assert(params.del_fails == atomic_load(&(lfht.deletion_failures)));
+    assert(params.search_fails == atomic_load(&(lfht.failed_searches)));
+    assert(params.search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(params.swap_val_fails == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(params.itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(params.itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(params.itter_ends == atomic_load(&(lfht.itter_ends)));
+
+    assert(0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(3 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(20000 == atomic_load(&(lfht.insertions)));
+    assert(10000 == atomic_load(&(lfht.insertion_failures)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(30000 == atomic_load(&(lfht.deletion_attempts)));
+    assert(10000 == atomic_load(&(lfht.deletion_failures)));
+    assert(20000 == atomic_load(&(lfht.deletion_starts)));
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert(atomic_load(&(lfht.ins_deletion_completions)) + 
+           atomic_load(&(lfht.del_deletion_completions)) +
+           atomic_load(&(lfht.lfsll_phys_len)) - 2 == 20000);
+
+    assert(30000 == atomic_load(&(lfht.searches)));
+    assert(20000 == atomic_load(&(lfht.successful_searches)));
+    assert(10000 == atomic_load(&(lfht.failed_searches)));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+    assert(10000 == (atomic_load(&(lfht.successful_val_swaps)) / 2) + 
+                    atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(1 == params.itter_inits);
+    assert(params.itter_nexts + 1 == (atomic_load(&(lfht.successful_val_swaps)) / 2));
+    assert(1 == params.itter_ends);
+
+    assert(0 == params.search_by_val_fails);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_lfsll_mt_test_fcn_1__serial_test() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_mt_test_fcn_2__serial_test()
+ *
+ *     Serial test of lfht_mt_test_fcn_2() with the lock free hash table 
+ *     configured to function as a lock free singly linked list.
+ *
+ *                                                   JRM -- 6/28/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_mt_test_fcn_2__serial_test()
+{
+    unsigned int seed;
+    int count = 0;
+    int log[10000];
+    struct timeval t;
+    struct lfht_t lfht;
+    struct lfht_mt_test_params_t params = {
+        /* lfht_ptr                = */ NULL,
+        /* start_id                = */ 0LL,
+        /* step                    = */ 0LL, /* not used in this case */
+        /* num_ids                 = */ 10000LL,
+        /* iterations              = */ 1000000LL,
+        /* ins_fails               = */ 0LL,
+        /* del_fails               = */ 0LL,
+        /* search_fails            = */ 0LL,
+        /* search_by_val_fails     = */ 0LL,
+        /* swap_val_fails          = */ 0LL,
+        /* ins_successes           = */ 0LL, 
+        /* del_successes           = */ 0LL,
+        /* search_successes        = */ 0LL,
+        /* search_by_val_successes = */ 0LL,
+        /* swap_val_successes      = */ 0LL, 
+        /* itter_inits             = */ 0LL,
+        /* itter_nexts             = */ 0LL,
+        /* itter_ends              = */ 0LL
+    };
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT LFSLL serial test of lfht_mt_test_fcn_2 (seed = 0x%x) ...", seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table
+     * to funtion as a lock free singly linked list, as it forces all entries
+     * into a single hash bucket.
+     */
+    lfht.max_index_bits = 0;
+
+    params.lfht_ptr = &lfht;
+
+    lfht_mt_test_fcn_2((void *)(&params));
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(params.ins_fails           == atomic_load(&(lfht.insertion_failures)));
+    assert(params.del_fails           == atomic_load(&(lfht.deletion_failures)));
+    assert(params.search_fails        == atomic_load(&(lfht.failed_searches)));
+    assert(params.search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(params.swap_val_fails      == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(params.ins_successes           == atomic_load(&(lfht.insertions)));
+    assert(params.del_successes           == atomic_load(&(lfht.deletion_starts)));
+    assert(params.search_successes        == atomic_load(&(lfht.successful_searches)));
+    assert(params.search_by_val_successes == atomic_load(&(lfht.successful_val_searches)));
+    assert(params.swap_val_successes      == atomic_load(&(lfht.successful_val_swaps)));
+
+    assert(params.itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(params.itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(params.itter_ends  == atomic_load(&(lfht.itter_ends)));
+
+
+    /* lfht.log_len & lfht.phys_len will vary */
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    /* lfht.insertions & lfht.insertion_failures will vary */
+
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    /* lfht.deletion_attempts, lfht.deletion_failures, & lfht.deletion_starts will vary */
+
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert(atomic_load(&(lfht.ins_deletion_completions)) + 
+           atomic_load(&(lfht.del_deletion_completions)) +
+           atomic_load(&(lfht.lfsll_phys_len)) - 2 == atomic_load(&(lfht.insertions)));
+
+    /* lfht.searches, lfht.successful_searches, & lfht.failed_searches will vary */
+
+    assert( atomic_load(&(lfht.searches)) == 
+            (atomic_load(&(lfht.successful_searches)) + atomic_load(&(lfht.failed_searches))) );
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+    assert((params.search_by_val_fails + params.search_by_val_successes) ==
+           atomic_load(&(lfht.value_searches)));
+
+    assert((params.swap_val_fails + params.swap_val_successes) ==
+           atomic_load(&(lfht.value_swaps)));
+
+    assert(1 == params.itter_inits);
+    /* number of itter_nexts varies */
+    assert(1 == params.itter_ends);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_lfsll_mt_test_fcn_2__serial_test() */
+
+
+/***********************************************************************************
+ *
+ * lfht_mt_test_fcn_1__serial_test()
+ *
+ *     Serial test of lfht_mt_test_fcn_1().
+ *
+ *                                                   JRM -- 6/19/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_mt_test_fcn_1__serial_test()
+{
+    unsigned int seed;
+    int count = 0;
+    int log[10000];
+    struct timeval t;
+    struct lfht_t lfht;
+    struct lfht_mt_test_params_t params = {
+        /* lfht_ptr                = */ NULL,
+        /* start_id                = */ 50000LL,
+        /* step                    = */ -3LL,
+        /* num_ids                 = */ 10000LL,
+        /* iterations              = */ 0,   /* not used in this case */
+        /* ins_fails               = */ 0LL,
+        /* del_fails               = */ 0LL,
+        /* search_fails            = */ 0LL,
+        /* search_by_val_fails     = */ 0LL,
+        /* swap_val_fails          = */ 0LL,
+        /* ins_successes           = */ 0LL, /* not used in this case */
+        /* del_successes           = */ 0LL, /* not used in this case */
+        /* search_successes        = */ 0LL, /* not used in this case */
+        /* search_by_val_successes = */ 0LL, /* not used in this case */
+        /* swap_val_successes      = */ 0LL, /* not used in this case */
+        /* itter_inits             = */ 0LL,
+        /* itter_nexts             = */ 0LL,
+        /* itter_ends              = */ 0LL
+    };
+
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT serial test of lfht_mt_test_fcn_1 (seed = 0x%x) ...", seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    params.lfht_ptr = &lfht;
+
+    lfht_mt_test_fcn_1((void *)(&params));
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(params.ins_fails == atomic_load(&(lfht.insertion_failures)));
+    assert(params.del_fails == atomic_load(&(lfht.deletion_failures)));
+    assert(params.search_fails == atomic_load(&(lfht.failed_searches)));
+    assert(params.search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(params.swap_val_fails == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(params.itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(params.itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(params.itter_ends == atomic_load(&(lfht.itter_ends)));
+
+    assert(   0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(2049 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(20000 == atomic_load(&(lfht.insertions)));
+    assert(10000 == atomic_load(&(lfht.insertion_failures)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(30000 == atomic_load(&(lfht.deletion_attempts)));
+    assert(10000 == atomic_load(&(lfht.deletion_failures)));
+    assert(20000 == atomic_load(&(lfht.deletion_starts)));
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert(atomic_load(&(lfht.ins_deletion_completions)) + 
+           atomic_load(&(lfht.del_deletion_completions)) +
+           atomic_load(&(lfht.lfsll_phys_len)) - 
+           atomic_load(&(lfht.buckets_initialized)) - 1 == 20000);
+
+    assert(30000 == atomic_load(&(lfht.searches)));
+    assert(20000 == atomic_load(&(lfht.successful_searches)));
+    assert(10000 == atomic_load(&(lfht.failed_searches)));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and i
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+    assert(10000 == (atomic_load(&(lfht.successful_val_swaps)) / 2) + 
+                    atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(1 == params.itter_inits);
+    assert(params.itter_nexts + 1 == (atomic_load(&(lfht.successful_val_swaps)) / 2));
+    assert(1 == params.itter_ends);
+
+    assert(0 == params.search_by_val_fails);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_mt_test_fcn_1__serial_test() */
+
+
+/***********************************************************************************
+ *
+ * lfht_mt_test_fcn_2__serial_test()
+ *
+ *     Serial test of lfht_mt_test_fcn_2().
+ *
+ *                                                   JRM -- 6/28/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_mt_test_fcn_2__serial_test()
+{
+    unsigned int seed;
+    int count = 0;
+    int log[10000];
+    struct timeval t;
+    struct lfht_t lfht;
+    struct lfht_mt_test_params_t params = {
+        /* lfht_ptr                = */ NULL,
+        /* start_id                = */ 0LL,
+        /* step                    = */ 0LL, /* not used in this case */
+        /* num_ids                 = */ 10000LL,
+        /* iterations              = */ 1000000LL,
+        /* ins_fails               = */ 0LL,
+        /* del_fails               = */ 0LL,
+        /* search_fails            = */ 0LL,
+        /* search_by_val_fails     = */ 0LL,
+        /* swap_val_fails          = */ 0LL,
+        /* ins_successes           = */ 0LL, 
+        /* del_successes           = */ 0LL,
+        /* search_successes        = */ 0LL,
+        /* search_by_val_successes = */ 0LL,
+        /* swap_val_successes      = */ 0LL,
+        /* itter_inits             = */ 0LL,
+        /* itter_nexts             = */ 0LL,
+        /* itter_ends              = */ 0LL
+    };
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT serial test of lfht_mt_test_fcn_2 (seed = 0x%x) ...", seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    params.lfht_ptr = &lfht;
+
+    lfht_mt_test_fcn_2((void *)(&params));
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert(params.ins_fails           == atomic_load(&(lfht.insertion_failures)));
+    assert(params.del_fails           == atomic_load(&(lfht.deletion_failures)));
+    assert(params.search_fails        == atomic_load(&(lfht.failed_searches)));
+    assert(params.search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(params.swap_val_fails      == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(params.ins_successes           == atomic_load(&(lfht.insertions)));
+    assert(params.del_successes           == atomic_load(&(lfht.deletion_starts)));
+    assert(params.search_successes        == atomic_load(&(lfht.successful_searches)));
+    assert(params.search_by_val_successes == atomic_load(&(lfht.successful_val_searches)));
+    assert(params.swap_val_successes      == atomic_load(&(lfht.successful_val_swaps)));
+
+    assert(params.itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(params.itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(params.itter_ends  == atomic_load(&(lfht.itter_ends)));
+
+
+    /* lfht.log_len & lfht.phys_len will vary */
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    /* lfht.insertions & lfht.insertion_failures will vary */
+
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_ins_col)));
+    assert(    0 == atomic_load(&(lfht.ins_restarts_due_to_del_col)));
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    /* lfht.deletion_attempts, lfht.deletion_failures, & lfht.deletion_starts will vary */
+
+    assert(    0 == atomic_load(&(lfht.deletion_start_cols)));
+    assert(    0 == atomic_load(&(lfht.del_restarts_due_to_del_col)));
+
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert(atomic_load(&(lfht.ins_deletion_completions)) + 
+           atomic_load(&(lfht.del_deletion_completions)) +
+           atomic_load(&(lfht.lfsll_phys_len)) - 
+           atomic_load(&(lfht.buckets_initialized)) - 1 == atomic_load(&(lfht.insertions)));
+
+    /* lfht.searches, lfht.successful_searches, & lfht.failed_searches will vary */
+
+    assert( atomic_load(&(lfht.searches)) == 
+            (atomic_load(&(lfht.successful_searches)) + atomic_load(&(lfht.failed_searches))) );
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+    assert((params.search_by_val_fails + params.search_by_val_successes) ==
+           atomic_load(&(lfht.value_searches)));
+
+    assert((params.swap_val_fails + params.swap_val_successes) ==
+           atomic_load(&(lfht.value_swaps)));
+
+    assert(1 == params.itter_inits);
+    /* number of itter_nexts varies */
+    assert(1 == params.itter_ends);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_mt_test_fcn_2__serial_test() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_mt_test_1()
+ *
+ *     Setup a lock free hash table, but configure it to function as a lock free
+ *     singly linked list.
+ *
+ *     Spawn nthreads threads, each of which performs operations on the LFHT
+ *     in parallel.  In this case, allow only one thread to touch any one value.
+ *     As a result, there should be no insert, deleted, or search collisions
+ *     proper.  However collisions allocating and discarding entries will occur,
+ *     as will collisions when completing deletions. 
+ *
+ *                                                   JRM -- 6/19/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_mt_test_1(int nthreads)
+{
+    int i;
+    long long int ins_fails = 0LL;
+    long long int del_fails = 0LL;
+    long long int search_fails = 0LL;
+    long long int search_by_val_fails = 0LL;
+    long long int swap_val_fails = 0LL;
+    long long int itter_inits = 0LL;
+    long long int itter_nexts = 0LL;
+    long long int itter_ends = 0LL;
+    unsigned int seed;
+    struct timeval t;
+    struct lfht_t lfht;
+    pthread_t threads[MAX_NUM_THREADS];
+    struct lfht_mt_test_params_t params[MAX_NUM_THREADS];
+
+    assert(nthreads <= MAX_NUM_THREADS);
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT LFSLL multi-thread test 1 (nthreads = %d, seed = 0x%x) ...", 
+            nthreads, seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table
+     * to funtion as a lock free singly linked list, as it forces all entries
+     * into a single hash bucket.
+     */   
+    lfht.max_index_bits = 0; 
+
+    for (i = 0; i < nthreads; i++) {
+
+        params[i].lfht_ptr                = &lfht;
+        params[i].start_id                = (long long int)i;
+        params[i].step                    = (long long int)nthreads;
+        params[i].num_ids                 = 10000LL;
+        params[i].itterations             = 0LL; /* not used in this test */
+        params[i].ins_fails               = 0LL;
+        params[i].del_fails               = 0LL;
+        params[i].search_fails            = 0LL;
+        params[i].search_by_val_fails     = 0LL;
+        params[i].swap_val_fails          = 0LL;
+        params[i].ins_successes           = 0LL; /* not used in this test */
+        params[i].del_successes           = 0LL; /* not used in this test */
+        params[i].search_successes        = 0LL; /* not used in this test */
+        params[i].search_by_val_successes = 0LL; /* not used in this test */
+        params[i].swap_val_successes      = 0LL; /* not used in this test */
+        params[i].itter_inits             = 0LL;
+        params[i].itter_nexts             = 0LL;
+        params[i].itter_ends              = 0LL;
+    }
+
+    /* create the threads and have them execute &lfht_mt_test_fcn_1. */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_create(&(threads[i]), NULL, &lfht_mt_test_fcn_1, (void *)(&(params[i]))));
+    }
+
+    /* Wait for all the threads to complete */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_join(threads[i], NULL));
+
+        ins_fails           += params[i].ins_fails;
+        del_fails           += params[i].del_fails;
+        search_fails        += params[i].search_fails;
+        search_by_val_fails += params[i].search_by_val_fails;
+        swap_val_fails      += params[i].swap_val_fails;
+
+        itter_inits         += params[i].itter_inits;
+        itter_nexts         += params[i].itter_nexts;
+        itter_ends          += params[i].itter_ends;
+    }
+
+#if 0 
+    fprintf(stdout, "\nins / del / search fails = %lld / %lld / %lld\n", 
+            ins_fails, del_fails, search_fails);
+    fprintf(stdout, "nodes allocated / freed / net = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.num_nodes_allocated)),
+            atomic_load(&(lfht.num_nodes_freed)),
+            (atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))));
+    fprintf(stdout, "phys_len / fl_len / sum = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.lfsll_phys_len)), atomic_load(&(lfht.fl_len)),
+            (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+#endif
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    assert(ins_fails == atomic_load(&(lfht.insertion_failures)));
+    assert(del_fails == atomic_load(&(lfht.deletion_failures)));
+    assert(search_fails == atomic_load(&(lfht.failed_searches)));
+    assert(search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(swap_val_fails == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(itter_ends == atomic_load(&(lfht.itter_ends)));
+
+    assert(0 == atomic_load(&(lfht.lfsll_log_len)));
+    assert(3 == atomic_load(&(lfht.lfsll_phys_len)));
+
+    assert(2 * nthreads * 10000 == atomic_load(&(lfht.insertions)));
+    assert(    nthreads * 10000 == atomic_load(&(lfht.insertion_failures)));
+
+    /* lfht.lfht.ins_restarts_due_to_ins_col and lfht.lfht.ins_restarts_due_to_del_col will vary */
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.deletion_attempts)));
+    assert(    nthreads * 10000 == atomic_load(&(lfht.deletion_failures)));
+    assert(2 * nthreads * 10000 == atomic_load(&(lfht.deletion_starts)));
+
+    /* lfht.deletion_start_cols and lfht.del_restarts_due_to_del_col) will vary */
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert( ( atomic_load(&(lfht.ins_deletion_completions)) + 
+              atomic_load(&(lfht.del_deletion_completions)) +
+              atomic_load(&(lfht.lfsll_log_len)) )  == 
+            ( (2 * nthreads * 10000) - (atomic_load(&(lfht.lfsll_phys_len)) - 2) ) );
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.searches)));
+    assert(2 * nthreads * 10000 == atomic_load(&(lfht.successful_searches)));
+    assert(    nthreads * 10000 == atomic_load(&(lfht.failed_searches)));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    /* value swaps (total, successful, and failed) will vary */
+
+    assert(nthreads == itter_inits);
+    /* itter_nexts will vary */
+    assert(nthreads == itter_ends);
+
+    assert(0 == search_by_val_fails);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_lfsll_mt_test_1() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_mt_test_2()
+ *
+ *     Setup a lock free hash table, but configure it to function as a lock free 
+ *     singly linked list.
+ *
+ *     Spawn nthreads threads, each of which performs operations on the LFHT
+ *     in parallel.  In this case, all threads perform the same set of operations
+ *     on the same set of value -- thus all manner of collisions, insert, search, 
+ *     and delete failures are expected.  Further, since operations are performed
+ *     in a largely random order, correctness is hard to check.
+ *
+ *     Instead, we simply verify that the statistics ballance -- i.e. allocs and 
+ *     frees ballance, successful inserts and deletes ballance, etc.
+ *
+ *                                                   JRM -- 6/27/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_mt_test_2(int nthreads)
+{
+    int i;
+    long long int ins_fails = 0LL;
+    long long int del_fails = 0LL;
+    long long int search_fails = 0LL;
+    long long int search_by_val_fails = 0LL;
+    long long int swap_val_fails = 0LL;
+    long long int ins_successes = 0LL;
+    long long int del_successes = 0LL;
+    long long int search_successes = 0LL;
+    long long int search_by_val_successes = 0LL;
+    long long int swap_val_successes = 0LL;
+    long long int itter_inits = 0LL;
+    long long int itter_nexts = 0LL;
+    long long int itter_ends = 0LL;
+    unsigned int seed;
+    struct timeval t;
+    struct lfht_t lfht;
+    pthread_t threads[MAX_NUM_THREADS];
+    struct lfht_mt_test_params_t params[MAX_NUM_THREADS];
+
+    assert(nthreads <= MAX_NUM_THREADS);
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT LFSLL multi-thread test 2 (nthreads = %d, seed = 0x%x) ...", 
+            nthreads, seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table
+     * to funtion as a lock free singly linked list, as it forces all entries
+     * into a single hash bucket.
+     */
+    lfht.max_index_bits = 0;
+
+    for (i = 0; i < nthreads; i++) {
+
+        params[i].lfht_ptr                = &lfht;
+
+        if ( (i % 2) == 0 ) {
+
+            params[i].start_id            = (long long int)0;
+            params[i].step                = (long long int)1;
+
+        } else {
+
+            params[i].start_id            = (long long int)9999;
+            params[i].step                = (long long int)-1;
+        }
+        params[i].num_ids                 = 10000LL;
+        params[i].itterations             = 0LL; /* not used in this test */
+        params[i].ins_fails               = 0LL;
+        params[i].del_fails               = 0LL;
+        params[i].search_fails            = 0LL;
+        params[i].search_by_val_fails     = 0LL;
+        params[i].swap_val_fails          = 0LL;
+        params[i].ins_successes           = 0LL; /* not used in this test */
+        params[i].del_successes           = 0LL; /* not used in this test */
+        params[i].search_successes        = 0LL; /* not used in this test */
+        params[i].search_by_val_successes = 0LL; /* not used in this test */
+        params[i].swap_val_successes      = 0LL; /* not used in this test */
+        params[i].itter_inits             = 0LL;
+        params[i].itter_nexts             = 0LL;
+        params[i].itter_ends              = 0LL;
+    }
+
+    /* create the threads and have them execute &lfht_mt_test_fcn_1. */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_create(&(threads[i]), NULL, &lfht_mt_test_fcn_1, (void *)(&(params[i]))));
+    }
+
+    /* Wait for all the threads to complete */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_join(threads[i], NULL));
+
+        ins_fails               += params[i].ins_fails;
+        del_fails               += params[i].del_fails;
+        search_fails            += params[i].search_fails;
+        search_by_val_fails     += params[i].search_by_val_fails;
+        swap_val_fails          += params[i].swap_val_fails;
+
+        ins_successes           += params[i].ins_successes;
+        del_successes           += params[i].del_successes;
+        search_successes        += params[i].search_successes;
+        search_by_val_successes += params[i].search_by_val_successes;
+        swap_val_successes      += params[i].swap_val_successes;
+
+        itter_inits             += params[i].itter_inits;
+        itter_nexts             += params[i].itter_nexts;
+        itter_ends              += params[i].itter_ends;
+    }
+
+#if 0 
+    fprintf(stdout, "\nins / del / search fails = %lld / %lld / %lld\n", 
+            ins_fails, del_fails, search_fails);
+    fprintf(stdout, "\nins / del / search successes = %lld / %lld / %lld\n", 
+            ins_successes, del_successes, search_successes);
+    fprintf(stdout, "nodes allocated / freed / net = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.num_nodes_allocated)),
+            atomic_load(&(lfht.num_nodes_freed)),
+            (atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))));
+    fprintf(stdout, "lfsll_phys_len / fl_len / sum = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.lfsll_phys_len)), atomic_load(&(lfht.fl_len)),
+            (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+#endif
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    assert(ins_fails == atomic_load(&(lfht.insertion_failures)));
+    assert(del_fails == atomic_load(&(lfht.deletion_failures)));
+    assert(search_fails == atomic_load(&(lfht.failed_searches)));
+    assert(search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(swap_val_fails == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(itter_ends == atomic_load(&(lfht.itter_ends)));
+
+    /* lfht.lfsll_log_len and lfht.lfsll_phys_len will vary */
+
+    assert(3 * nthreads * 10000 == 
+           (atomic_load(&(lfht.insertions)) + atomic_load(&(lfht.insertion_failures))));
+
+    /* lfht.lfht.ins_restarts_due_to_ins_col and lfht.lfht.ins_restarts_due_to_del_col will vary */
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.deletion_attempts)));
+    assert((nthreads * 10000) + (ins_fails - (nthreads * 10000)) == 
+            atomic_load(&(lfht.deletion_failures)) + atomic_load(&(lfht.deletion_start_cols)) - 
+            atomic_load(&((lfht.lfsll_log_len))));
+    assert(((2 * nthreads * 10000) - (ins_fails - (nthreads * 10000))) ==
+           (atomic_load(&(lfht.deletion_starts)) + atomic_load(&(lfht.lfsll_log_len))));
+
+    /* lfht.deletion_start_cols and lfht.del_restarts_due_to_del_col) will vary */
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert( ( atomic_load(&(lfht.ins_deletion_completions)) + 
+              atomic_load(&(lfht.del_deletion_completions)) +
+              atomic_load(&(lfht.lfsll_phys_len)) - 2 )  == 
+            ( (2 * nthreads * 10000) - (ins_fails - (nthreads * 10000)) ) );
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.searches)));
+    assert(3 * nthreads * 10000 == 
+          ( atomic_load(&(lfht.successful_searches)) + atomic_load(&(lfht.failed_searches)) ) );
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    /* value swaps (total, successful, and failed) will vary */
+
+    assert(nthreads == itter_inits);
+    /* itter_nexts will vary */
+    assert(nthreads == itter_ends);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_lfsll_mt_test_2() */
+
+
+/***********************************************************************************
+ *
+ * lfht_lfsll_mt_test_3()
+ *
+ *     Setup a lock free hash table, but configure it to function as a lock free
+ *     singly linked list.
+ *
+ *     Spawn nthreads threads, each of which performs random operations on the LFHT
+ *     in parallel.  
+ *
+ *     In this case, all threads perform random operations on random values in 
+ *     the same range -- thus all manner of collisions, insert, search, 
+ *     and delete failures are expected.  Further, since operations are performed
+ *     in random order, correctness is hard to check.
+ *
+ *     Instead, we simply verify that the statistics ballance -- i.e. allocs and 
+ *     frees ballance, successful inserts and deletes ballance, etc.
+ *
+ *                                                   JRM -- 6/28/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_lfsll_mt_test_3(int nthreads)
+{
+    int i;
+    long long int ins_fails = 0LL;
+    long long int del_fails = 0LL;
+    long long int search_fails = 0LL;
+    long long int search_by_val_fails = 0LL;
+    long long int swap_val_fails = 0LL;
+    long long int ins_successes = 0LL;
+    long long int del_successes = 0LL;
+    long long int search_successes = 0LL;
+    long long int search_by_val_successes = 0LL;
+    long long int swap_val_successes = 0LL;
+    long long int itter_inits = 0LL;
+    long long int itter_nexts = 0LL;
+    long long int itter_ends = 0LL;
+    unsigned int seed;
+    struct timeval t;
+    struct lfht_t lfht;
+    pthread_t threads[MAX_NUM_THREADS];
+    struct lfht_mt_test_params_t params[MAX_NUM_THREADS];
+
+    assert(nthreads <= MAX_NUM_THREADS);
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT LFSLL multi-thread test 3 (nthreads = %d, seed = 0x%x) ...", 
+            nthreads, seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    /* set lfht.max_index_bits to zero -- which forces the lock free hash table
+     * to funtion as a lock free singly linked list, as it forces all entries
+     * into a single hash bucket.
+     */   
+    lfht.max_index_bits = 0; 
+
+    for (i = 0; i < nthreads; i++) {
+
+        params[i].lfht_ptr                = &lfht;
+        params[i].start_id                = (long long int)0;
+        params[i].step                    = (long long int)0; /* not used in this case */
+        params[i].num_ids                 = 10000LL;
+        params[i].itterations             = 100000LL;
+        params[i].ins_fails               = 0LL;
+        params[i].del_fails               = 0LL;
+        params[i].search_fails            = 0LL;
+        params[i].search_by_val_fails     = 0LL;
+        params[i].swap_val_fails          = 0LL;
+        params[i].ins_successes           = 0LL; 
+        params[i].del_successes           = 0LL;
+        params[i].search_successes        = 0LL;
+        params[i].search_by_val_successes = 0LL;
+        params[i].swap_val_successes      = 0LL;
+        params[i].itter_inits             = 0LL;
+        params[i].itter_nexts             = 0LL;
+        params[i].itter_ends              = 0LL;
+    }
+
+    /* create the threads and have them execute &lfht_mt_test_fcn_1. */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_create(&(threads[i]), NULL, &lfht_mt_test_fcn_2, (void *)(&(params[i]))));
+    }
+
+    /* Wait for all the threads to complete */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_join(threads[i], NULL));
+
+        ins_fails               += params[i].ins_fails;
+        del_fails               += params[i].del_fails;
+        search_fails            += params[i].search_fails;
+        search_by_val_fails     += params[i].search_by_val_fails;
+        swap_val_fails          += params[i].swap_val_fails;
+
+        ins_successes           += params[i].ins_successes;
+        del_successes           += params[i].del_successes;
+        search_successes        += params[i].search_successes;
+        search_by_val_successes += params[i].search_by_val_successes;
+        swap_val_successes      += params[i].swap_val_successes;
+
+        itter_inits             += params[i].itter_inits;
+        itter_nexts             += params[i].itter_nexts;
+        itter_ends              += params[i].itter_ends;
+    }
+
+#if 0 
+    fprintf(stdout, "\nins / del / search fails = %lld / %lld / %lld\n", 
+            ins_fails, del_fails, search_fails);
+    fprintf(stdout, "\nins / del / search successes = %lld / %lld / %lld\n", 
+            ins_successes, del_successes, search_successes);
+    fprintf(stdout, "nodes allocated / freed / net = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.num_nodes_allocated)),
+            atomic_load(&(lfht.num_nodes_freed)),
+            (atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))));
+    fprintf(stdout, "lfsll_phys_len / fl_len / sum = %lld / %lld / %lld, lfsll_log_len = %lld.\n",
+            atomic_load(&(lfht.lfsll_phys_len)), atomic_load(&(lfht.fl_len)),
+            (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))),
+            atomic_load(&(lfht.lfsll_log_len)));
+#endif
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    assert(ins_fails            == atomic_load(&(lfht.insertion_failures)));
+    assert(del_fails            == atomic_load(&(lfht.deletion_failures)));
+    assert(search_fails         == atomic_load(&(lfht.failed_searches)));
+    assert(search_by_val_fails  == atomic_load(&(lfht.failed_val_searches)));
+    assert(swap_val_fails       == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(ins_successes            == atomic_load(&(lfht.insertions)));
+    assert(del_successes            == (atomic_load(&(lfht.deletion_starts)) + 
+                                        atomic_load(&(lfht.deletion_start_cols))));
+    assert(search_successes         == atomic_load(&(lfht.successful_searches)));
+    assert(search_by_val_successes  == atomic_load(&(lfht.successful_val_searches)));
+    assert(swap_val_successes       == atomic_load(&(lfht.successful_val_swaps)));
+
+    assert(itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(itter_ends  == atomic_load(&(lfht.itter_ends)));
+
+    /* lfht.lfsll_log_len and lfht.lfsll_phys_len will vary */
+
+    /* lfht.insertions & lfht.insertion_failures will vary */
+
+    /* lfht.lfht.ins_restarts_due_to_ins_col and lfht.lfht.ins_restarts_due_to_del_col will vary */
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    /* lfht.deletion_attempts will vary */
+
+    /* lfht.deletion_failures will vary */
+
+    assert( (ins_successes - atomic_load(&(lfht.lfsll_log_len))) == 
+            (atomic_load(&(lfht.ins_deletion_completions)) +
+             atomic_load(&(lfht.del_deletion_completions)) +
+             (atomic_load(&(lfht.lfsll_phys_len)) - atomic_load(&(lfht.lfsll_log_len)) - 2)) ); 
+
+    /* lfht.deletion_start_cols and lfht.del_restarts_due_to_del_col) will vary */
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    /* lfht.searches, lfht.successful_searches and lfht.failed_searches will vary. */
+
+    assert(atomic_load(&(lfht.searches)) == (search_successes + search_fails));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    assert((search_by_val_fails + search_by_val_successes) == atomic_load(&(lfht.value_searches)));
+
+    assert((swap_val_fails + swap_val_successes) == atomic_load(&(lfht.value_swaps)));
+
+    assert(nthreads == itter_inits);
+    /* number of itter_nexts varies */
+    assert(nthreads == itter_ends);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_lfsll_mt_test_3() */
+
+
+/***********************************************************************************
+ *
+ * lfht_mt_test_1()
+ *
+ *     Setup a lock free hash table.
+ *
+ *     Spawn nthreads threads, each of which performs operations on the LFHT
+ *     in parallel.  In this case, allow only one thread to touch any one value.
+ *     As a result, there should be no insert, deleted, or search collisions
+ *     proper.  However collisions allocating and discarding entries will occur,
+ *     as will collisions when completing deletions. 
+ *
+ *                                                   JRM -- 6/19/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_mt_test_1(int run, int nthreads)
+{
+    int i;
+    long long int ins_fails = 0LL;
+    long long int del_fails = 0LL;
+    long long int search_fails = 0LL;
+    long long int search_by_val_fails = 0LL;
+    long long int swap_val_fails = 0LL;
+    long long int itter_inits = 0LL;
+    long long int itter_nexts = 0LL;
+    long long int itter_ends = 0LL;
+    unsigned int seed;
+    struct timeval t;
+    struct lfht_t lfht;
+    pthread_t threads[MAX_NUM_THREADS];
+    struct lfht_mt_test_params_t params[MAX_NUM_THREADS];
+
+    assert(nthreads <= MAX_NUM_THREADS);
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT multi-thread test 1 (nthreads = %d, run = %d, seed = 0x%x) ...", 
+            nthreads, run, seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    for (i = 0; i < nthreads; i++) {
+
+        params[i].lfht_ptr                = &lfht;
+        params[i].start_id                = (long long int)i;
+        params[i].step                    = (long long int)nthreads;
+        params[i].num_ids                 = 10000LL;
+        params[i].itterations             = 0LL; /* not used in this test */
+        params[i].ins_fails               = 0LL;
+        params[i].del_fails               = 0LL;
+        params[i].search_fails            = 0LL;
+        params[i].search_by_val_fails     = 0LL;
+        params[i].swap_val_fails          = 0LL;
+        params[i].ins_successes           = 0LL; /* not used in this test */
+        params[i].del_successes           = 0LL; /* not used in this test */
+        params[i].search_successes        = 0LL; /* not used in this test */
+        params[i].search_by_val_successes = 0LL; /* not used in this test */
+        params[i].swap_val_successes      = 0LL; /* not used in this test */
+        params[i].itter_inits             = 0LL;
+        params[i].itter_nexts             = 0LL;
+        params[i].itter_ends              = 0LL;
+    }
+
+    /* create the threads and have them execute &lfht_mt_test_fcn_1. */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_create(&(threads[i]), NULL, &lfht_mt_test_fcn_1, (void *)(&(params[i]))));
+    }
+
+    /* Wait for all the threads to complete */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_join(threads[i], NULL));
+
+        ins_fails           += params[i].ins_fails;
+        del_fails           += params[i].del_fails;
+        search_fails        += params[i].search_fails;
+        search_by_val_fails += params[i].search_by_val_fails;
+        swap_val_fails      += params[i].swap_val_fails;
+
+        itter_inits         += params[i].itter_inits;
+        itter_nexts         += params[i].itter_nexts;
+        itter_ends          += params[i].itter_ends;
+    }
+
+#if 0 
+    fprintf(stdout, "\nins / del / search fails = %lld / %lld / %lld\n", 
+            ins_fails, del_fails, search_fails);
+    fprintf(stdout, "nodes allocated / freed / net = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.num_nodes_allocated)),
+            atomic_load(&(lfht.num_nodes_freed)),
+            (atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))));
+    fprintf(stdout, "phys_len / fl_len / sum = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.lfsll_phys_len)), atomic_load(&(lfht.fl_len)),
+            (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+#endif
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    assert(ins_fails           == atomic_load(&(lfht.insertion_failures)));
+    assert(del_fails           == atomic_load(&(lfht.deletion_failures)));
+    assert(search_fails        == atomic_load(&(lfht.failed_searches)));
+    assert(search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(swap_val_fails      == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(itter_inits         == atomic_load(&(lfht.itter_inits)));
+    assert(itter_nexts         == atomic_load(&(lfht.itter_nexts)));
+    assert(itter_ends          == atomic_load(&(lfht.itter_ends)));
+
+    assert(   0 == atomic_load(&(lfht.lfsll_log_len)));
+
+    /* lfsll_phys_len varies, and is checked below */
+
+    assert(2 * nthreads * 10000 == atomic_load(&(lfht.insertions)));
+    assert(    nthreads * 10000 == atomic_load(&(lfht.insertion_failures)));
+
+    /* lfht.lfht.ins_restarts_due_to_ins_col and lfht.lfht.ins_restarts_due_to_del_col will vary */
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.deletion_attempts)));
+    assert(    nthreads * 10000 == atomic_load(&(lfht.deletion_failures)));
+    assert(2 * nthreads * 10000 == atomic_load(&(lfht.deletion_starts)));
+
+    /* lfht.deletion_start_cols and lfht.del_restarts_due_to_del_col) will vary */
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert( ( atomic_load(&(lfht.ins_deletion_completions)) + 
+              atomic_load(&(lfht.del_deletion_completions)) +
+              atomic_load(&(lfht.lfsll_log_len)) )  == 
+            ( (2 * nthreads * 10000) - 
+              (atomic_load(&(lfht.lfsll_phys_len)) - atomic_load(&(lfht.buckets_initialized)) - 1) ) );
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.searches)));
+    assert(2 * nthreads * 10000 == atomic_load(&(lfht.successful_searches)));
+    assert(    nthreads * 10000 == atomic_load(&(lfht.failed_searches)));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    /* value swaps (total, successful, and failed) will vary */
+
+    assert(nthreads == itter_inits);
+    /* itter_nexts will vary */
+    assert(nthreads == itter_ends);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_mt_test_1() */
+
+
+/***********************************************************************************
+ *
+ * lfht_mt_test_2()
+ *
+ *     Setup a lock free hash table.
+ *
+ *     Spawn nthreads threads, each of which performs operations on the LFHT
+ *     in parallel.  In this case, all threads perform the same set of operations
+ *     on the same set of value -- thus all manner of collisions, insert, search, 
+ *     and delete failures are expected.  Further, since operations are performed
+ *     in a largely random order, correctness is hard to check.
+ *
+ *     Instead, we simply verify that the statistics ballance -- i.e. allocs and 
+ *     frees ballance, successful inserts and deletes ballance, etc.
+ *
+ *                                                   JRM -- 6/27/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_mt_test_2(int run, int nthreads)
+{
+    int i;
+    long long int ins_fails = 0LL;
+    long long int del_fails = 0LL;
+    long long int search_fails = 0LL;
+    long long int search_by_val_fails = 0LL;
+    long long int swap_val_fails = 0LL;
+    long long int ins_successes = 0LL;
+    long long int del_successes = 0LL;
+    long long int search_successes = 0LL;
+    long long int search_by_val_successes = 0LL;
+    long long int swap_val_successes = 0LL;
+    long long int itter_inits = 0LL;
+    long long int itter_nexts = 0LL;
+    long long int itter_ends = 0LL;
+    unsigned int seed;
+    struct timeval t;
+    struct lfht_t lfht;
+    pthread_t threads[MAX_NUM_THREADS];
+    struct lfht_mt_test_params_t params[MAX_NUM_THREADS];
+
+    assert(nthreads <= MAX_NUM_THREADS);
+
+    assert(0 == gettimeofday(&t, NULL));
+
+    seed = (unsigned int)(t.tv_usec);
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT multi-thread test 2 (nthreads = %d, run = %d, seed = 0x%x) ...", 
+            nthreads, run, seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    for (i = 0; i < nthreads; i++) {
+
+        params[i].lfht_ptr                = &lfht;
+
+        if ( (i % 2) == 0 ) {
+
+            params[i].start_id            = (long long int)0;
+            params[i].step                = (long long int)1;
+
+        } else {
+
+            params[i].start_id            = (long long int)9999;
+            params[i].step                = (long long int)-1;
+        }
+        params[i].num_ids                 = 10000LL;
+        params[i].itterations             = 0LL; /* not used in this test */
+        params[i].ins_fails               = 0LL;
+        params[i].del_fails               = 0LL;
+        params[i].search_fails            = 0LL;
+        params[i].search_by_val_fails     = 0LL;
+        params[i].swap_val_fails          = 0LL;
+        params[i].ins_successes           = 0LL; /* not used in this test */
+        params[i].del_successes           = 0LL; /* not used in this test */
+        params[i].search_successes        = 0LL; /* not used in this test */
+        params[i].search_by_val_successes = 0LL; /* not used in this test */
+        params[i].swap_val_successes      = 0LL; /* not used in this test */
+        params[i].itter_inits             = 0LL;
+        params[i].itter_nexts             = 0LL;
+        params[i].itter_ends              = 0LL;
+    }
+
+    /* create the threads and have them execute &lfht_mt_test_fcn_1. */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_create(&(threads[i]), NULL, &lfht_mt_test_fcn_1, (void *)(&(params[i]))));
+    }
+
+    /* Wait for all the threads to complete */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_join(threads[i], NULL));
+
+        ins_fails               += params[i].ins_fails;
+        del_fails               += params[i].del_fails;
+        search_fails            += params[i].search_fails;
+        search_by_val_fails     += params[i].search_by_val_fails;
+        swap_val_fails          += params[i].swap_val_fails;
+
+        ins_successes           += params[i].ins_successes;
+        del_successes           += params[i].del_successes;
+        search_successes        += params[i].search_successes;
+        search_by_val_successes += params[i].search_by_val_successes;
+        swap_val_successes      += params[i].swap_val_successes;
+
+        itter_inits             += params[i].itter_inits;
+        itter_nexts             += params[i].itter_nexts;
+        itter_ends              += params[i].itter_ends;
+    }
+
+#if 0 
+    fprintf(stdout, "\nins / del / search fails = %lld / %lld / %lld\n", 
+            ins_fails, del_fails, search_fails);
+    fprintf(stdout, "\nins / del / search successes = %lld / %lld / %lld\n", 
+            ins_successes, del_successes, search_successes);
+    fprintf(stdout, "nodes allocated / freed / net = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.num_nodes_allocated)),
+            atomic_load(&(lfht.num_nodes_freed)),
+            (atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))));
+    fprintf(stdout, "lfsll_phys_len / fl_len / sum = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.lfsll_phys_len)), atomic_load(&(lfht.fl_len)),
+            (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+#endif
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    assert(ins_fails           == atomic_load(&(lfht.insertion_failures)));
+    assert(del_fails           == atomic_load(&(lfht.deletion_failures)));
+    assert(search_fails        == atomic_load(&(lfht.failed_searches)));
+    assert(search_by_val_fails == atomic_load(&(lfht.failed_val_searches)));
+    assert(swap_val_fails      == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(itter_inits         == atomic_load(&(lfht.itter_inits)));
+    assert(itter_nexts         == atomic_load(&(lfht.itter_nexts)));
+    assert(itter_ends          == atomic_load(&(lfht.itter_ends)));
+
+    /* lfht.lfsll_log_len and lfht.lfsll_phys_len will vary */
+
+    assert(3 * nthreads * 10000 == 
+           (atomic_load(&(lfht.insertions)) + atomic_load(&(lfht.insertion_failures))));
+
+    /* lfht.lfht.ins_restarts_due_to_ins_col and lfht.lfht.ins_restarts_due_to_del_col will vary */
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.deletion_attempts)));
+
+    assert((nthreads * 10000) + (ins_fails - (nthreads * 10000)) == 
+            atomic_load(&(lfht.deletion_failures)) + atomic_load(&(lfht.deletion_start_cols)) - 
+            atomic_load(&((lfht.lfsll_log_len))));
+
+    assert(((2 * nthreads * 10000) - (ins_fails - (nthreads * 10000))) ==
+           (atomic_load(&(lfht.deletion_starts)) + atomic_load(&(lfht.lfsll_log_len))));
+
+    /* lfht.deletion_start_cols and lfht.del_restarts_due_to_del_col) will vary */
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    assert( ( atomic_load(&(lfht.ins_deletion_completions)) + 
+              atomic_load(&(lfht.del_deletion_completions)) +
+              atomic_load(&(lfht.lfsll_phys_len)) - 
+              atomic_load(&(lfht.buckets_initialized)) - 1) ==
+            ( (2 * nthreads * 10000) - (ins_fails - (nthreads * 10000)) ) );
+
+    assert(3 * nthreads * 10000 == atomic_load(&(lfht.searches)));
+
+    assert(3 * nthreads * 10000 == 
+          ( atomic_load(&(lfht.successful_searches)) + atomic_load(&(lfht.failed_searches)) ) );
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    /* value swaps (total, successful, and failed) will vary */
+
+    assert(nthreads == itter_inits);
+    /* itter_nexts will vary */
+    assert(nthreads == itter_ends);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_mt_test_2() */
+
+
+/***********************************************************************************
+ *
+ * lfht_mt_test_3()
+ *
+ *     Setup a lock free hash table.
+ *
+ *     Spawn nthreads threads, each of which performs random operations on the LFHT
+ *     in parallel.  
+ *
+ *     In this case, all threads perform random operations on random values in 
+ *     the same range -- thus all manner of collisions, insert, search, 
+ *     and delete failures are expected.  Further, since operations are performed
+ *     in random order, correctness is hard to check.
+ *
+ *     Instead, we simply verify that the statistics ballance -- i.e. allocs and 
+ *     frees ballance, successful inserts and deletes ballance, etc.
+ *
+ *                                                   JRM -- 6/28/23
+ *
+ * Changes:
+ *
+ *     None.
+ *
+ ***********************************************************************************/
+
+void lfht_mt_test_3(int run, int nthreads)
+{
+    int i;
+    long long int ins_fails = 0LL;
+    long long int del_fails = 0LL;
+    long long int search_fails = 0LL;
+    long long int search_by_val_fails = 0LL;
+    long long int swap_val_fails = 0LL;
+    long long int ins_successes = 0LL;
+    long long int del_successes = 0LL;
+    long long int search_successes = 0LL;
+    long long int search_by_val_successes = 0LL;
+    long long int swap_val_successes = 0LL;
+    long long int itter_inits = 0LL;
+    long long int itter_nexts = 0LL;
+    long long int itter_ends = 0LL;
+    unsigned int seed;
+    struct timeval t;
+    struct lfht_t lfht;
+    pthread_t threads[MAX_NUM_THREADS];
+    struct lfht_mt_test_params_t params[MAX_NUM_THREADS];
+
+    assert(nthreads <= MAX_NUM_THREADS);
+
+    assert(0 == gettimeofday(&t, NULL));
+
+#if 1 
+    seed = (unsigned int)(t.tv_usec);
+#else
+    seed = 0xa4d3e;
+#endif
+
+    srand(seed);
+
+    fprintf(stdout, "LFHT multi-thread test 3 (nthreads = %d, run = %d, seed = 0x%x) ...", 
+            nthreads, run, seed);
+
+    fflush(stdout);
+
+    lfht_init(&lfht);
+
+    for (i = 0; i < nthreads; i++) {
+
+        params[i].lfht_ptr                = &lfht;
+        params[i].start_id                = (long long int)0;
+        params[i].step                    = (long long int)0; /* not used in this case */
+        params[i].num_ids                 = 10000LL;
+        params[i].itterations             = 100000LL;
+        params[i].ins_fails               = 0LL;
+        params[i].del_fails               = 0LL;
+        params[i].search_fails            = 0LL;
+        params[i].search_by_val_fails     = 0LL;
+        params[i].swap_val_fails          = 0LL;
+        params[i].ins_successes           = 0LL; 
+        params[i].del_successes           = 0LL;
+        params[i].search_successes        = 0LL;
+        params[i].search_by_val_successes = 0LL;
+        params[i].swap_val_successes      = 0LL;
+        params[i].itter_inits             = 0LL;
+        params[i].itter_nexts             = 0LL;
+        params[i].itter_ends              = 0LL;
+    }
+
+    /* create the threads and have them execute &lfht_mt_test_fcn_1. */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_create(&(threads[i]), NULL, &lfht_mt_test_fcn_2, (void *)(&(params[i]))));
+    }
+
+    /* Wait for all the threads to complete */
+    for (i = 0; i < nthreads; i++) {
+
+        assert(0 == pthread_join(threads[i], NULL));
+
+        ins_fails               += params[i].ins_fails;
+        del_fails               += params[i].del_fails;
+        search_fails            += params[i].search_fails;
+        search_by_val_fails     += params[i].search_by_val_fails;
+        swap_val_fails          += params[i].swap_val_fails;
+
+        ins_successes           += params[i].ins_successes;
+        del_successes           += params[i].del_successes;
+        search_successes        += params[i].search_successes;
+        search_by_val_successes += params[i].search_by_val_successes;
+        swap_val_successes      += params[i].swap_val_successes;
+
+        itter_inits             += params[i].itter_inits;
+        itter_nexts             += params[i].itter_nexts;
+        itter_ends              += params[i].itter_ends;
+    }
+
+#if 0 
+    fprintf(stdout, "\nins / del / search fails = %lld / %lld / %lld\n", 
+            ins_fails, del_fails, search_fails);
+    fprintf(stdout, "\nins / del / search successes = %lld / %lld / %lld\n", 
+            ins_successes, del_successes, search_successes);
+    fprintf(stdout, "nodes allocated / freed / net = %lld / %lld / %lld.\n",
+            atomic_load(&(lfht.num_nodes_allocated)),
+            atomic_load(&(lfht.num_nodes_freed)),
+            (atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))));
+    fprintf(stdout, "lfsll_phys_len / fl_len / sum = %lld / %lld / %lld, lfsll_log_len = %lld.\n",
+            atomic_load(&(lfht.lfsll_phys_len)), atomic_load(&(lfht.fl_len)),
+            (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))),
+            atomic_load(&(lfht.lfsll_log_len)));
+#endif
+
+#if 0 /* JRM */
+    lfht_dump_list(&lfht, stdout);
+#endif /* JRM */
+
+#if 0 /* JRM */
+    lfht_dump_stats(&lfht, stdout);
+#endif /* JRM */
+
+    lfht_verify_list_lens(&lfht);
+
+    lfht_dump_interesting_stats(&lfht);
+
+    assert((atomic_load(&(lfht.num_nodes_allocated)) - atomic_load(&(lfht.num_nodes_freed))) ==
+           (atomic_load(&(lfht.lfsll_phys_len)) + atomic_load(&(lfht.fl_len))));
+
+    assert(ins_fails            == atomic_load(&(lfht.insertion_failures)));
+    assert(del_fails            == atomic_load(&(lfht.deletion_failures)));
+    assert(search_fails         == atomic_load(&(lfht.failed_searches)));
+    assert(search_by_val_fails  == atomic_load(&(lfht.failed_val_searches)));
+    assert(swap_val_fails       == atomic_load(&(lfht.failed_val_swaps)));
+
+    assert(ins_successes            == atomic_load(&(lfht.insertions)));
+    assert(del_successes            == (atomic_load(&(lfht.deletion_starts)) + 
+                                        atomic_load(&(lfht.deletion_start_cols))));
+    assert(search_successes         == atomic_load(&(lfht.successful_searches)));
+    assert(search_by_val_successes  == atomic_load(&(lfht.successful_val_searches)));
+    assert(swap_val_successes       == atomic_load(&(lfht.successful_val_swaps)));
+
+    assert(itter_inits == atomic_load(&(lfht.itter_inits)));
+    assert(itter_nexts == atomic_load(&(lfht.itter_nexts)));
+    assert(itter_ends  == atomic_load(&(lfht.itter_ends)));
+
+    /* lfht.lfsll_log_len and lfht.lfsll_phys_len will vary */
+
+    /* lfht.insertions & lfht.insertion_failures will vary */
+
+    /* lfht.lfht.ins_restarts_due_to_ins_col and lfht.lfht.ins_restarts_due_to_del_col will vary */
+
+    /* lfht.ins_deletion_completions and lfht.nodes_visited_during_ins will vary */
+
+    /* lfht.deletion_attempts will vary */
+
+    /* lfht.deletion_failures will vary */
+
+    assert( (ins_successes - atomic_load(&(lfht.lfsll_log_len))) == 
+            (atomic_load(&(lfht.ins_deletion_completions)) +
+             atomic_load(&(lfht.del_deletion_completions)) +
+             (atomic_load(&(lfht.lfsll_phys_len)) - 
+              atomic_load(&(lfht.lfsll_log_len)) - 
+              atomic_load(&(lfht.buckets_initialized)) - 1)) ); 
+
+    /* lfht.deletion_start_cols and lfht.del_restarts_due_to_del_col) will vary */
+    /* lfht.del_deletion_completions and lfht.nodes_visited_during_dels will vary */
+
+    /* lfht.searches, lfht.successful_searches and lfht.failed_searches will vary. */
+
+    assert(atomic_load(&(lfht.searches)) == (search_successes + search_fails));
+
+    /* lfht.marked_nodes_visited_in_succ_searches, lfht.unmarked_nodes_visited_in_succ_searches
+     * lfht.marked_nodes_visited_in_failed_searches, and 
+     * lfht.unmarked_nodes_visited_in_failed_searches will vary
+     */
+
+    assert((search_by_val_fails + search_by_val_successes) == atomic_load(&(lfht.value_searches)));
+
+    assert((swap_val_fails + swap_val_successes) == atomic_load(&(lfht.value_swaps)));
+
+    assert(nthreads == itter_inits);
+    /* number of itter_nexts varies */
+    assert(nthreads == itter_ends);
+
+    lfht_clear(&lfht);
+
+    fprintf(stdout, " Done. \n");
+
+    return;
+
+} /* lfht_mt_test_3() */
+
+#define RUN_LFSLL_TESTS 0
+
+int main()
+{
+    int i;
+    int nthreads = 8;
+#if LFHT__USE_SPTR
+    struct lfht_flsptr_t test = {NULL, 0x0ULL};
+    _Atomic struct lfht_flsptr_t atest;
+
+    atomic_init(&(atest), test);
+
+    fprintf(stdout, "atomic_is_lock_free(&atest) = %d\n", (int)atomic_is_lock_free(&atest));
+#endif /* LFHT__USE_SPTR */
+
+    lfht_hash_fcn_test();
+    lfht_hash_to_index_test();
+
+#if RUN_LFSLL_TESTS
+    lfht_lfsll_serial_test_1();
+    lfht_lfsll_serial_test_2();
+    lfht_lfsll_serial_test_3();
+#endif
+
+    lfht_serial_test_1();
+    lfht_serial_test_2();
+    lfht_serial_test_3();
+
+#if RUN_LFSLL_TESTS
+    lfht_lfsll_mt_test_fcn_1__serial_test();
+    lfht_lfsll_mt_test_fcn_2__serial_test();
+#endif
+
+    lfht_mt_test_fcn_1__serial_test();
+    lfht_mt_test_fcn_2__serial_test();
+#if 0
+    lfht_lfsll_mt_test_1(nthreads);
+    lfht_lfsll_mt_test_2(nthreads);
+    lfht_lfsll_mt_test_3(nthreads);
+    lfht_mt_test_1(1, nthreads);
+    lfht_mt_test_2(1, nthreads);
+    lfht_mt_test_3(1, nthreads);
+
+#else
+    for ( nthreads = 1; nthreads < 32; nthreads++ ) {
+
+#if RUN_LFSLL_TESTS
+        lfht_lfsll_mt_test_1(nthreads);
+        lfht_lfsll_mt_test_2(nthreads);
+        lfht_lfsll_mt_test_3(nthreads);
+#endif
+        for ( i = 0; i < 10; i++) {
+
+            lfht_mt_test_1(i, nthreads);
+            lfht_mt_test_2(i, nthreads);
+            lfht_mt_test_3(i, nthreads);
+        }
+    }
+#endif
+
+    fprintf(stdout, "\nLFHT tests complete.\n");
+
+    return(0);
+
+} /* main() */

--- a/hdf5/src/libhdf5.settings.in
+++ b/hdf5/src/libhdf5.settings.in
@@ -77,6 +77,7 @@ Dimension scales w/ new references: @DIMENSION_SCALES_WITH_NEW_REF@
                   Build HDF5 Tools: @HDF5_TOOLS@
                    Build GIF Tools: @HDF5_HL_GIF_TOOLS@
                       Threadsafety: @THREADSAFE@
+                       MultiThread: @MULTITHREAD@
                Default API mapping: @DEFAULT_API_VERSION@
     With deprecated public symbols: @DEPRECATED_SYMBOLS@
             I/O filters (external): @EXTERNAL_FILTERS@

--- a/hdf5/test/Makefile.am
+++ b/hdf5/test/Makefile.am
@@ -70,7 +70,7 @@ TEST_PROG= testhdf5 \
            enc_dec_plist_cross_platform getname vfd ros3 s3comms hdfs ntypes \
            dangle dtransform reserved cross_read freespace mf vds file_image \
            unregister cache_logging cork swmr thread_id vol timer event_set \
-		   onion
+           onion mt_id_test
 
 # List programs to be built when testing here
 #

--- a/hdf5/test/Makefile.in
+++ b/hdf5/test/Makefile.in
@@ -187,7 +187,7 @@ am__EXEEXT_1 = testhdf5$(EXEEXT) cache$(EXEEXT) cache_api$(EXEEXT) \
 	mf$(EXEEXT) vds$(EXEEXT) file_image$(EXEEXT) \
 	unregister$(EXEEXT) cache_logging$(EXEEXT) cork$(EXEEXT) \
 	swmr$(EXEEXT) thread_id$(EXEEXT) vol$(EXEEXT) timer$(EXEEXT) \
-	event_set$(EXEEXT) onion$(EXEEXT)
+	event_set$(EXEEXT) onion$(EXEEXT) mt_id_test$(EXEEXT)
 @HAVE_SHARED_CONDITIONAL_TRUE@am__EXEEXT_2 = filter_plugin$(EXEEXT) \
 @HAVE_SHARED_CONDITIONAL_TRUE@	vfd_plugin$(EXEEXT) \
 @HAVE_SHARED_CONDITIONAL_TRUE@	vol_plugin$(EXEEXT)
@@ -603,6 +603,10 @@ mount_SOURCES = mount.c
 mount_OBJECTS = mount.$(OBJEXT)
 mount_LDADD = $(LDADD)
 mount_DEPENDENCIES = libh5test.la $(LIBHDF5)
+mt_id_test_SOURCES = mt_id_test.c
+mt_id_test_OBJECTS = mt_id_test.$(OBJEXT)
+mt_id_test_LDADD = $(LDADD)
+mt_id_test_DEPENDENCIES = libh5test.la $(LIBHDF5)
 mtime_SOURCES = mtime.c
 mtime_OBJECTS = mtime.$(OBJEXT)
 mtime_LDADD = $(LDADD)
@@ -864,8 +868,9 @@ am__depfiles_remade = ./$(DEPDIR)/accum.Po \
 	./$(DEPDIR)/lheap.Po ./$(DEPDIR)/links.Po \
 	./$(DEPDIR)/links_env.Po ./$(DEPDIR)/mdset.Po \
 	./$(DEPDIR)/mf.Po ./$(DEPDIR)/mirror_vfd.Po \
-	./$(DEPDIR)/mount.Po ./$(DEPDIR)/mtime.Po \
-	./$(DEPDIR)/ntypes.Po ./$(DEPDIR)/null_vfd_plugin.Plo \
+	./$(DEPDIR)/mount.Po ./$(DEPDIR)/mt_id_test.Po \
+	./$(DEPDIR)/mtime.Po ./$(DEPDIR)/ntypes.Po \
+	./$(DEPDIR)/null_vfd_plugin.Plo \
 	./$(DEPDIR)/null_vol_connector.Plo ./$(DEPDIR)/objcopy.Po \
 	./$(DEPDIR)/objcopy_ref.Po ./$(DEPDIR)/ohdr.Po \
 	./$(DEPDIR)/onion.Po ./$(DEPDIR)/page_buffer.Po \
@@ -950,16 +955,16 @@ SOURCES = $(libfilter_plugin1_dsets_la_SOURCES) \
 	gen_nullspace.c gen_plist.c gen_sizes_lheap.c \
 	gen_specmetaread.c gen_udlinks.c getname.c gheap.c hdfs.c \
 	hyperslab.c istore.c lheap.c links.c links_env.c mdset.c mf.c \
-	$(mirror_vfd_SOURCES) mount.c mtime.c ntypes.c objcopy.c \
-	objcopy_ref.c ohdr.c onion.c page_buffer.c reserved.c ros3.c \
-	s3comms.c select_io_dset.c set_extent.c space_overflow.c \
-	stab.c swmr.c swmr_addrem_writer.c swmr_generator.c \
-	swmr_reader.c swmr_remove_reader.c swmr_remove_writer.c \
-	swmr_sparse_reader.c swmr_sparse_writer.c swmr_start_write.c \
-	swmr_writer.c tcheck_version.c $(testhdf5_SOURCES) testmeta.c \
-	thread_id.c timer.c $(ttsafe_SOURCES) twriteorder.c unlink.c \
-	unregister.c $(use_append_chunk_SOURCES) \
-	$(use_append_chunk_mirror_SOURCES) \
+	$(mirror_vfd_SOURCES) mount.c mt_id_test.c mtime.c ntypes.c \
+	objcopy.c objcopy_ref.c ohdr.c onion.c page_buffer.c \
+	reserved.c ros3.c s3comms.c select_io_dset.c set_extent.c \
+	space_overflow.c stab.c swmr.c swmr_addrem_writer.c \
+	swmr_generator.c swmr_reader.c swmr_remove_reader.c \
+	swmr_remove_writer.c swmr_sparse_reader.c swmr_sparse_writer.c \
+	swmr_start_write.c swmr_writer.c tcheck_version.c \
+	$(testhdf5_SOURCES) testmeta.c thread_id.c timer.c \
+	$(ttsafe_SOURCES) twriteorder.c unlink.c unregister.c \
+	$(use_append_chunk_SOURCES) $(use_append_chunk_mirror_SOURCES) \
 	$(use_append_mchunks_SOURCES) \
 	$(use_disable_mdc_flushes_SOURCES) vds.c vds_env.c \
 	vds_swmr_gen.c vds_swmr_reader.c vds_swmr_writer.c vfd.c \
@@ -989,16 +994,16 @@ DIST_SOURCES = $(am__libfilter_plugin1_dsets_la_SOURCES_DIST) \
 	gen_nullspace.c gen_plist.c gen_sizes_lheap.c \
 	gen_specmetaread.c gen_udlinks.c getname.c gheap.c hdfs.c \
 	hyperslab.c istore.c lheap.c links.c links_env.c mdset.c mf.c \
-	$(mirror_vfd_SOURCES) mount.c mtime.c ntypes.c objcopy.c \
-	objcopy_ref.c ohdr.c onion.c page_buffer.c reserved.c ros3.c \
-	s3comms.c select_io_dset.c set_extent.c space_overflow.c \
-	stab.c swmr.c swmr_addrem_writer.c swmr_generator.c \
-	swmr_reader.c swmr_remove_reader.c swmr_remove_writer.c \
-	swmr_sparse_reader.c swmr_sparse_writer.c swmr_start_write.c \
-	swmr_writer.c tcheck_version.c $(testhdf5_SOURCES) testmeta.c \
-	thread_id.c timer.c $(ttsafe_SOURCES) twriteorder.c unlink.c \
-	unregister.c $(use_append_chunk_SOURCES) \
-	$(use_append_chunk_mirror_SOURCES) \
+	$(mirror_vfd_SOURCES) mount.c mt_id_test.c mtime.c ntypes.c \
+	objcopy.c objcopy_ref.c ohdr.c onion.c page_buffer.c \
+	reserved.c ros3.c s3comms.c select_io_dset.c set_extent.c \
+	space_overflow.c stab.c swmr.c swmr_addrem_writer.c \
+	swmr_generator.c swmr_reader.c swmr_remove_reader.c \
+	swmr_remove_writer.c swmr_sparse_reader.c swmr_sparse_writer.c \
+	swmr_start_write.c swmr_writer.c tcheck_version.c \
+	$(testhdf5_SOURCES) testmeta.c thread_id.c timer.c \
+	$(ttsafe_SOURCES) twriteorder.c unlink.c unregister.c \
+	$(use_append_chunk_SOURCES) $(use_append_chunk_mirror_SOURCES) \
 	$(use_append_mchunks_SOURCES) \
 	$(use_disable_mdc_flushes_SOURCES) vds.c vds_env.c \
 	vds_swmr_gen.c vds_swmr_reader.c vds_swmr_writer.c vfd.c \
@@ -1739,7 +1744,7 @@ TEST_PROG = testhdf5 \
            enc_dec_plist_cross_platform getname vfd ros3 s3comms hdfs ntypes \
            dangle dtransform reserved cross_read freespace mf vds file_image \
            unregister cache_logging cork swmr thread_id vol timer event_set \
-		   onion
+           onion mt_id_test
 
 
 # These programs generate test files for the tests.  They don't need to be
@@ -2266,6 +2271,10 @@ mount$(EXEEXT): $(mount_OBJECTS) $(mount_DEPENDENCIES) $(EXTRA_mount_DEPENDENCIE
 	@rm -f mount$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(mount_OBJECTS) $(mount_LDADD) $(LIBS)
 
+mt_id_test$(EXEEXT): $(mt_id_test_OBJECTS) $(mt_id_test_DEPENDENCIES) $(EXTRA_mt_id_test_DEPENDENCIES) 
+	@rm -f mt_id_test$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(mt_id_test_OBJECTS) $(mt_id_test_LDADD) $(LIBS)
+
 mtime$(EXEEXT): $(mtime_OBJECTS) $(mtime_DEPENDENCIES) $(EXTRA_mtime_DEPENDENCIES) 
 	@rm -f mtime$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(mtime_OBJECTS) $(mtime_LDADD) $(LIBS)
@@ -2544,6 +2553,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mf.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mirror_vfd.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mount.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mt_id_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mtime.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ntypes.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/null_vfd_plugin.Plo@am__quote@ # am--include-marker
@@ -3347,6 +3357,13 @@ onion.log: onion$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+mt_id_test.log: mt_id_test$(EXEEXT)
+	@p='mt_id_test$(EXEEXT)'; \
+	b='mt_id_test'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 .sh.log:
 	@p='$<'; \
 	$(am__set_b); \
@@ -3528,6 +3545,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/mf.Po
 	-rm -f ./$(DEPDIR)/mirror_vfd.Po
 	-rm -f ./$(DEPDIR)/mount.Po
+	-rm -f ./$(DEPDIR)/mt_id_test.Po
 	-rm -f ./$(DEPDIR)/mtime.Po
 	-rm -f ./$(DEPDIR)/ntypes.Po
 	-rm -f ./$(DEPDIR)/null_vfd_plugin.Plo
@@ -3741,6 +3759,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/mf.Po
 	-rm -f ./$(DEPDIR)/mirror_vfd.Po
 	-rm -f ./$(DEPDIR)/mount.Po
+	-rm -f ./$(DEPDIR)/mt_id_test.Po
 	-rm -f ./$(DEPDIR)/mtime.Po
 	-rm -f ./$(DEPDIR)/ntypes.Po
 	-rm -f ./$(DEPDIR)/null_vfd_plugin.Plo

--- a/hdf5/test/mt_id_test.c
+++ b/hdf5/test/mt_id_test.c
@@ -1,0 +1,1884 @@
+#include "h5test.h"
+#include "H5Iprivate.h"
+
+#ifdef H5_HAVE_MULTITHREAD
+#include <stdatomic.h>
+
+#define ID_TYPE_T__TAG  0x1010
+
+typedef struct id_type_kernel_t {
+    hbool_t    in_progress;
+    hbool_t    created;
+    hbool_t    discarded;
+    int        type_id;
+} id_type_kernel_t;
+
+typedef struct id_type_t {
+    unsigned                 tag;
+    _Atomic id_type_kernel_t k;
+    hbool_t                  mt_safe;
+    _Atomic long long int    successful_clears;
+    _Atomic long long int    failed_clears;
+    _Atomic long long int    successful_destroys;
+    _Atomic long long int    failed_destroys;
+    H5I_free_t               free_func;
+} id_type_t;
+
+
+#define ID_OBJECT_T__TAG 0x2020
+
+typedef struct id_object_kernel_t {
+    hbool_t    in_progress;
+    hbool_t    allocated;
+    hbool_t    discarded;
+    hbool_t    future;
+    hid_t      id;
+} id_object_kernel_t;
+
+typedef struct id_object_t{
+    unsigned                   tag;
+    _Atomic id_object_kernel_t k;
+    _Atomic long long int      accesses;
+} id_object_t; 
+
+
+#define ID_INSTANCE_T__TAG 0x3030
+
+typedef struct id_instance_kernel_t {
+    hbool_t  in_progress;
+    hbool_t  created;
+    hbool_t  discarded;
+    hbool_t  future;
+    hbool_t  realized;
+    hid_t id;
+} id_instance_kernel_t;
+
+typedef struct id_instance_t {
+    unsigned                     tag;
+    _Atomic id_instance_kernel_t k;
+    _Atomic long long int        accesses;
+} id_instance_t;
+
+#define NUM_ID_TYPES            256
+#define NUM_ID_OBJECTS          (1024 * 1024)
+#define NUM_ID_INSTANCES        (1024 * 1024)
+
+#define MAX_NUM_THREADS         32
+
+/***********************************************************************************
+ *
+ * struct mt_test_params_t
+ *
+ * Structure used to pass control information into and results out of H5I
+ * multi-thread test functions.  The individual fields in this structure are
+ * discussed below.
+ *
+ * types_start: Index of the initial entry in the types_array.
+ *
+ * types_count: Number of instance in the types_array to use.
+ *
+ * types_stride: Increment between entries used in the types_arry.
+ *
+ * ids_start:  Index of the initial entry in the id_instance_array.
+ *
+ * ids_count: Number of instance in the id_instance_array to use.
+ *
+ * ids_stride: Increment between entries used in the id_instance_array.
+ *
+ * objects_start: Index of the initial entry in the objects_array.
+ *
+ * objects_count: Number of instances in the objects_array to use.
+ *
+ * objects_stride: Increment between entries used in the objects_array.
+ *
+ *
+ ***********************************************************************************/
+
+typedef struct mt_test_params_t {
+
+    int types_start;
+    int types_count;
+    int types_stride;
+
+    int ids_start;
+    int ids_count;
+    int ids_stride;
+
+    int objects_start;
+    int objects_count;
+    int objects_stride;
+
+} mt_test_params_t;
+
+id_type_t     types_array[NUM_ID_TYPES];
+id_object_t   objects_array[NUM_ID_OBJECTS];
+id_instance_t id_instance_array[NUM_ID_INSTANCES];
+
+void    init_globals(void);
+void    reset_globals(void);
+herr_t  free_func(void * obj, void ** request);
+hbool_t register_type(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds);
+hbool_t clear_type(id_type_t * id_type_ptr, hbool_t force, hbool_t cs, hbool_t ds);
+hbool_t destroy_type(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds);
+hbool_t register_id(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                    hbool_t cs, hbool_t ds);
+hbool_t object_verify(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                      hbool_t cs, hbool_t ds);
+hbool_t get_type(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, hbool_t cs, hbool_t ds);
+hbool_t remove_verify(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                      hbool_t cs, hbool_t ds);
+hbool_t dec_ref(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                hbool_t cs, hbool_t ds);
+hbool_t inc_ref(id_instance_t * id_inst_ptr, hbool_t cs, hbool_t ds);
+int     get_ref(id_instance_t * id_inst_ptr, hbool_t cs, hbool_t ds);
+int     nmembers(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds);
+htri_t  type_exists(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds);
+hbool_t inc_type_ref(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds);
+hbool_t dec_type_ref(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds);
+
+
+void create_types(int types_start, int types_count, int types_stride);
+void dec_type_refs(int types_start, int types_count, int types_stride);
+void inc_type_refs(int types_start, int types_count, int types_stride);
+void destroy_types(int types_start, int types_count, int types_stride);
+
+void register_ids(int types_start, int types_count, int types_stride, int ids_start, int ids_count, int ids_stride);
+void dec_refs(int types_start, int types_count, int types_stride, int ids_start, int ids_count, int ids_stride);
+void inc_refs(int ids_start, int ids_count, int ids_stride);
+void verify_objects(int types_start, int types_count, int types_stride, int ids_start, int ids_count, 
+                    int ids_stride);
+
+
+void serial_test_1(void);
+void serial_test_2(int types_start, int types_count, int ids_start, int ids_count);
+void serial_test_3(void);
+
+void * mt_test_fcn_1(void * params);
+
+void mt_test_fcn_1_serial_test(void);
+void mt_test_1(int num_threads);
+
+void init_globals(void)
+{
+    int i;
+    struct id_type_kernel_t     type_k  = {FALSE, FALSE, FALSE, 0};
+    struct id_object_kernel_t   obj_k   = {FALSE, FALSE, FALSE, FALSE, 0};
+    struct id_instance_kernel_t inst_k  = {FALSE, FALSE, FALSE, FALSE, FALSE, 0};
+
+    for ( i = 0; i < NUM_ID_TYPES; i++ )
+    {
+        types_array[i].tag = ID_TYPE_T__TAG;
+        atomic_init(&(types_array[i].k), type_k);
+        types_array[i].mt_safe = FALSE;
+        atomic_init(&(types_array[i].successful_clears), 0ULL);
+        atomic_init(&(types_array[i].failed_clears), 0ULL);
+        atomic_init(&(types_array[i].successful_destroys), 0ULL);
+        atomic_init(&(types_array[i].failed_destroys), 0ULL);
+        types_array[i].free_func = free_func;
+    }
+
+    for ( i = 0; i < NUM_ID_OBJECTS; i++ )
+    {
+        objects_array[i].tag = ID_OBJECT_T__TAG;
+        atomic_init(&(objects_array[i].k), obj_k);
+        atomic_init(&(objects_array[i].accesses), 0ULL);
+    }
+
+    for ( i = 0; i < NUM_ID_INSTANCES; i++ )
+    {
+        id_instance_array[i].tag = ID_INSTANCE_T__TAG;
+        atomic_init(&(id_instance_array[i].k), inst_k);
+        atomic_init(&(id_instance_array[i].accesses), 0ULL);
+    }
+
+    return;
+
+} /* init_globals() */
+
+void reset_globals(void)
+{
+    int i;
+    struct id_type_kernel_t     type_k  = {FALSE, FALSE, FALSE, 0};
+    struct id_object_kernel_t   obj_k   = {FALSE, FALSE, FALSE, FALSE, 0};
+    struct id_instance_kernel_t inst_k  = {FALSE, FALSE, FALSE, FALSE, FALSE, 0};
+
+    for ( i = 0; i < NUM_ID_TYPES; i++ )
+    {
+        types_array[i].tag = ID_TYPE_T__TAG;
+        atomic_store(&(types_array[i].k), type_k);
+        types_array[i].mt_safe = FALSE;
+        atomic_store(&(types_array[i].successful_clears), 0ULL);
+        atomic_store(&(types_array[i].failed_clears), 0ULL);
+        atomic_store(&(types_array[i].successful_destroys), 0ULL);
+        atomic_store(&(types_array[i].failed_destroys), 0ULL);
+        types_array[i].free_func = free_func;
+    }
+
+    for ( i = 0; i < NUM_ID_OBJECTS; i++ )
+    {
+        objects_array[i].tag = ID_OBJECT_T__TAG;
+        atomic_store(&(objects_array[i].k), obj_k);
+        atomic_store(&(objects_array[i].accesses), 0ULL);
+    }
+
+    for ( i = 0; i < NUM_ID_INSTANCES; i++ )
+    {
+        id_instance_array[i].tag = ID_INSTANCE_T__TAG;
+        atomic_store(&(id_instance_array[i].k), inst_k);
+        atomic_store(&(id_instance_array[i].accesses), 0ULL);
+    }
+
+    return;
+
+} /* reset_globals() */
+
+herr_t free_func(void * obj, void ** request)
+{
+    id_object_t * object_ptr = (id_object_t *)obj;
+    id_object_kernel_t obj_k;
+    id_object_kernel_t mod_obj_k;
+
+    assert(object_ptr);
+
+    assert(ID_OBJECT_T__TAG == object_ptr->tag);
+
+    obj_k = atomic_load(&(object_ptr->k));
+    
+    assert(obj_k.allocated);
+    assert(!obj_k.discarded);
+    assert(!obj_k.future);
+
+    mod_obj_k.allocated = obj_k.allocated;
+    mod_obj_k.discarded = TRUE;
+    mod_obj_k.future    = obj_k.future;
+    mod_obj_k.id        = obj_k.id;
+
+    
+    if ( atomic_compare_exchange_strong(&(object_ptr->k), &obj_k, mod_obj_k ) ) {
+
+        return(SUCCEED);
+
+    } else {
+
+        return(FAIL);
+    }
+} /* free_func() */
+
+
+hbool_t register_type(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t          success = TRUE; /* will set to FALSE on failure */
+    int              type_id;
+    id_type_kernel_t id_k;
+    id_type_kernel_t mod_id_k;
+
+    assert(id_type_ptr);
+
+    assert( ID_TYPE_T__TAG == id_type_ptr->tag );
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_k = atomic_load(&(id_type_ptr->k));
+
+    if ( ( id_k.in_progress ) || ( id_k.created ) ) {
+
+        success = FALSE; /* another thread beat us to it */
+
+    } else {
+
+        mod_id_k.in_progress = TRUE;
+        mod_id_k.created     = id_k.created;
+        mod_id_k.discarded   = id_k.discarded;
+        mod_id_k.type_id     = id_k.type_id;
+    }
+
+    if ( success ) {
+
+        if ( ! atomic_compare_exchange_strong(&(id_type_ptr->k), &id_k, mod_id_k) ) {
+
+            success = FALSE; /* another thread beat us to it */
+
+        } else {
+
+            /* get fresh copy of the type kernel */
+            id_k = atomic_load(&(id_type_ptr->k));
+        }
+    }
+
+    if ( success ) {
+
+        type_id = (int)H5Iregister_type((size_t)0, 0, id_type_ptr->free_func);
+
+        if ( H5I_BADID == type_id ) {
+
+            mod_id_k.in_progress = FALSE;
+            mod_id_k.created     = id_k.created;
+            mod_id_k.discarded   = id_k.discarded;
+            mod_id_k.type_id     = id_k.type_id;
+
+            success = FALSE;
+
+        } else {
+
+            mod_id_k.in_progress = FALSE;
+            mod_id_k.created     = TRUE;
+            mod_id_k.discarded   = id_k.discarded;
+            mod_id_k.type_id     = type_id;
+        }
+
+        assert(atomic_compare_exchange_strong(&(id_type_ptr->k), &id_k, mod_id_k));
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iregister_type");
+    }
+
+    return(success);
+
+} /* register_type() */
+
+
+hbool_t clear_type(id_type_t * id_type_ptr, hbool_t force, hbool_t cs, hbool_t ds)
+{
+    hbool_t             success = TRUE; /* will set to FALSE on failure */
+    id_type_kernel_t id_k;
+
+    assert(id_type_ptr);
+
+    assert( ID_TYPE_T__TAG == id_type_ptr->tag );
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_k = atomic_load(&(id_type_ptr->k));
+
+    if ( ( id_k.in_progress ) || ( ! id_k.created ) || ( id_k.discarded ) ) { 
+
+        success = FALSE; 
+    }
+
+    if ( success ) {
+
+        if ( H5Iclear_type((H5I_type_t)(id_k.type_id), force) != SUCCEED ) {
+
+            success = FALSE;
+            atomic_fetch_add(&(id_type_ptr->failed_clears), 1ULL);
+
+        } else {
+
+            atomic_fetch_add(&(id_type_ptr->successful_clears), 1ULL);
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iclear_type");
+    }
+
+    return(success);
+
+} /* clear_type() */
+
+
+hbool_t destroy_type(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t          success = TRUE; /* will set to FALSE on failure */
+    hbool_t          destroy_succeeded;
+    id_type_kernel_t id_k;
+    id_type_kernel_t mod_id_k;
+
+    assert(id_type_ptr);
+
+    assert( ID_TYPE_T__TAG == id_type_ptr->tag );
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_k = atomic_load(&(id_type_ptr->k));
+
+    assert( ID_TYPE_T__TAG == id_type_ptr->tag );
+
+    if ( ( id_k.in_progress ) || ( ! id_k.created ) || ( id_k.discarded ) ) { 
+
+        success = FALSE; 
+    }
+
+    if ( success ) {
+
+        if ( H5Idestroy_type((H5I_type_t)(id_k.type_id)) != SUCCEED ) {
+
+            success = FALSE;
+            destroy_succeeded = FALSE;
+            atomic_fetch_add(&(id_type_ptr->failed_destroys), 1ULL);
+
+        } else {
+
+            destroy_succeeded = TRUE;
+            atomic_fetch_add(&(id_type_ptr->successful_destroys), 1ULL);
+        }
+
+        if ( destroy_succeeded ) { /* set the discarded flag */
+
+            id_k = atomic_load(&(id_type_ptr->k));
+
+            while ( ! id_k.discarded ) {
+
+                mod_id_k.in_progress = id_k.in_progress;
+                mod_id_k.created     = id_k.created;
+                mod_id_k.discarded   = TRUE;
+                mod_id_k.type_id     = 0;
+
+                atomic_compare_exchange_strong(&(id_type_ptr->k), &id_k, mod_id_k);
+
+                id_k = atomic_load(&(id_type_ptr->k));
+            }
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Idestroy_type");
+    }
+
+    return(success);
+
+} /* destroy_type() */
+
+hbool_t register_id(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                    hbool_t cs, hbool_t ds)
+{
+    hbool_t success = TRUE; /* will set to FALSE on failure */
+    H5I_type_t           type;
+    hid_t                id;
+    id_type_kernel_t     id_type_k;
+    id_instance_kernel_t id_inst_k;
+    id_instance_kernel_t mod_id_inst_k;
+    id_object_kernel_t   id_obj_k;
+    id_object_kernel_t   mod_id_obj_k;
+
+    assert(id_type_ptr);
+    assert(id_inst_ptr);
+    assert(id_obj_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+    assert(ID_INSTANCE_T__TAG == id_inst_ptr->tag);
+    assert(ID_OBJECT_T__TAG == id_obj_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+    id_inst_k = atomic_load(&(id_inst_ptr->k));
+    id_obj_k  = atomic_load(&(id_obj_ptr->k));
+
+    if ( ( id_type_k.in_progress) || ( ! id_type_k.created ) || ( id_type_k.discarded ) ) {
+
+        success = FALSE;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( success )
+    {
+        if ( ( id_inst_k.in_progress ) || ( id_inst_k.created ) || ( id_inst_k.discarded ) ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( success )
+    {
+        if ( ( id_obj_k.in_progress ) || ( id_obj_k.allocated ) || ( id_obj_k.discarded ) ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( success ) {
+
+        mod_id_inst_k.in_progress = TRUE;
+        mod_id_inst_k.created     = id_inst_k.created;
+        mod_id_inst_k.discarded   = id_inst_k.discarded;
+        mod_id_inst_k.future      = id_inst_k.future;
+        mod_id_inst_k.realized    = id_inst_k.realized;
+        mod_id_inst_k.id          = id_inst_k.id;
+
+        if ( ! atomic_compare_exchange_strong(&(id_inst_ptr->k), &id_inst_k, mod_id_inst_k) ) {
+
+            success = FALSE;
+
+        } else {
+
+            id_inst_k = atomic_load(&(id_inst_ptr->k)); /* get fresh copy */
+        }
+    }
+
+    if ( success ) { 
+
+        mod_id_obj_k.in_progress = TRUE;
+        mod_id_obj_k.allocated   = id_obj_k.allocated;
+        mod_id_obj_k.discarded   = id_obj_k.discarded;
+        mod_id_obj_k.future      = id_obj_k.future;
+        mod_id_obj_k.id          = id_obj_k.id;
+        
+        if ( ! atomic_compare_exchange_strong(&(id_obj_ptr->k), &id_obj_k, mod_id_obj_k) ) {
+
+            success = FALSE;
+
+            /* in progress flag is set in id_inst_ptr->k.  Must reset it */
+            mod_id_inst_k.in_progress = FALSE;
+            mod_id_inst_k.created     = id_inst_k.created;
+            mod_id_inst_k.discarded   = id_inst_k.discarded;
+            mod_id_inst_k.future      = id_inst_k.future;
+            mod_id_inst_k.realized    = id_inst_k.realized;
+            mod_id_inst_k.id          = id_inst_k.id;
+
+            assert(atomic_compare_exchange_strong(&(id_inst_ptr->k), &id_inst_k, mod_id_inst_k));
+
+        } else {
+
+            id_obj_k  = atomic_load(&(id_obj_ptr->k));
+        }
+    }
+
+    if ( success ) {
+
+        mod_id_inst_k.in_progress = FALSE;
+        mod_id_inst_k.created     = id_inst_k.created;
+        mod_id_inst_k.discarded   = id_inst_k.discarded;
+        mod_id_inst_k.future      = id_inst_k.future;
+        mod_id_inst_k.realized    = id_inst_k.realized;
+        mod_id_inst_k.id          = id_inst_k.id;
+
+        mod_id_obj_k.in_progress = FALSE;
+        mod_id_obj_k.allocated   = id_obj_k.allocated;
+        mod_id_obj_k.discarded   = id_obj_k.discarded;
+        mod_id_obj_k.future      = id_obj_k.future;
+        mod_id_obj_k.id          = id_obj_k.id;
+
+        id = H5Iregister(type, (void *)id_obj_ptr);
+
+        if ( id != H5I_INVALID_HID ) { 
+
+            mod_id_inst_k.created = TRUE;
+            mod_id_inst_k.id      = id;
+
+            mod_id_obj_k.allocated   = TRUE;
+            mod_id_obj_k.id          = id;
+
+        } else {
+
+            success = FALSE;
+        } 
+
+        assert(atomic_compare_exchange_strong(&(id_obj_ptr->k), &id_obj_k, mod_id_obj_k));
+        assert(atomic_compare_exchange_strong(&(id_inst_ptr->k), &id_inst_k, mod_id_inst_k));
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iregister");
+    }
+
+    return(success);
+
+} /* register_id() */ 
+
+hbool_t object_verify(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                      hbool_t cs, hbool_t ds)
+{
+    hbool_t success = TRUE; /* will set to FALSE on failure */
+    H5I_type_t           type;
+    hid_t                id;
+    id_type_kernel_t     id_type_k;
+    id_instance_kernel_t id_inst_k;
+    id_object_kernel_t   id_obj_k;
+
+    assert(id_type_ptr);
+    assert(id_inst_ptr);
+    assert(id_obj_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+    assert(ID_INSTANCE_T__TAG == id_inst_ptr->tag);
+    assert(ID_OBJECT_T__TAG == id_obj_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+    id_inst_k = atomic_load(&(id_inst_ptr->k));
+    id_obj_k  = atomic_load(&(id_obj_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        success = FALSE;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( success )
+    {
+        if ( ! id_inst_k.created ) {
+
+            success = FALSE;
+
+        } else {
+
+            id = id_inst_k.id;
+        }
+    }
+
+    if ( success )
+    {
+        if ( ! id_obj_k.allocated ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( success ) {
+
+        if ( (void *)id_obj_ptr != H5Iobject_verify(id, type) ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iobject_verify");
+    }
+
+    return(success);
+
+} /* object_verify() */
+
+hbool_t get_type(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t success = TRUE; /* will set to FALSE on failure */
+    H5I_type_t           type;
+    hid_t                id;
+    id_type_kernel_t     id_type_k;
+    id_instance_kernel_t id_inst_k;
+
+    assert(id_type_ptr);
+    assert(id_inst_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+    assert(ID_INSTANCE_T__TAG == id_inst_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+    id_inst_k = atomic_load(&(id_inst_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        success = FALSE;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( success )
+    {
+        if ( ! id_inst_k.created ) {
+
+            success = FALSE;
+
+        } else {
+
+            id = id_inst_k.id;
+        }
+    }
+
+    if ( success ) {
+
+        if ( type != H5Iget_type(id) ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iget_type");
+    }
+
+    return(success);
+
+} /* get_type() */
+
+hbool_t remove_verify(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                      hbool_t cs, hbool_t ds)
+{
+    hbool_t success = TRUE; /* will set to FALSE on failure */
+    H5I_type_t           type;
+    hid_t                id;
+    id_type_kernel_t     id_type_k;
+    id_instance_kernel_t id_inst_k;
+    id_instance_kernel_t mod_id_inst_k;
+    id_object_kernel_t   id_obj_k;
+    id_object_kernel_t   mod_id_obj_k;
+
+    assert(id_type_ptr);
+    assert(id_inst_ptr);
+    assert(id_obj_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+    assert(ID_INSTANCE_T__TAG == id_inst_ptr->tag);
+    assert(ID_OBJECT_T__TAG == id_obj_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+    id_inst_k = atomic_load(&(id_inst_ptr->k));
+    id_obj_k = atomic_load(&(id_obj_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        success = FALSE;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( success )
+    {
+        if ( ! id_inst_k.created ) {
+
+            success = FALSE;
+
+        } else {
+
+            id = id_inst_k.id;
+        }
+    }
+
+    if ( success )
+    {
+        if ( ! id_obj_k.allocated ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( success ) {
+
+        if ( (void *)id_obj_ptr != H5Iremove_verify(id, type) ) {
+
+            success = FALSE;
+
+        } else {
+
+            id_obj_k  = atomic_load(&(id_obj_ptr->k));
+
+            assert( id_obj_k.id == id );
+        }
+    }
+
+    if ( success ) { /* must mark *id_inst_ptr as discarded */
+
+        assert( ! id_inst_k.discarded );
+
+        assert( ! id_obj_k.discarded );
+
+        /* mark *id_inst_k as discarded */
+        while ( ! id_inst_k.discarded ) {
+
+            mod_id_inst_k.in_progress = id_inst_k.in_progress;
+            mod_id_inst_k.created     = id_inst_k.created;
+            mod_id_inst_k.discarded   = TRUE;
+            mod_id_inst_k.future      = id_inst_k.future;
+            mod_id_inst_k.realized    = id_inst_k.realized;
+            mod_id_inst_k.id          = id_inst_k.id;
+
+            atomic_compare_exchange_strong(&(id_inst_ptr->k), &id_inst_k, mod_id_inst_k);
+
+            id_inst_k = atomic_load(&(id_inst_ptr->k));
+        }
+
+        /* for whatever reason, H5Iremove_verify() doesn't call the free routine 
+         * for objects in the index.  Thus we should set the discarded flag on 
+         * the object so we can detect other calls to the free function.
+         */
+        while ( ! id_obj_k.discarded ) {
+
+            mod_id_obj_k.in_progress = id_obj_k.in_progress;
+            mod_id_obj_k.allocated   = id_obj_k.allocated;
+            mod_id_obj_k.discarded   = TRUE;
+            mod_id_obj_k.future      = id_obj_k.future;
+            mod_id_obj_k.id          = id_obj_k.id;
+
+            atomic_compare_exchange_strong(&(id_obj_ptr->k), &id_obj_k, mod_id_obj_k);
+
+            id_obj_k = atomic_load(&(id_obj_ptr->k));
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iremove_verify");
+    }
+
+    return(success);
+
+} /* remove_verify() */
+
+hbool_t dec_ref(id_type_t * id_type_ptr, id_instance_t * id_inst_ptr, id_object_t * id_obj_ptr, 
+                hbool_t cs, hbool_t ds)
+{
+    hbool_t success = TRUE; /* will set to FALSE on failure */
+    hid_t                id;
+    int                  ref_count;
+    id_type_kernel_t     id_type_k;
+    id_instance_kernel_t id_inst_k;
+    id_instance_kernel_t mod_id_inst_k;
+    id_object_kernel_t   id_obj_k;
+
+    assert(id_type_ptr);
+    assert(id_inst_ptr);
+    assert(id_obj_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+    assert(ID_INSTANCE_T__TAG == id_inst_ptr->tag);
+    assert(ID_OBJECT_T__TAG == id_obj_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+    id_inst_k = atomic_load(&(id_inst_ptr->k));
+    id_obj_k = atomic_load(&(id_obj_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        success = FALSE;
+    } 
+
+    if ( success )
+    {
+        if ( ! id_inst_k.created ) {
+
+            success = FALSE;
+
+        } else {
+
+            id = id_inst_k.id;
+        }
+    }
+
+    if ( success )
+    {
+        if ( ! id_obj_k.allocated ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( success ) {
+
+        ref_count = H5Idec_ref(id);
+
+        if ( ref_count < 0 ) {
+
+            success = FALSE;
+
+        } else if ( 0 == ref_count ) {
+
+            id_obj_k = atomic_load(&(id_obj_ptr->k));
+
+            assert(id_obj_k.discarded);
+
+            /* mark *id_inst_k as discarded */
+            while ( ! id_inst_k.discarded ) {
+
+                mod_id_inst_k.in_progress = id_inst_k.in_progress;
+                mod_id_inst_k.created     = id_inst_k.created;
+                mod_id_inst_k.discarded   = TRUE;
+                mod_id_inst_k.future      = id_inst_k.future;
+                mod_id_inst_k.realized    = id_inst_k.realized;
+                mod_id_inst_k.id          = id_inst_k.id;
+
+                atomic_compare_exchange_strong(&(id_inst_ptr->k), &id_inst_k, mod_id_inst_k);
+
+                id_inst_k = atomic_load(&(id_inst_ptr->k));
+            }
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Idec_ref");
+    }
+
+    return(success);
+
+} /* dec_ref()() */
+
+
+hbool_t inc_ref(id_instance_t * id_inst_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t success = TRUE; /* will set to FALSE on failure */
+    hid_t                id;
+    int                  ref_count;
+    id_instance_kernel_t id_inst_k;
+
+    assert(id_inst_ptr);
+
+    assert(ID_INSTANCE_T__TAG == id_inst_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_inst_k = atomic_load(&(id_inst_ptr->k));
+
+    if ( ! id_inst_k.created ) {
+
+        success = FALSE;
+
+    } else {
+
+            id = id_inst_k.id;
+    }
+
+    if ( success ) {
+
+        ref_count = H5Iinc_ref(id);
+
+        if ( ref_count < 0 ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iinc_ref");
+    }
+
+    return(success);
+
+} /* inc_ref()() */
+
+int get_ref(id_instance_t * id_inst_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t              success = TRUE; /* will set to FALSE on failure */
+    hid_t                id;
+    int                  ref_count;
+    id_instance_kernel_t id_inst_k;
+
+    assert(id_inst_ptr);
+
+    assert(ID_INSTANCE_T__TAG == id_inst_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_inst_k = atomic_load(&(id_inst_ptr->k));
+
+    if ( ! id_inst_k.created ) {
+
+        success = FALSE;
+        ref_count = -1;
+
+    } else {
+
+        id = id_inst_k.id;
+    }
+
+    if ( success ) {
+
+        ref_count = H5Iget_ref(id);
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iget_ref");
+    }
+
+    return(ref_count);
+
+} /* get_ref()() */
+
+int nmembers(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t              success = TRUE; /* will set to FALSE on failure */
+    hsize_t              num_members;
+    H5I_type_t           type;
+    id_type_kernel_t     id_type_k;
+
+    assert(id_type_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        success = FALSE;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( success ) {
+
+        if ( H5Inmembers(type, &num_members) != SUCCEED ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "nmembers");
+    }
+
+    if ( success ) {
+
+        return((int)num_members);
+
+    } else {
+
+        return(-1);
+    }
+
+} /* nmembers() */
+
+htri_t type_exists(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds)
+{
+    htri_t               result = TRUE; /* will set to FAIL on failure */
+    H5I_type_t           type;
+    id_type_kernel_t     id_type_k;
+
+    assert(id_type_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        result = FAIL;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( result == TRUE ) {
+
+        result = H5Itype_exists(type);
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Itype_exists");
+    }
+
+    return(result);
+
+} /* type_exists() */
+
+hbool_t inc_type_ref(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t              success = TRUE; /* will set to FAIL on failure */
+    int                  ref_count;
+    H5I_type_t           type;
+    id_type_kernel_t     id_type_k;
+
+    assert(id_type_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        success = FALSE;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( success ) {
+
+        ref_count = H5Iinc_type_ref(type);
+
+        if ( ref_count == -1 ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Iinc_type_ref");
+    }
+
+    return(success);
+
+} /* inc_type_ref() */
+
+hbool_t dec_type_ref(id_type_t * id_type_ptr, hbool_t cs, hbool_t ds)
+{
+    hbool_t              success = TRUE; /* will set to FAIL on failure */
+    herr_t               ref_count;
+    H5I_type_t           type;
+    id_type_kernel_t     id_type_k;
+
+    assert(id_type_ptr);
+
+    assert(ID_TYPE_T__TAG == id_type_ptr->tag);
+
+    if ( cs ) {
+
+        H5I_clear_stats();
+    }
+
+    id_type_k = atomic_load(&(id_type_ptr->k));
+
+    if ( ! id_type_k.created ) {
+
+        success = FALSE;
+
+    } else {
+
+        type = (H5I_type_t)id_type_k.type_id;
+    } 
+
+    if ( success ) {
+
+        ref_count = H5Idec_type_ref(type);
+
+        if ( ref_count == -1 ) {
+
+            success = FALSE;
+        }
+    }
+
+    if ( ds ) {
+
+        H5I_dump_nz_stats(stdout, "H5Idec_type_ref");
+    }
+
+    return(success);
+
+} /* dec_type_ref() */
+
+void create_types(int types_start, int types_count, int types_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+
+    for ( i = types_start; i < types_start + (types_count * types_stride); i += types_stride ) {
+
+        assert(i >= 0);
+        assert(i < NUM_ID_TYPES);
+        assert(register_type(&(types_array[i]), cs, ds));
+    }
+
+    return;
+
+} /* create_types() */
+
+void dec_type_refs(int types_start, int types_count, int types_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+
+    for ( i = types_start; i < types_start + (types_count * types_stride); i += types_stride ) {
+
+        assert(i >= 0);
+        assert(i < NUM_ID_TYPES);
+        assert(dec_type_ref(&(types_array[i]), cs, ds));
+    }
+
+    return;
+
+} /* dec_type_refs() */
+
+void inc_type_refs(int types_start, int types_count, int types_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+
+    for ( i = types_start; i < types_start + (types_count * types_stride); i += types_stride ) {
+
+        assert(i >= 0);
+        assert(i < NUM_ID_TYPES);
+        assert(inc_type_ref(&(types_array[i]), cs, ds));
+    }
+
+    return;
+
+} /* inc_type_refs() */
+
+void destroy_types(int types_start, int types_count, int types_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+
+    for ( i = types_start; i < types_start + (types_count * types_stride); i += types_stride ) {
+
+        assert(i >= 0);
+        assert(i < NUM_ID_TYPES);
+        assert(destroy_type(&(types_array[i]), cs, ds));
+    }
+
+    return;
+
+} /* create_types() */
+
+void register_ids(int types_start, int types_count, int types_stride, int ids_start, int ids_count, int ids_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+    int j;
+    int k;
+
+    for ( j = ids_start, k = 0; j < ids_start + (ids_count * ids_stride); j++, k = (k + 1) % types_count ) {
+
+        assert( k >= 0);
+        assert( k < types_stride);
+        i = types_start + (k * types_stride);
+        assert( i >= types_start );
+        assert( i < types_start + (types_count * types_stride) );
+
+        assert(register_id(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+    }
+
+    return;
+
+} /* register_ids() */
+
+void dec_refs(int types_start, int types_count, int types_stride, int ids_start, int ids_count, int ids_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+    int j;
+    int k;
+
+    for ( j = ids_start, k = 0; 
+          j < ids_start + (ids_count * ids_stride); 
+          j += ids_stride, k = (k + 1) % types_count ) {
+
+        assert( k >= 0);
+        assert( k < types_stride);
+        i = types_start + (k * types_stride);
+        assert( i >= types_start );
+        assert( i < types_start + (types_count * types_stride) );
+
+        assert(dec_ref(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+    }
+
+    return;
+
+} /* inc_refs_ids() */
+
+void inc_refs(int ids_start, int ids_count, int ids_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int j;
+
+    for ( j = ids_start; j < ids_start + (ids_count * ids_stride); j += ids_stride ) {
+
+        assert(inc_ref(&(id_instance_array[j]), cs, ds));
+    }
+
+    return;
+
+} /* inc_refs_ids() */
+
+void verify_objects(int types_start, int types_count, int types_stride, int ids_start, int ids_count, int ids_stride)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+    int j;
+    int k;
+
+    for ( j = ids_start, k = 0; 
+          j < ids_start + (ids_count * ids_stride); 
+          j += ids_stride, k = (k + 1) % types_count ) {
+
+        assert( k >= 0);
+        assert( k < types_stride);
+        i = types_start + (k * types_stride);
+        assert( i >= types_start );
+        assert( i < types_start + (types_count * types_stride) );
+
+        assert(object_verify(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+    }
+
+    return;
+
+} /* verify_objects() */
+
+
+/*******************************************************************************************
+'*
+ * serial_test_1
+ *
+ * Quick smoke check for the test wrappers on most of the H5I public API calls.
+ *
+ *******************************************************************************************/
+
+void serial_test_1(void)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+    int j;
+    int k;
+    int l;
+    int m;
+
+    fprintf(stdout, "\n running serial test #1 ... ");
+
+    assert(H5open() >= 0 );
+
+    for ( i = 0; i < NUM_ID_TYPES; i++ ) {
+#if 0
+        if ( 1 == i || 2 == i ) {
+
+            cs = TRUE;
+            ds = TRUE;
+
+        } else {
+
+            cs = FALSE;
+            ds = FALSE;
+        }
+#endif
+        j = i + NUM_ID_TYPES;
+        k = j + NUM_ID_TYPES;
+        l = k + NUM_ID_TYPES;
+        m = l + NUM_ID_TYPES;
+
+        if ( ds ) {
+
+            fprintf(stdout, "\ni/j/k/l/m = %d/%d/%d/%d/%d\n\n", i, j, k, l, m);
+        }
+
+        assert(register_type(&(types_array[i]), cs, ds));
+
+        assert(register_id(&(types_array[i]), &(id_instance_array[i]), &(objects_array[i]), cs, ds));
+
+        assert(object_verify(&(types_array[i]), &(id_instance_array[i]), &(objects_array[i]), cs, ds));
+
+        assert(get_type(&(types_array[i]), &(id_instance_array[i]), cs, ds));
+
+        assert(remove_verify(&(types_array[i]), &(id_instance_array[i]), &(objects_array[i]), cs, ds));
+
+        assert(register_id(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+        assert(register_id(&(types_array[i]), &(id_instance_array[k]), &(objects_array[k]), cs, ds));
+        assert(1 == get_ref(&(id_instance_array[j]), cs, ds));
+        assert(1 == get_ref(&(id_instance_array[k]), cs, ds));
+        assert(inc_ref(&(id_instance_array[j]), cs, ds));
+        assert(inc_ref(&(id_instance_array[k]), cs, ds));
+        assert(2 == get_ref(&(id_instance_array[j]), cs, ds));
+        assert(2 == get_ref(&(id_instance_array[k]), cs, ds));
+        assert(dec_ref(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+        assert(1 == get_ref(&(id_instance_array[j]), cs, ds));
+        assert(dec_ref(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+
+        assert(1 == nmembers(&(types_array[i]), cs, ds));
+
+        assert(register_id(&(types_array[i]), &(id_instance_array[l]), &(objects_array[l]), cs, ds));
+        assert(register_id(&(types_array[i]), &(id_instance_array[m]), &(objects_array[m]), cs, ds));
+        assert(1 == get_ref(&(id_instance_array[l]), cs, ds));
+        assert(1 == get_ref(&(id_instance_array[m]), cs, ds));
+        assert(inc_ref(&(id_instance_array[l]), cs, ds));
+        assert(inc_ref(&(id_instance_array[m]), cs, ds));
+        assert(2 == get_ref(&(id_instance_array[l]), cs, ds));
+        assert(2 == get_ref(&(id_instance_array[m]), cs, ds));
+
+        assert(3 == nmembers(&(types_array[i]), cs, ds));
+
+        assert(clear_type(&(types_array[i]), FALSE, cs, ds));
+
+        assert(3 == nmembers(&(types_array[i]), cs, ds));
+
+        assert(TRUE == type_exists(&(types_array[i]), cs, ds));
+
+        assert(inc_type_ref(&(types_array[i]), cs, ds));
+
+        assert(dec_type_ref(&(types_array[i]), cs, ds));
+
+        assert(TRUE == type_exists(&(types_array[i]), cs, ds));
+
+        if ( (i % 2) > 0 ) {
+
+            assert(dec_type_ref(&(types_array[i]), cs, ds));
+
+        } else {
+
+            assert(destroy_type(&(types_array[i]), cs, ds));
+        }
+
+        assert(FALSE == type_exists(&(types_array[i]), cs, ds));
+    }
+
+    fprintf(stdout, "Done.\n");
+
+    assert(H5close() >= 0 );
+
+    return;
+
+} /* serial_test_1() */
+
+
+void serial_test_2(int types_start, int types_count, int ids_start, int ids_count)
+{
+    hbool_t cs = FALSE;
+    hbool_t ds = FALSE;
+    int i;
+    int j;
+
+    fprintf(stdout, "\n running serial test #2 ... ");
+    fflush(stdout);
+
+    assert(H5open() >= 0 );
+
+    H5I_clear_stats();
+
+    for ( i = types_start; i < types_start + types_count; i++ ) {
+
+        assert(register_type(&(types_array[i]), cs, ds));
+    }
+
+    for ( j = ids_start; j < ids_start + ids_count; j++ ) {
+
+        i = types_start + (j % types_count);
+        assert( i >= types_start );
+        assert( i < types_start + types_count );
+
+        assert(register_id(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+    }
+
+    for ( j = ids_start + ids_count - 1; j >= ids_start; j-- ) {
+
+        i = types_start + (j % types_count);
+        assert( i >= types_start );
+        assert( i < types_start + types_count );
+
+        assert(object_verify(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+    }
+
+    for ( i = types_start; i < types_start + types_count; i++ ) {
+
+        assert(nmembers(&(types_array[i]), cs, ds) == (ids_count / types_count) + 
+                                                      (((ids_count % types_count) > i) ? 1 : 0) );
+    }
+
+    for ( j = ids_start; j < ids_start + ids_count; j++ ) {
+
+        i = types_start + (j % types_count);
+        assert( i >= types_start );
+        assert( i < types_start + types_count );
+
+        if ( j % 2 > 0 ) {
+
+            assert(inc_ref(&(id_instance_array[j]), cs, ds));
+
+        } else {
+
+            assert(dec_ref(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+        }
+    }
+
+    for ( i = types_start; i < types_start + types_count; i++ ) {
+
+        assert(clear_type(&(types_array[i]), FALSE, cs, ds));
+    }
+
+    for ( j = ids_start + 1; j < ids_start + ids_count; j += 2 ) {
+
+        i = types_start + (j % types_count);
+        assert( i >= types_start );
+        assert( i < types_start + types_count );
+
+        assert(object_verify(&(types_array[i]), &(id_instance_array[j]), &(objects_array[j]), cs, ds));
+    }
+
+    for ( i = types_start; i < types_start + types_count; i++ ) {
+
+        if ( (i % 2) > 0 ) {
+
+            assert(dec_type_ref(&(types_array[i]), cs, ds));
+
+        } else {
+            
+            assert(destroy_type(&(types_array[i]), cs, ds));
+        }
+    }
+
+    fprintf(stdout, "Done.\n");
+    fflush(stdout);
+
+    // H5I_dump_stats(stdout);
+
+    assert(H5close() >= 0 );
+
+    return;
+
+} /* serial_test_2() */
+
+void serial_test_3(void)
+{
+    hbool_t display_op_stats = FALSE;
+
+    fprintf(stdout, "\n running serial test #3 ... ");
+    fflush(stdout);
+
+    assert(H5open() >= 0 );
+
+    H5I_clear_stats();
+
+    create_types(0, 3, 3);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "create_types()");
+        H5I_clear_stats();
+    }
+
+    register_ids(0, 3, 3, 0, 10000, 1);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "register_ids");
+        H5I_clear_stats();
+    }
+
+    inc_type_refs(0, 2, 3);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "inc_type_refs()");
+        H5I_clear_stats();
+    }
+
+    dec_refs(0, 1, 1, 0, 1000, 3);
+    dec_refs(3, 1, 1, 1, 1000, 3);
+    dec_refs(6, 1, 1, 2, 1000, 3);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "dec_refs()");
+        H5I_clear_stats();
+    }    
+
+    inc_refs(3001, 3000, 1);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "inc_refs()");
+        H5I_clear_stats();
+    }
+
+    verify_objects(0, 3, 3,  3000, 7000, 1);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "verify_objects()");
+        H5I_clear_stats();
+    }
+
+    dec_type_refs(0, 3, 3);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "dec_type_refs()");
+        H5I_clear_stats();
+    }
+
+    destroy_types(0, 2, 3);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "destroy_types()");
+        H5I_clear_stats();
+    }
+
+    //H5I_dump_stats(stdout);
+
+    assert(H5close() >= 0 );
+
+    fprintf(stdout, "Done.\n");
+    fflush(stdout);
+
+    return;
+
+} /* serial_test_3() */
+
+
+void * mt_test_fcn_1(void * _params)
+{
+    hbool_t display_op_stats = FALSE;
+    int                i;
+    int                j;
+    mt_test_params_t * params = (mt_test_params_t *)_params;
+
+    assert(H5open() >= 0 );
+
+    if ( display_op_stats ) {
+
+        H5I_clear_stats();
+    }
+
+    register_ids(params->types_start, params->types_count, params->types_stride,
+                 params->ids_start, params->ids_count, params->ids_stride);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "register_ids()");
+        H5I_clear_stats();
+    }
+
+    inc_refs(params->ids_start, params->ids_count, params->ids_stride);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "inc_refs()");
+        H5I_clear_stats();
+    }
+
+    verify_objects(params->types_start, params->types_count, params->types_stride,
+                   params->ids_start, params->ids_count, params->ids_stride);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "verify_objects()");
+        H5I_clear_stats();
+    }
+
+    inc_type_refs(params->types_start, params->types_count / 2, params->types_stride);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "inc_type_refs()");
+        H5I_clear_stats();
+    }
+
+    for ( i = 0; i < params->types_count; i++ ) {
+
+        j = params->types_start + (i * params->types_stride);
+
+        dec_refs(j, 1, 1, params->ids_start + i, params->ids_count / (params->types_count * 2), 
+                 params->ids_stride * params->types_count);
+    }
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "dec_refs()");
+        H5I_clear_stats();
+    }
+
+    verify_objects(params->types_start, params->types_count, params->types_stride,
+                   params->ids_start, params->ids_count, params->ids_stride);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "verify_objects()");
+        H5I_clear_stats();
+    }
+    
+    dec_refs(params->types_start, params->types_count, params->types_stride,
+             params->ids_start, params->ids_count, params->ids_stride);
+
+    if ( display_op_stats ) {
+
+        H5I_dump_nz_stats(stdout, "dec_refs()");
+        H5I_clear_stats();
+    }
+
+    return(NULL);
+
+} /* mt_test_fcn_1() */
+
+void mt_test_fcn_1_serial_test(void)
+{
+    mt_test_params_t params = { /* types_start    = */     0,
+                                /* types_count    = */     3,
+                                /* types_stride   = */     3,
+                                /* ids_start      = */     0,
+                                /* ids_count      = */ 10000,
+                                /* ids_stride     = */     1,
+                                /* objects_start  = */     0,
+                                /* objects_count  = */ 10000,
+                                /* objects_stride = */     1
+                              };
+
+    fprintf(stdout, "\n running mt_test_fcn_1 serial test ... ");
+    fflush(stdout);
+
+    assert(H5open() >= 0 );
+
+    create_types(params.types_start, params.types_count, params.types_stride);
+
+    mt_test_fcn_1((void *)(&params));
+
+    destroy_types(params.types_start, params.types_count, params.types_stride);
+
+    // H5I_dump_stats(stdout);
+
+    assert(H5close() >= 0 );
+
+    fprintf(stdout, "Done.\n");
+    fflush(stdout);
+
+    return;
+
+} /* mt_test_fcn_1_serial_test() */
+
+void mt_test_1(int num_threads) 
+{
+    int              i;
+    pthread_t        threads[MAX_NUM_THREADS];
+    mt_test_params_t params[MAX_NUM_THREADS];
+
+    assert( 1 <= num_threads );
+    assert( num_threads <= MAX_NUM_THREADS );
+
+    fprintf(stdout, "\n running mt_test_fcn_1 ... ");
+    fflush(stdout);
+
+    assert(H5open() >= 0 );
+
+    for ( i = 0; i < num_threads; i++ ) {
+
+        params[i].types_start    = 0;
+        params[i].types_count    = 3;
+        params[i].types_stride   = 3;
+
+        params[i].ids_start      = i * 20000;
+        params[i].ids_count      = 20000;
+        params[i].ids_stride     = 1;
+
+        params[i].objects_start  = i * 20000;
+        params[i].objects_count  = 20000;
+        params[i].objects_stride = 1;
+    }
+
+    create_types(params[0].types_start, params[0].types_count, params[0].types_stride);
+
+    for ( i = 0;  i < num_threads; i++ ) {
+
+        assert(0 == pthread_create(&(threads[i]), NULL, &mt_test_fcn_1, (void *)(&(params[i]))));
+    }
+
+    /* Wait for all the threads to complete */
+    for (i = 0; i < num_threads; i++) {
+
+        assert(0 == pthread_join(threads[i], NULL));
+    }
+
+    destroy_types(params[0].types_start, params[0].types_count, params[0].types_stride);
+
+    H5I_dump_stats(stdout);
+
+    assert(H5close() >= 0);
+
+    fprintf(stdout, "Done.\n");
+    fflush(stdout);
+
+    return;
+
+} /* mt_test_1() */
+
+int main() 
+{
+    init_globals();
+
+    serial_test_1();
+
+    reset_globals();
+
+    serial_test_2(0, 32, 0, NUM_ID_INSTANCES);
+
+    reset_globals();
+
+    serial_test_3();
+
+    reset_globals();
+
+    mt_test_fcn_1_serial_test();
+
+    reset_globals();
+
+    mt_test_1(32);
+    reset_globals();
+
+    // H5I_dump_stats(stdout);
+    // H5I_clear_stats();
+
+    return(0);
+
+} /* main() */
+#else /* H5_HAVE_MULTITHREAD */
+int
+main(void)
+{
+    TESTING("multithread");
+    SKIPPED();
+    fprintf(stderr, "Multithread isn't enabled in the configure.\n");
+    return (0);
+}
+#endif /* H5_HAVE_MULTITHREAD */


### PR DESCRIPTION
One must use the `--enable-multithread` for configure to enable the multithread support. On Mac OS, this option requires the presence of Pthread library and the Atomic header (stdatomic.h).

On Linux, it requires the presence of Pthread and Atomic libraries and the Atomic header.  Missing any of these requirements will cause configure to fail. Using the multithread feature requires
disabling the high-level API, C++, Fortran, Java interfaces, and thread safe. This feature currently only works with debugging mode (`--enable-build-mode=debug`), not the production mode.

The following command is an example to enable the multithread support:

`configure --enable-multithread --enable-build-mode=debug --disable-hl`

The only test program to check the correctness of multithread support is hdf5/test/mt_id_test.c.