### PR TITLE
Fix error stack cleanup in non-main threads

### DIFF
--- a/hdf5/src/H5E.c
+++ b/hdf5/src/H5E.c
@@ -388,13 +388,14 @@ H5E__set_default_auto(H5E_t *stk)
 H5E_t *
 H5E__get_stack(void)
 {
+    H5TS_tl_value_t *tl_value = NULL;
     H5E_t *estack = NULL;
 
     FUNC_ENTER_PACKAGE_NOERR
 
-    estack = (H5E_t *)H5TS_get_thread_local_value(H5TS_errstk_key_g);
+    tl_value = (H5TS_tl_value_t *)H5TS_get_thread_local_value(H5TS_errstk_key_g);
 
-    if (!estack) {
+    if (!tl_value) {
         /* No associated value with current thread - create one */
 #ifdef H5_HAVE_WIN_THREADS
         /* Win32 has to use LocalAlloc to match the LocalFree in DllMain */
@@ -411,12 +412,21 @@ H5E__get_stack(void)
         estack->nused = 0;
         H5E__set_default_auto(estack);
 
+        /* Set up threadlocal wrapper */
+        tl_value = (H5TS_tl_value_t *)malloc(sizeof(H5TS_tl_value_t));
+        assert(tl_value);
+
+        tl_value->type  = H5TS_ERRSTK;
+        tl_value->value = (void *)estack;
         /* (It's not necessary to release this in this API, it is
          *      released by the "key destructor" set up in the H5TS
          *      routines.  See calls to pthread_key_create() in H5TS.c -QAK)
          */
-        H5TS_set_thread_local_value(H5TS_errstk_key_g, (void *)estack);
-    } /* end if */
+        H5TS_set_thread_local_value(H5TS_errstk_key_g, (void *) tl_value);
+    } else {
+        estack = (H5E_t *)tl_value->value;
+        assert(estack);
+    }
 
     /* Set return value */
     FUNC_LEAVE_NOAPI(estack)

--- a/hdf5/src/H5Eint.c
+++ b/hdf5/src/H5Eint.c
@@ -813,8 +813,10 @@ H5E__clear_entries(H5E_t *estack, size_t nentries)
         /* (In reverse order that they were incremented, so that reference counts work well) */
         if (H5I_dec_ref(error->min_num) < 0)
             HGOTO_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "unable to decrement ref count on error message");
+        
         if (H5I_dec_ref(error->maj_num) < 0)
             HGOTO_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "unable to decrement ref count on error message");
+
         if (H5I_dec_ref(error->cls_id) < 0)
             HGOTO_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "unable to decrement ref count on error class");
 
@@ -863,7 +865,6 @@ herr_t
 H5E_clear_stack(H5E_t *estack)
 {
     herr_t ret_value = SUCCEED; /* Return value */
-
     FUNC_ENTER_NOAPI(FAIL)
 
 #ifdef H5_HAVE_MULTITHREAD
@@ -886,10 +887,9 @@ H5E_clear_stack(H5E_t *estack)
             HGOTO_ERROR(H5E_ERROR, H5E_CANTGET, FAIL, "can't get current error stack");
 
     } else {
-
         bool have_global_mutex;
         
-        /* Verify that the have the global lock.  */
+        /* Verify that we have the global lock. */
         if ( H5TS_have_mutex(&H5_g.init_lock, &have_global_mutex) < 0 )
 
             HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "Can't determine whether we have the global mutex");

--- a/hdf5/src/H5TS.c
+++ b/hdf5/src/H5TS.c
@@ -58,6 +58,7 @@ static void   H5TS__key_destructor(void *key_val);
 static herr_t H5TS__mutex_acquire(H5TS_mutex_t *mutex, unsigned int lock_count, bool *acquired);
 static herr_t H5TS__mutex_unlock(H5TS_mutex_t *mutex, unsigned int *lock_count);
 
+static void H5TS_tid_destructor(void *_v);
 /*********************/
 /* Package Variables */
 /*********************/
