### PR TITLE
Set 60 minute timeout for testing

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -23,6 +23,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Restrict runtime to 60 minutes in case test hangs
+    timeout-minutes: 60
+
     steps:
       - name: Install Linux Dependencies
         run: |


### PR DESCRIPTION
Sets a 60 minute timeout for testing in case the multi-threaded tests hang