### PR TITLE
Add initial autotools build and test workflows

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -1,0 +1,58 @@
+name: Lifeboat hdf5 dev autotools CI
+
+# Triggers the workflow on a call from another workflow
+on:
+  workflow_call:
+    inputs:
+      build_mode:
+        description: "release vs. debug build"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+
+  build_and_test:
+    name: "GCC-${{ inputs.build_mode }}"
+
+    # Don't run the action if the commit message says to skip CI
+    if: "!contains(github.event.head_commit.message, 'skip-ci')"
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Linux Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential libtool libtool-bin
+
+      # Check out repository under $GITHUB_WORKSPACE
+      - name: Get Sources
+        uses: actions/checkout@v4.1.7
+        with:
+          ref: 1_14_2_multithread
+
+      - name: Autotools Configure
+        run: |
+          cd $GITHUB_WORKSPACE/hdf5
+          sh ./autogen.sh
+          mkdir "$GITHUB_WORKSPACE/hdf5/build"
+          cd "$GITHUB_WORKSPACE/hdf5/build"
+          ../configure \
+            --enable-build-mode=${{ inputs.build_mode }} \
+            --enable-shared \
+            --enable-static \
+            --enable-multithread \
+            --disable-hl
+        shell: bash
+
+      - name: Autotools Build
+        run: make -j3
+        working-directory: ${{ github.workspace }}/hdf5/build
+
+      - name: Autotools Run Tests
+        run: make check -j2
+        working-directory: ${{ github.workspace }}/hdf5/build

--- a/.github/workflows/main-auto.yml
+++ b/.github/workflows/main-auto.yml
@@ -1,0 +1,37 @@
+name: Lifeboat hdf5 dev autotools CI
+
+# For now, run as a daily build at 07:00 CDT (12:00 UTC) or on
+# demand. Later on this workflow can be enabled on commits ('push')
+# or pull requests.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * *"
+#  push:
+#  pull_request:
+#    branches: [ 1_14_2_multithread ]
+#    paths-ignore:
+#      - '**.md'
+
+permissions:
+  contents: read
+
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  call-debug-autotools:
+    name: "Autotools Debug Workflows"
+    uses: ./.github/workflows/autotools.yml
+    with:
+      build_mode: "debug"
+
+# Disable production builds for now until future development allows
+# for controlling testing time  
+#  call-release-autotools:
+#    name: "Autotools Release Workflows"
+#    uses: ./.github/workflows/autotools.yml
+#    with:
+#      build_mode: "production"


### PR DESCRIPTION
Production builds are disabled for now until changes are merged for integrating the MT ID test with the 'testframe' framework so that a test alarm can be enabled. The debug builds seem fairly consistent about failing due to the known assertion failure, but production builds run for a decent while.