@@ -151,13 +152,46 @@ static H5TS_key_t H5TS_tid_key;
  *--------------------------------------------------------------------------
  */
 static void
-H5TS__key_destructor(void *key_val)
+H5TS__key_destructor(void *_key_val)
 {
     FUNC_ENTER_PACKAGE_NAMECHECK_ONLY
+    H5TS_tl_value_t *key_val = (H5TS_tl_value_t *)_key_val;
 
     /* Use free() here instead of H5MM_xfree(), to avoid calling the H5CS routines */
-    if (key_val != NULL)
+    if (key_val != NULL) {
+        assert(key_val->type != H5TS_INVALID);
+
+        switch(key_val->type) {
+            case H5TS_ERRSTK: {
+                H5E_t *estack = (H5E_t *)key_val->value;
+
+                /* Clear this thread's local error stack if it exists */
+                if (estack) {
+                    /* Temporarily re-publish threadlocal key for use by H5E_clear_stack */
+                    H5TS_set_thread_local_value(H5TS_errstk_key_g, (void*)key_val);
+                    H5E_clear_stack(NULL);
+                    H5TS_set_thread_local_value(H5TS_errstk_key_g, NULL);
+                }
+
+                free(estack);
+                break;
+            }
+
+            case H5TS_THREAD_ID: {
+                H5TS_tid_destructor(key_val->value);
+                break;
+            }
+
+            default: {
+                /* Free generic threadlocal value pointer */
+                free(key_val->value);
+                break;
+            }
+        }
+        
+        /* Free the value struct itself */
         free(key_val);
+    }
 
     FUNC_LEAVE_NOAPI_VOID_NAMECHECK_ONLY
 } /* end H5TS__key_destructor() */
@@ -211,7 +245,7 @@ static void
 H5TS_tid_init(void)
 {
     pthread_mutex_init(&H5TS_tid_mtx, NULL);
-    pthread_key_create(&H5TS_tid_key, H5TS_tid_destructor);
+    pthread_key_create(&H5TS_tid_key, H5TS__key_destructor);
 }
 
 /*--------------------------------------------------------------------------
@@ -241,12 +275,18 @@ H5TS_tid_init(void)
 uint64_t
 H5TS_thread_id(void)
 {
-    H5TS_tid_t *tid = pthread_getspecific(H5TS_tid_key);
+    H5TS_tl_value_t *tl_value = NULL;
+    H5TS_tid_t *tid = NULL; 
     H5TS_tid_t  proto_tid;
 
-    /* An ID is already assigned. */
-    if (tid != NULL)
+    /* If value exists, an ID is already assigned */
+    tl_value = pthread_getspecific(H5TS_tid_key);
+
+    if (tl_value != NULL) {
+        tid = (H5TS_tid_t *)tl_value->value;
+        assert(tid);
         return tid->id;
+    }
 
     /* An ID is *not* already assigned: reuse an ID that's on the
      * free list, or else generate a new ID.
@@ -276,7 +316,16 @@ H5TS_thread_id(void)
      * to it.
      */
     tid->next = NULL;
-    if (pthread_setspecific(H5TS_tid_key, tid) != 0) {
+
+    if ((tl_value = malloc(sizeof(*tl_value))) == NULL) {
+        H5TS_tid_destructor(tid);
+        return 0;
+    }
+
+    tl_value->type  = H5TS_THREAD_ID;
+    tl_value->value = (void*) tid;
+
+    if (pthread_setspecific(H5TS_tid_key, (void*) tl_value) != 0) {
         H5TS_tid_destructor(tid);
         return 0;
     }
@@ -745,6 +794,7 @@ herr_t
 H5TS_cancel_count_inc(void)
 {
 #ifndef H5_HAVE_WIN_THREADS
+    H5TS_tl_value_t *tl_value = NULL;
     H5TS_cancel_t *cancel_counter;
 #endif /* H5_HAVE_WIN_THREADS */
     herr_t ret_value = SUCCEED;
@@ -755,10 +805,10 @@ H5TS_cancel_count_inc(void)
     /* unsupported */
 #else  /* H5_HAVE_WIN_THREADS */
     /* Acquire the thread's cancellation counter */
-    cancel_counter = (H5TS_cancel_t *)H5TS_get_thread_local_value(H5TS_cancel_key_s);
+    tl_value = (H5TS_tl_value_t *)H5TS_get_thread_local_value(H5TS_cancel_key_s);
 
     /* Check if it's created yet */
-    if (!cancel_counter) {
+    if (!tl_value) {
         /*
          * First time thread calls library - create new counter and associate
          * with key.
@@ -770,12 +820,25 @@ H5TS_cancel_count_inc(void)
         if (NULL == cancel_counter)
             HGOTO_DONE(FAIL);
 
+        /* Set up threadlocal wrapper around cancel counter */
+        if (NULL == (tl_value = (H5TS_tl_value_t *)malloc(sizeof(H5TS_tl_value_t)))) {
+            free(cancel_counter);
+            HGOTO_DONE(FAIL);
+        }
+
+        tl_value->type  = H5TS_CANCEL;
+        tl_value->value = (void *)cancel_counter;
+
         /* Set the thread's cancellation counter with the new object */
-        ret_value = pthread_setspecific(H5TS_cancel_key_s, (void *)cancel_counter);
+        ret_value = pthread_setspecific(H5TS_cancel_key_s, (void*) tl_value);
         if (ret_value) {
             free(cancel_counter);
             HGOTO_DONE(FAIL);
         }
+    } else {
+        cancel_counter = (H5TS_cancel_t *)tl_value->value;
+        if (!cancel_counter)
+            HGOTO_DONE(FAIL);
     }
 
     /* Check if thread entering library */
@@ -819,6 +882,7 @@ herr_t
 H5TS_cancel_count_dec(void)
 {
 #ifndef H5_HAVE_WIN_THREADS
+    H5TS_tl_value_t *tl_value = NULL;
     H5TS_cancel_t *cancel_counter;
 #endif /* H5_HAVE_WIN_THREADS */
     herr_t ret_value = SUCCEED;
@@ -829,7 +893,11 @@ H5TS_cancel_count_dec(void)
     /* unsupported */
 #else  /* H5_HAVE_WIN_THREADS */
     /* Acquire the thread's cancellation counter */
-    cancel_counter = (H5TS_cancel_t *)H5TS_get_thread_local_value(H5TS_cancel_key_s);
+    tl_value = (H5TS_tl_value_t *)H5TS_get_thread_local_value(H5TS_cancel_key_s);
+    assert(tl_value);
+
+    cancel_counter = (H5TS_cancel_t *)tl_value->value;
+    assert(cancel_counter);
 
     /* Check for leaving last API routine */
     if (cancel_counter->cancel_count == 1)

--- a/hdf5/src/H5TSprivate.h
+++ b/hdf5/src/H5TSprivate.h
@@ -70,7 +70,7 @@ H5_DLL herr_t        H5TS_win32_thread_exit(void);
 
 /* Library level data structures */
 
-/* Structures for threads to handle threadlocal values.
+/* The types of threadlocal keys *
  * TBD: May be replaced upon integration of multi-threading with main library */
 typedef enum H5TS_tl_type_t {
 	H5TS_INVALID,
@@ -81,6 +81,9 @@ typedef enum H5TS_tl_type_t {
 	H5TS_CANCEL
 } H5TS_tl_type_t;
 
+/* Common structure for the values of thread-local keys.
+ * Necessary to handle cleanup of specific types at thread exit.
+ * TBD: May be replaced upon integration of multi-threading with main library */
 typedef struct H5TS_tl_value_t {
 	H5TS_tl_type_t type;
 	void *value;

--- a/hdf5/src/H5TSprivate.h
+++ b/hdf5/src/H5TSprivate.h
@@ -70,6 +70,22 @@ H5_DLL herr_t        H5TS_win32_thread_exit(void);
 
 /* Library level data structures */
 
+/* Structures for threads to handle threadlocal values.
+ * TBD: May be replaced upon integration of multi-threading with main library */
+typedef enum H5TS_tl_type_t {
+	H5TS_INVALID,
+	H5TS_CTX,
+	H5TS_ERRSTK,
+	H5TS_FUNCSTK,
+	H5TS_THREAD_ID,
+	H5TS_CANCEL
+} H5TS_tl_type_t;
+
+typedef struct H5TS_tl_value_t {
+	H5TS_tl_type_t type;
+	void *value;
+} H5TS_tl_value_t;
+
 /* Mutexes, Threads, and Attributes */
 typedef struct H5TS_mutex_struct {
     pthread_t       owner_thread; /* current lock owner */

--- a/hdf5/test/CMakeLists.txt
+++ b/hdf5/test/CMakeLists.txt
@@ -344,6 +344,7 @@ set (ttsafe_SOURCES
     ${HDF5_TEST_SOURCE_DIR}/ttsafe_cancel.c
     ${HDF5_TEST_SOURCE_DIR}/ttsafe_acreate.c
     ${HDF5_TEST_SOURCE_DIR}/ttsafe_attr_vlen.c
+    ${HDF5_TEST_SOURCE_DIR}/ttsafe_error_stacks.c
 )
 
 set (H5_TESTS

--- a/hdf5/test/Makefile.am
+++ b/hdf5/test/Makefile.am
@@ -162,7 +162,7 @@ LDADD=libh5test.la $(LIBHDF5)
 
 # List the source files for tests that have more than one
 ttsafe_SOURCES=ttsafe.c ttsafe_dcreate.c ttsafe_error.c ttsafe_cancel.c       \
-               ttsafe_acreate.c ttsafe_attr_vlen.c
+               ttsafe_acreate.c ttsafe_attr_vlen.c ttsafe_error_stacks.c
 cache_image_SOURCES=cache_image.c genall5.c
 mirror_vfd_SOURCES=mirror_vfd.c genall5.c
 

--- a/hdf5/test/ttsafe.c
+++ b/hdf5/test/ttsafe.c
@@ -105,6 +105,8 @@ main(int argc, char *argv[])
     AddTest("dcreate", tts_dcreate, cleanup_dcreate, "multi-dataset creation", NULL);
     AddTest("error", tts_error, cleanup_error, "per-thread error stacks", NULL);
 #ifdef H5_HAVE_PTHREAD_H
+    /* TBD - Later library versions add H5TS wrapper routines for compatibility with windows threads too */
+    AddTest("tts_errstk", tts_errstk, NULL, "per-thread error stack cleanup", NULL);
     /* Thread cancellability only supported with pthreads ... */
     AddTest("cancel", tts_cancel, cleanup_cancel, "thread cancellation safety test", NULL);
 #endif /* H5_HAVE_PTHREAD_H */

--- a/hdf5/test/ttsafe.h
+++ b/hdf5/test/ttsafe.h
@@ -34,6 +34,7 @@ void tts_error(void);
 void tts_cancel(void);
 void tts_acreate(void);
 void tts_attr_vlen(void);
+void tts_errstk(void);
 
 /* Prototypes for the cleanup routines */
 void cleanup_dcreate(void);

--- a/hdf5/test/ttsafe_error_stacks.c
+++ b/hdf5/test/ttsafe_error_stacks.c
@@ -1,0 +1,115 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+#include "ttsafe.h"
+
+/* TBD - Later library versions add H5TS wrapper routines for compatibility with windows threads too */
+#ifdef H5_HAVE_PTHREAD_H
+
+#define ERR_CLS_NAME        "Custom error class"
+#define ERR_CLS_LIB_NAME    "example_lib"
+#define ERR_CLS_LIB_VERSION "0.1"
+
+#define ERR_MAJOR_MSG "Okay, Houston, we've had a problem here"
+#define ERR_MINOR_MSG "Oops!"
+
+void* generate_hdf5_error(void *arg);
+void* generate_user_error(void *arg);
+
+/* Helper routine to generate an HDF5 library error */
+void*
+generate_hdf5_error(void H5_ATTR_UNUSED *arg)
+{
+    void* ret_value = NULL;
+    ssize_t           nobjs     = 0;
+
+    H5E_BEGIN_TRY
+    {
+        nobjs = H5Fget_obj_count(H5I_INVALID_HID, H5F_OBJ_ALL);
+    }
+    H5E_END_TRY
+
+    /* Expect call to fail */
+    VERIFY(nobjs, FAIL, "H5Fget_obj_count");
+
+    return ret_value;
+}
+
+/* Helper routine to generate a user-defined error */
+void*
+generate_user_error(void H5_ATTR_UNUSED *arg)
+{
+    void* ret_value = NULL;
+    hid_t             cls       = H5I_INVALID_HID;
+    hid_t             major     = H5I_INVALID_HID;
+    hid_t             minor     = H5I_INVALID_HID;
+    herr_t            status    = FAIL;
+
+    cls = H5Eregister_class(ERR_CLS_NAME, ERR_CLS_LIB_NAME, ERR_CLS_LIB_VERSION);
+    CHECK(cls, H5I_INVALID_HID, "H5Eregister_class");
+
+    major = H5Ecreate_msg(cls, H5E_MAJOR, ERR_MAJOR_MSG);
+    CHECK(major, H5I_INVALID_HID, "H5Ecreate_msg");
+
+    minor = H5Ecreate_msg(cls, H5E_MINOR, ERR_MINOR_MSG);
+    CHECK(minor, H5I_INVALID_HID, "H5Ecreate_msg");
+
+    status = H5Epush2(H5E_DEFAULT, __FILE__, __func__, __LINE__, cls, major, minor, "Hello, error\n");
+    CHECK(status, FAIL, "H5Epush2");
+
+    ret_value = (void*)cls;
+
+    return ret_value;
+}
+
+/*
+**********************************************************************
+* tts_errstk
+*
+* Test that error stacks with user-defined error classes and messages
+* in secondary threads are properly cleaned up at library shutdown time.
+**********************************************************************
+*/
+void
+tts_errstk(void)
+{
+    H5TS_thread_t threads[2];
+    herr_t        status     = FAIL;
+    hid_t         err_cls_id = H5I_INVALID_HID;
+
+    /* Open library */
+    H5open();
+
+    status = pthread_create(&threads[0], NULL, generate_hdf5_error, NULL);
+    CHECK(status, FAIL, "H5TS_thread_create");
+
+    status = pthread_join(threads[0], NULL);
+    CHECK(status, FAIL, "H5TS_thread_join");
+
+    status = pthread_create(&threads[1], NULL, generate_user_error, NULL);
+    CHECK(status, FAIL, "H5TS_thread_create");
+
+    status = pthread_join(threads[1], (void *)&err_cls_id);
+    CHECK(status, FAIL, "H5TS_thread_join");
+
+    if (err_cls_id <= 0) {
+        TestErrPrintf("Failed to set up user error\n");
+        return;
+    }
+
+    status = H5Eunregister_class(err_cls_id);
+    CHECK(status, FAIL, "H5Eunregister_class");
+
+    /* Close library */
+    H5close();
+}
+
+#endif /* H5_HAVE_PTHREAD_H */


### PR DESCRIPTION
All thread-local keys are now stored in a shared struct that supports introspection at thread cleanup time, allowing for error records in non-main-threads to be cleaned up properly. This is implemented through the common struct `H5TS_tl_value_t` and the type-enum `H5TS_tl_type_t` for the various keys stored threadlocally.  Changes are tested in `ttsafe_error_stacks.c`

There are enough changes between the threadlocal code in 1.14.2 and the develop branch of HDF5 that most of this won't survive the eventual merge, but it will fix the issue for now.

Fixes #13.